### PR TITLE
Add table of contents and change record to make title

### DIFF
--- a/examples/LDM-nnn.tex
+++ b/examples/LDM-nnn.tex
@@ -1,4 +1,4 @@
-\documentclass[DM,lsstdraft]{lsstdoc}
+\documentclass[DM,lsstdraft,toc]{lsstdoc}
 
 \usepackage[english]{babel}
 \usepackage[utf8x]{inputenc}
@@ -41,25 +41,20 @@ documents. Build this document in the normal way, making sure that the class fil
 available in the \LaTeX\ load path.
 }
 
+% Change history defined here. Will be inserted into
+% correct place with \maketitle
+% OLDEST FIRST: VERSION, DATE, DESCRIPTION, OWNER NAME
+\setDocChangeRecord{%
+\addtohist{1}{2017-09-10}{Initial release. Based on Gaia examples.}{Tim Jenness}
+\addtohist{2}{yyyy-mm-dd}{Future changes}{Future person}
+}
+
 \begin{document}
 
 % Create the title page
+% Table of contents will be added automatically if "toc" class option
+% is used.
 \maketitle
-
-% Change history goes after the title page
-% OLDEST FIRST: VERSION, DATE, DESCRIPTION, OWNER NAME
-\begin{docHistory}
-\addtohist{1}{2017-09-10}{Initial release. Based on Gaia examples.}{Tim Jenness}
-\addtohist{2}{yyyy-mm-dd}{Future changes}{Future person}
-\end{docHistory}
-
-% Create the table of contents
-\clearpage
-\tableofcontents
-\clearpage
-
-% Now that the preamble is complete, switch to arabic numbers for pages
-\pagenumbering{arabic}
 
 \section{Introduction}
 

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -68,6 +68,17 @@
 }
 
 %
+% Automatically include table of contents in maketitle with the
+% addtoc option.
+%
+\newif\if@addtoc
+\@addtocfalse
+\DeclareOption{toc}{\@addtoctrue}
+\if@compatibility\else
+\DeclareOption{notoc}{\@addtocfalse}
+\fi
+
+%
 % Define the various document types
 %
 \DeclareOption{CP}{
@@ -234,6 +245,15 @@
     \pagebreak
 }}
 
+\newcommand{\docChangeRecord}{}
+\newcommand{\setDocChangeRecord}[1]{\renewcommand{\docChangeRecord}
+{
+\clearpage
+\begin{docHistory}
+#1
+\end{docHistory}
+}}
+
 \providecommand{\putlogo}{
   \begin{center}
 	\includegraphics{lsst_logo_notext}\\
@@ -352,6 +372,14 @@ revision:\>    \docRevision\\
     \fi
    \pagenumbering{roman}
    \docAbstract
+   \docChangeRecord
+
+   \if@addtoc
+     \setcounter{tocdepth}{3}
+     \tableofcontents
+     \clearpage
+     \pagenumbering{arabic}
+   \fi
 }
 
 \ProcessOptions\relax


### PR DESCRIPTION
* New class option "toc" to automatically add table of contents.
  This allows \maketitle to put it in the correct place in the document
  and to fix the page number to arabic.
* Add \setDocChangeRecord to allow change record to be defined
  in the preamble. This allows \maketitle to put it in the correct
  place in the document.

Both these changes allow \maketitle to set up the document in a standard
way rather than relying on the author to do it correctly. These changes
do not affect backwards compatibility.