### PR TITLE
Add standard baseline LSST documents to bib file

### DIFF
--- a/tests/test-bibtex.tex
+++ b/tests/test-bibtex.tex
@@ -24,6 +24,9 @@ In the following pages, all bibliographic entries from this repository will be l
 These are used to test that the entries in the relevant \texttt{.bib} files are formatted correctly.
 Bibtex will issue Warnings but the build will only be stopped if Errors are located.
 
+Test the standard references to baseline documents: (\SRD), \DPDD, \LSR, \OSS, \DMSR, \appsUMLdomain, \appsUMLusecase, \SUI, \DMSD, \MOPSD, \DMMD, \DMOps, (\SDQAP), \NewPCP, \UCAL.
+
+
 \nocite{*}
 
 \bibliographystyle{gaia_aa}

--- a/texmf/bibtex/bib/lsst.bib
+++ b/texmf/bibtex/bib/lsst.bib
@@ -1,3 +1,170 @@
+@LiveLink{LDM-,
+author = {},
+title={},
+year={20},
+month={Sept},
+url={http://ls.st/LDM-},
+note={},
+llnote={},
+livelinknumber={LDM-},
+livelinkshortnumber={{LDM-}}
+}
+
+@LiveLink{LDM-156,
+author = {Jonathan Myers and Lynne Jones and Tim Axelrod},
+title={Moving Object Pipeline System Design},
+year={2013},
+month=oct,
+url={http://ls.st/LDM-156},
+note={},
+llnote={},
+livelinknumber={LDM-156},
+livelinkshortnumber={{LDM-156}}
+}
+
+@LiveLink{LDM-131,
+author = {Schuyler {van Dyk} and Deborah Levine},
+title={Science User Interface and Science User Tools Conceptual Design},
+year={2013},
+month=oct,
+url={http://ls.st/LDM-131},
+note={},
+llnote={},
+livelinknumber={LDM-131},
+livelinkshortnumber={{LDM-131}}
+}
+
+@LiveLink{LDM-134,
+author = {Mario Juric and Robyn Allsman and Jeff Kantor},
+title={Data Management Applications UML Use Case Model},
+year={2013},
+month=oct,
+url={http://ls.st/LDM-134},
+note={},
+llnote={},
+livelinknumber={LDM-134},
+livelinkshortnumber={{LDM-134}}
+}
+
+@LiveLink{LDM-133,
+author = {Mario Juric and Kian-Tat Lim and Jeff Kantor},
+title={Data Management UML Domain Model},
+year={2013},
+month=oct,
+url={http://ls.st/LDM-133},
+note={},
+llnote={},
+livelinknumber={LDM-133},
+livelinkshortnumber={{LDM-133}}
+}
+
+@LiveLink{LDM-240,
+ author = {Jeff Kantor and Mario Juric and Kian-Tat Lim},
+ title={Data Management Releases},
+ year={2016},
+ month=feb,
+ url={http://ls.st/LDM-240},
+ note={},
+ llnote={},
+ livelinknumber={LDM-240},
+ livelinkshortnumber={{LDM-240}}
+}
+
+@LiveLink{LPM-17,
+author = {{\v Z}. {Ivezi{\'c}} and {The LSST Science Collaboaration}},
+title={LSST Science Requirements Document},
+year={2011},
+month=jul,
+url={http://ls.st/LPM-17},
+note={},
+llnote={},
+livelinknumber={LPM-17},
+livelinkshortnumber={{LPM-17}}
+}
+
+@LiveLink{LSE-29,
+author = {Charles F. Claver and {The LSST Systems Engineering Integrated Project Team}},
+title={LSST System Requirements},
+year={2016},
+month=aug,
+url={http://ls.st/LSE-29},
+note={},
+llnote={},
+livelinknumber={LSE-29},
+livelinkshortnumber={{LSE-29}}
+}
+
+@LiveLink{LSE-30,
+author = {Charles F. Claver and {The LSST Systems Engineering Integrated Project Team}},
+title={LSST System Requirements},
+year={2016},
+month=aug,
+url={http://ls.st/LSE-30},
+note={},
+llnote={},
+livelinknumber={LSE-30},
+livelinkshortnumber={{LSE-30}}
+}
+
+@LiveLink{LSE-61,
+author = {Gregory Dubois-Felsmann},
+title={LSST Data Management Subsystem Requirements},
+year={2016},
+month=feb,
+url={http://ls.st/LSE-61},
+note={},
+llnote={},
+livelinknumber={LSE-61},
+livelinkshortnumber={{LSE-61}}
+}
+
+@LiveLink{LSE-63,
+author = {Tony Tyson and {DQA Team} and {Science Collaboration}},
+title={Data quality Assurance Plan: Requirements for hte LSST Data Quality Assessment Framework},
+year={2011},
+month=jul,
+url={http://ls.st/LSE-63},
+note={},
+llnote={},
+livelinknumber={LSE-63},
+livelinkshortnumber={{LSE-63}}
+}
+
+@LiveLink{LSE-163,
+ author = {Mario Juric and others},
+ title={LSST Data Products Definition Document},
+ year={2017},
+ month={April},
+ url={http://ls.st/LSE-163},
+ note={},
+ llnote={},
+ livelinknumber={LSE-163},
+ livelinkshortnumber={{LSE-163}}
+}
+
+@LiveLink{LSE-180,
+author = {Lynne Jones},
+title={Level 2 Photometric Calibration for the LSST Survey},
+year={2013},
+month=nov,
+url={http://ls.st/LSE-180},
+note={},
+llnote={},
+livelinknumber={LSE-180},
+livelinkshortnumber={{LSE-180}}
+}
+
+@LiveLink{Document-15125,
+author = {Peter Yoachim and Lynne Jones and {\v Z}. {Ivezi{\'c}}  and Tim Axelrod},
+title={Photometric Self Calibration Design and Prototype},
+year={2013},
+month=oct,
+url={http://ls.st/Document-15125},
+note={},
+llnote={},
+livelinknumber={Document-15125},
+livelinkshortnumber={{Document-15125}}
+}
 
 @LiveLink{SUIT-VISION,
 author = {David R. Ciardi and Xiuqin Wu and Gregory Dubois-Felsmann},

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -1026,21 +1026,28 @@ No actions have been identified.}
 % Command to link to a document in Docushare. Pass an LSST document handle as argument, or a document number
 \newcommand{\ds}[2]{{\color{blue} \href{https://docushare.lsstcorp.org/docushare/dsweb/Get/#1}{#2}}\xspace}
 
-\newcommand{\SRD}{\ds{LPM-17}{SRD}}
-\newcommand{\DPDD}{\ds{LSE-163}{DPDD}}
-\newcommand{\LSR}{\ds{LSE-29}{LSR}}
-\newcommand{\OSS}{\ds{LSE-30}{OSS}}
-\newcommand{\DMSR}{\ds{LSE-61}{DMSR}}
-\newcommand{\appsUMLdomain}{\ds{LDM-133}{LDM-133}}
-\newcommand{\appsUMLusecase}{\ds{LDM-134}{LDM-134}}
-\newcommand{\SUI}{\ds{LDM-131}{SUID}}
-\newcommand{\DMSD}{\ds{LDM-148}{DMSD}}
-\newcommand{\MOPSD}{\ds{LDM-156}{MOPSD}}
-\newcommand{\DMMD}{\ds{LDM-152}{DMMD}}
-\newcommand{\DMOps}{\ds{LDM-230}{DM OpsCon}}
-\newcommand{\SDQAP}{\ds{LSE-63}{LSE-63}}
-\newcommand{\NewPCP}{\ds{LSE-180}{LSE-180}}
-\newcommand{\UCAL}{\ds{Document-15125}{UCAL}}
+% Command to link to a Docushare document via a citation. This is preferred over \ds as it allows the document to be discovered in the references list. No parentheses are added around the supplied text, matching \ds. If both arguments are equal, a standard \citell citation is used. If they differ, \nocite is used with \ds. Blue text is used.
+\newcommand{\dscite}[2]{{\color{blue}
+\IfStrEq{#1}{#2}%
+{\citell{#1}}%
+{\nocite{#1}\ds{#1}{#2}}%
+}\xspace}
+
+\newcommand{\SRD}{\dscite{LPM-17}{SRD}}
+\newcommand{\DPDD}{\dscite{LSE-163}{DPDD}}
+\newcommand{\LSR}{\dscite{LSE-29}{LSR}}
+\newcommand{\OSS}{\dscite{LSE-30}{OSS}}
+\newcommand{\DMSR}{\dscite{LSE-61}{DMSR}}
+\newcommand{\appsUMLdomain}{\dscite{LDM-133}{LDM-133}}
+\newcommand{\appsUMLusecase}{\dscite{LDM-134}{LDM-134}}
+\newcommand{\SUI}{\dscite{LDM-131}{SUID}}
+\newcommand{\DMSD}{\dscite{LDM-148}{DMSD}}
+\newcommand{\MOPSD}{\dscite{LDM-156}{MOPSD}}
+\newcommand{\DMMD}{\dscite{LDM-152}{DMMD}}
+\newcommand{\DMOps}{\dscite{LDM-230}{DM OpsCon}}
+\newcommand{\SDQAP}{\dscite{LSE-63}{LSE-63}}
+\newcommand{\NewPCP}{\dscite{LSE-180}{LSE-180}}
+\newcommand{\UCAL}{\dscite{Document-15125}{UCAL}}
 
 \newcommand{\wbsSFM}{WBS 02C.03.01}
 \newcommand{\wbsAssocP}{WBS 02C.03.02}


### PR DESCRIPTION
* Includes all the documents explicitly listed in lsstdoc.cls
* Adds \dscite command, like \ds but adding a reference entry.