### PR TITLE
DM-9896: Test the bibtex entries are properly formed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.snm
 *.fls
 *.fdb_latexmk
+*.bbl
+*.blg

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,22 @@ EXAMPLES = \
 Example_presentation.tex \
 LDM-nnn.tex
 
+TESTFILES = \
+test-bibtex.tex
+
 .SUFFIXES:
 .SUFFIXES: .tex .pdf
 PDF = $(EXAMPLES:.tex=.pdf)
 
-all: $(PDF)
+TESTS = $(TESTFILES:.tex=.pdf)
+
+all: $(PDF) $(TESTS)
 
 $(PDF): %.pdf: examples/%.tex
 	latexmk -pdf -f $<
+
+$(TESTS): %.pdf: tests/%.tex
+	latexmk -pdf -bibtex -f $<
 
 .PHONY: clean
 clean:

--- a/tests/test-bibtex.tex
+++ b/tests/test-bibtex.tex
@@ -1,0 +1,32 @@
+\documentclass[DM,toc]{lsstdoc}
+
+\title[Bib testing]{Bibliography Verification}
+\author{Automated~Content}
+\date{\today}
+
+\setDocStatus{generated}
+\setDocRef{LSST-test}
+\setDocRevision{1}
+
+\setDocAbstract{%
+Standard LSST document class example but using all bibtex entries.
+This allows the bib files to be tested as well as the associated
+bibtex style.
+}
+
+\begin{document}
+
+\maketitle
+
+\section{Introduction}
+
+In the following pages, all bibliographic entries from this repository will be listed.
+These are used to test that the entries in the relevant \texttt{.bib} files are formatted correctly.
+Bibtex will issue Warnings but the build will only be stopped if Errors are located.
+
+\nocite{*}
+
+\bibliographystyle{gaia_aa}
+\bibliography{lsst,refs,books,refs_ads}
+
+\end{document}

--- a/texmf/bibtex/bib/lsst.bib
+++ b/texmf/bibtex/bib/lsst.bib
@@ -1,6 +1,6 @@
 
 @LiveLink{SUIT-VISION,
-author = {David R. Ciardi and Xiuqin Wu and Gregory Dubois‐Felsmann},
+author = {David R. Ciardi and Xiuqin Wu and Gregory Dubois-Felsmann},
 title={A Vision for the Science User Interface and Tools},
 institution={IPAC},
 year={2016},

--- a/texmf/bibtex/bib/refs.bib
+++ b/texmf/bibtex/bib/refs.bib
@@ -236,7 +236,7 @@ IMAGINARIES IN ALGEBRA },
   livelinkshortnumber =    {ECSS-M-40B }
 }
 
-@LiveLink{ecss:spmdoc,
+@LiveLink{ecss:spmdoc50B,
   author =  { {ESA Publications Division}},
   title =   { {S}pace {P}roject {M}anagent - information/documentation managment },
   institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
@@ -391,7 +391,11 @@ requirements},
   author = {{Schneider}, J.},
   title = "{Can the Perturbation of a Stellar Motion in a Triple System Mimic
             a Planet}",
-   crossref={TDUG},
+  booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
+  year = 2005,
+  editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
+            },
+  month = jan,
    pages = {263--266}
 }
 
@@ -1291,7 +1295,7 @@ pages = {774-14}
 }
 
 @LiveLink{IVOAMOC,
-	author = {Thomas Boch, Tom Donaldson, Daniel Durand, Pierre Fernique, Wil O'Mullane, Martin Reinecke, Mark Taylor
+	author = {Thomas Boch and Tom Donaldson and Daniel Durand and Pierre Fernique and Wil O'Mullane and Martin Reinecke and Mark Taylor
        	},
 	title={MOC - HEALPix Multi-Order Coverage map Version 1.0},
 	institution={},
@@ -1312,7 +1316,7 @@ pages = {774-14}
 
 }
 
-@proceeding{doi:10.1117/12.2233619,
+@proceedings{doi:10.1117/12.2233619,
 	author = {Vagg, Daniel and O'Callaghan, Derek and Ó hÓgáin, Fionn and McBreen, Sheila and Hanlon, Lorraine and Lynn, David and O'Mullane, William},
 	title = {
 GAVIP: a platform for Gaia data analysis
@@ -1330,7 +1334,7 @@ GAVIP: a platform for Gaia data analysis
 	eprint = {}
 }
 
-@proceeding{doi:10.1117/12.2233380,
+@proceedings{doi:10.1117/12.2233380,
 	author = {Kantor, Jeffrey and Long, Kevin and Becla, Jacek and Economou, Frossie and Gelman, Margaret and Juric, Mario and Lambert, Ron and Krughoff, Simon and Swinbank, John D. and Wu, Xiuqin},
 	title = {
 		Agile software development in an earned value world: a survival guide

--- a/texmf/bibtex/bib/refs_ads.bib
+++ b/texmf/bibtex/bib/refs_ads.bib
@@ -144,7 +144,7 @@ archivePrefix = "arXiv",
  keywords = {extrasolar planets, astrometry, radial velocities, interferometry, brown dwarfs, stars: binaries, stars: low-mass},
    school = {Observatoire de Gen{\`e}ve, Universit{\'e} de Gen{\`e}ve <EMAIL>Johannes.Sahlmann@unige.ch</EMAIL>},
      year = 2012,
-    month = June,
+    month = jun,
    adsurl = {http://adsabs.harvard.edu/abs/2012PhDT.......175S},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
@@ -814,7 +814,7 @@ booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
    editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.},
     month = jan,
     pages = {97-+},
-   adsurl = {\url{http://adsabs.harvard.edu/cgi-bin/nph-bib\_query?bibcode=2005tdug.conf...97S&db\_key=AST}},
+   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib\_query?bibcode=2005tdug.conf...97S&db_key=AST},
   adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
 }
 
@@ -843,7 +843,7 @@ booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
     month = dec,
    volume = 310,
     pages = {645-662},
-   adsurl = {\url{http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1999MNRAS.310..645W&db_key=AST}},
+   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1999MNRAS.310..645W&db_key=AST},
   adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
 }
 
@@ -1247,18 +1247,19 @@ booktitle = {Astronomical Society of the Pacific Conference Series},
 
 % moniez2003
 
-@ARTICLE{2003A%26A...412..105M,
+@ARTICLE{2003A&A...412..105M,
    author = {{Moniez}, M.},
     title = "{Does transparent hidden matter generate optical scintillation?}",
   journal = {\aap},
    eprint = {astro-ph/0302460},
+ keywords = {cosmology: dark matter, Galaxy: disk, Galaxy: halo, ISM: clouds, ISM: molecules},
      year = 2003,
     month = dec,
    volume = 412,
     pages = {105-120},
       doi = {10.1051/0004-6361:20031478},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2003A%26A...412..105M&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+   adsurl = {http://adsabs.harvard.edu/abs/2003A%26A...412..105M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % cu8:cbjparis
@@ -1765,19 +1766,6 @@ booktitle = {Scientific charge-coupled devices, Bellingham, WA: SPIE Optical Eng
    adsurl = {http://adsabs.harvard.edu/abs/2001sccd.book.....J},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-@ARTICLE{2003.Holland.IEEE,
-   author = {{Holland}, S. E. and {Groom}, D. E. and {Palaio}, N. P. and {Stover}, R. J.
-        and {Wei}, M.},
-    title = "{Fully depleted, back-illuminated charge-coupled devices fabricated
-              on high-resistivity silicon}",
-  journal = {IEEE transactions on electron devices},
-     year = 2003,
-    month = jan,
-   volume = 50,
-    pages = {225-238}
-}
-
 
 @INPROCEEDINGS{2004SPIE.5494..529B,
    author = {{Baccaro}, S. and {Cecilia}, A. and {Di Sarcina}, I. and {Piegari}, A.~M.
@@ -3107,5 +3095,3 @@ archivePrefix = "arXiv",
 						     adsurl = {http://ads.nao.ac.jp/abs/2016SPIE.9913E..1VV},
 						       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -806,12 +806,16 @@ No actions have been identified.}
 \def\aap{A\&A}             % Astronomy and Astrophysics
 \def\ssr{Space~Sci.~Rev.}  % Space Science Reviews
 \def\apj{ApJ}              % Astrophysical Journal
+\def\apjs{ApJS}            % Astrophysical Journal Supplement
 \def\aj{AJ}                % Astronomical Journal
 \def\mnras{MNRAS}          % Monthly Notices of the RAS
 \def\araa{ARA\&A}          % Annual Review of Astron and Astrophys
 \def\nat{Nature}           % Nature
 \def\apjl{ApJ}             % Astrophysical Journal, Letters
 \def\icarus{Icarus}        % Icarus
+\def\prd{Phys.~Rev.~D}     % Physical Review D
+\def\physrep{Phys.~Rep.}   % Physics Reports
+\def\pasp{PASP}            % Publications of the Astronomical Society of the Pacific
 
 \def\degr{\hbox{$^\circ$}}
 \def\arcmin{\hbox{$^\prime$}}


### PR DESCRIPTION
As we add more bibtex entries it seemed to me that we needed to ensure that our bib files didn't contain obvious formatting problems. Whilst editors can do a lot of this, bibtex itself seems to be a very good linter. Warnings from bibtex are not treated as errors (we have many of them).

This PR adds a new test latex file that uses the `lsstdoc.cls` document class and imports all the bibtex references and creates a document. This is added to the standard make file and therefore also tested by Travis.

The Gaia livelink entries are not vetted because they contain too many errors and are not relevant to LSST.

This PR includes some minor fixes to bibtex files required to allow the test document to be built.