### PR TITLE
Sort and reformat bib files

### DIFF
--- a/texmf/bibtex/bib/books.bib
+++ b/texmf/bibtex/bib/books.bib
@@ -1,245 +1,263 @@
 % Books file
 % Enter here books and proceedings which are reffered to.
 %
-@Book{book:bayesanalysis,
-  author =	{ P.~C.~Gregory},
-  title =	{ {B}ayesian Logical {D}ata {A}nalysis for the Physical Sciences },
-  publisher = { Cambridge University Press},
-  year =	2010,
-  edition = 1
+
+@Proceedings{Adass08,
+  title =        {{A}stronomical {D}ata {A}nalysis {S}oftware and
+                  {S}ystems {XVIII}},
+  year =         2009,
+  publisher =    {Astronomical Society of the Pacific},
+  series =       { Astronomical Society of the Pacific Conference
+                  Series }
 }
-
-@Book{book:numericalrecipes,
-  author =	{ W.~H.~Press and S.~A.~Teukolsky and W.~T.~Vetterling and B.~P.~Flannery },
-  title =	{ {N}umerical {R}ecipes in {C} },
-  publisher = { Cambridge University Press},
-  year =	2002,
-  edition = 2
-}
-
-@Book{book:projectmanagement,
-  author =	{ D.~Lock},
-  title =	{ {P}roject {P}hasing and {P}lanning },
-  publisher = { Gower},
-  year =	2000,
-  edition = 7
-}
-
-@Book{book:patterns,
-  author =	{ E.~Gamma and R.~Helm and R.~Johnson and J.~Vlissides },
-  title =	{ {D}esign {P}atterns: {E}lements of {R}eusable {O}bject-{O}riented {S}oftware  },
-  publisher = { Addison-Wesley Professional Computing Series},
-  year =	1994,
-}
-
-@Book{kane:1983,
-   author = {T.~R.~Kane and P.~W.~Likins and D.~A.~Levinson},
-   title = {{S}pacecraft dynamics},
-   year = {1983},
-   publisher = {McGraw Hill Book Company},
-   edition = {1}
- }
-
-
-@Book{wertz:1978,
-   author = {James.~R.~Wertz(Editor)},
-   title = {{S}pacecraft {A}ttitude {D}etermination and {C}ontrol},
-   year = {1978},
-   publisher = {Kluwer Academic Publishers},
-   edition = {1}
- }
-
-@Book{korn:1961,
-   author = {G.~A.~Korn and T.~M. Korn},
-   title = {{M}athematical handbook for scientists and engineers},
-   year = {1961},
-   publisher = {McGraw Hill Book Company},
-   edition = {1}
- }
-
-@Book{Will:1993,
-   author = {C.~Will},
-   title = {{T}heory and experiment in gravitational physics},
-   year = {1993},
-   publisher = {Cambridge University Press},
-   edition = {2}
- }
-
-@Book{it:xp,
-  author =		{ K.~Beck },
-  title =		{ {E}xtreme {P}rogramming {E}xplained: {E}mbrace {C}hange},
-  publisher =	{ Addison-Wesley },
-  year =		1999,
-  edition =		{1st}
-}
-
-@Book{it:effectivejava,
-  author =		{J.~Bloch },
-  title =		{Writing Effective Java},
-  publisher =	{ Addison-Wesley },
-  year =		2001,
-  edition =		{1st}
-}
-
-@Book{it:javaspec,
-  author =		{J.~Gosling and B.~Joy and G.~Steele },
-  title =		{ {T}he {J}ava {L}anguage {S}pecification },
-  publisher =	{ Addison-Wesley },
-  year =		2000,
-  edition =		{2nd}
-}
-
-
-@Book{hip:catalogue,
-	author = {ESA },
-        title = { {T}he {H}ipparcos and {T}ycho {C}atalogues },
-	institution = {ESA},
-	year = 1997,
-	note = {ESA SP-1200},
-	publisher={ESA}
-}
-
-%THIS exists in ADS - look in gaia_refs_ads ....
-@proceedings{TDUG,
- booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.}}
-
-
-@Book{it:rup,
-	author = {Philippe Kruchten  },
-        title = { The Rational Unified Process: An Introduction },
-        publisher = {Addison-Wesley Professional},
-	year = 2003,
-	edition = {3rd}
-}
-@Book{it:usdp,
-	author = {Ivar Jacobson and Grady Booch and James Rumbaugh  },
-        title = { The Unified Software Development Process },
-        publisher = {Addison-Wesley Professional},
-	year = 1999,
-	edition = {1st}
-}
-
-@Book{it:uml,
-	author = { Grady Booch  and James Rumbaugh and Ivar Jacobson   },
-        title = { The Unified Modeling Language User Guide},
-        publisher = {Addison-Wesley Professional},
-	year = 2005,
-	edition = {2nd}
-}
-
-@Book{book:hamilton,
-  author =	{ Thomas ~L.~Hankins},
-  title =	{ {S}ir {W}illiam {R}owan {H}amilton },
-  publisher = { The Johns Hopkins University Press},
-  year =	1980
-}
-
-@Book{asp:fomalont,
-author = {J.A.~Zensus, P.J.~Napier, P.J.~Napier},
-title = {Very Long Baseline Interferometry and the VLBA },
-publisher ={Astronomical Socienty of the Pacific,},
-year = {1995},
-edition = { ASP Conference Series Vol. 82}
-}
-
-@Book{book:orighip,
-author = {Floor van {L}eeuwen},
-title = {The {H}ipparcos {M}ission},
-publisher = {Springer},
-year = {1997},
-edition = {{S}pace {S}cience {R}eviews, {V}ol.81}
-}
-
-
-@Book{book:newhip,
-author = {Floor van Leeuwen},
-title = {{H}ipparcos, the {N}ew {R}eduction of the {R}aw {D}ata},
-publisher ={Springer },
-year = {2007},
-edition = {{A}strophysics and {S}pace {S}cience {L}ibrary. {V}ol. 350}
-}
-
-@Book{book:sivia,
-  author =	{ D.S.~Sivia},
-  title =	{ {D}ata {A}nalysis. {A} {B}ayesian {T}utorial},
-  publisher = { OUP},
-  year =	1996,
-  edition = 1
-}
-
-@Book{deBoor:2001,
-   author = {C.~de~Boor},
-   title = {{A} {P}ractical {G}uide to {S}plines},
-   year = {2001},
-   publisher = {Springer},
-   edition = {Revised}
- }
 
 @Book{Dierckx:1995,
-   author = {P.~Dierckx},
-   title = {{C} and {S}urface {F}itting with {S}plines},
-   year = {1995},
-   publisher = {Oxford Science Publications, Oxford University Press},
-   edition = {Paperback}
-}
-
-@Book{vanDerVorst2003,
-   author = {H.~van der Vorst},
-   title = {{I}terative {K}rylov {M}ethods for {L}arge {L}inear {S}ystems},
-   year = {2003},
-   publisher = {Cambridge University Press}
+  author =       {P.~Dierckx},
+  title =        {{C} and {S}urface {F}itting with {S}plines},
+  year =         1995,
+  publisher =    {Oxford Science Publications, Oxford University
+                  Press},
+  edition =      {Paperback}
 }
 
 @Book{Greenbaum1997,
-   author = {A.~Greenbaum},
-   title = {{I}terative {M}ethods for {S}olving {L}inear {S}ystems},
-   year = {1997},
-   publisher = {SIAM}
-}
-
-@Proceedings{Adass08,
-   title = {{A}stronomical {D}ata {A}nalysis {S}oftware and {S}ystems {XVIII}},
-   year = {2009},
-   publisher = {Astronomical Society of the Pacific},
-   series = { Astronomical Society of the Pacific Conference Series }
+  author =       {A.~Greenbaum},
+  title =        {{I}terative {M}ethods for {S}olving {L}inear
+                  {S}ystems},
+  year =         1997,
+  publisher =    {SIAM}
 }
 
 @Book{Perryman2009,
-   author = {Michael ~Perryman},
-   title = {{A}stronomical {A}pplications of {A}strometry: Ten Years of Exploitation of the Hipparcos Satellite Data},
-   year = {2009},
-   publisher = {Cambridge University Press}
+  author =       {Michael ~Perryman},
+  title =        {{A}stronomical {A}pplications of {A}strometry: Ten
+                  Years of Exploitation of the Hipparcos Satellite
+                  Data},
+  year =         2009,
+  publisher =    {Cambridge University Press}
+}
+
+@book{Perryman2010,
+  title =        {The Making of History's Greatest Star Map},
+  author =       {Perryman, A.C.},
+  isbn =         9783642116025,
+  lccn =         2010922053,
+  series =       {Astronomers' universe},
+  url =          {http://books.google.es/books?id=P-5pZ8GNuPIC},
+  year =         2010,
+  publisher =    {Springer}
+}
+
+@proceedings{TDUG,
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.}
+}
+
+@Book{Will:1993,
+  author =       {C.~Will},
+  title =        {{T}heory and experiment in gravitational physics},
+  year =         1993,
+  publisher =    {Cambridge University Press},
+  edition =      2
+}
+
+@Book{asp:fomalont,
+  author =       {J.A.~Zensus, P.J.~Napier, P.J.~Napier},
+  title =        {Very Long Baseline Interferometry and the VLBA },
+  publisher =    {Astronomical Socienty of the Pacific,},
+  year =         1995,
+  edition =      { ASP Conference Series Vol. 82}
+}
+
+@Book{book:bayesanalysis,
+  author =       { P.~C.~Gregory},
+  title =        { {B}ayesian Logical {D}ata {A}nalysis for the
+                  Physical Sciences },
+  publisher =    { Cambridge University Press},
+  year =         2010,
+  edition =      1
+}
+
+@Book{book:hamilton,
+  author =       { Thomas ~L.~Hankins},
+  title =        { {S}ir {W}illiam {R}owan {H}amilton },
+  publisher =    { The Johns Hopkins University Press},
+  year =         1980
+}
+
+@Book{book:newhip,
+  author =       {Floor van Leeuwen},
+  title =        {{H}ipparcos, the {N}ew {R}eduction of the {R}aw
+                  {D}ata},
+  publisher =    {Springer },
+  year =         2007,
+  edition =      {{A}strophysics and {S}pace {S}cience
+                  {L}ibrary. {V}ol. 350}
+}
+
+@Book{book:numericalrecipes,
+  author =       { W.~H.~Press and S.~A.~Teukolsky and
+                  W.~T.~Vetterling and B.~P.~Flannery },
+  title =        { {N}umerical {R}ecipes in {C} },
+  publisher =    { Cambridge University Press},
+  year =         2002,
+  edition =      2
+}
+
+%THIS exists in ADS - look in gaia_refs_ads ....
+
+@Book{book:orighip,
+  author =       {Floor van {L}eeuwen},
+  title =        {The {H}ipparcos {M}ission},
+  publisher =    {Springer},
+  year =         1997,
+  edition =      {{S}pace {S}cience {R}eviews, {V}ol.81}
+}
+
+@Book{book:patterns,
+  author =       { E.~Gamma and R.~Helm and R.~Johnson and
+                  J.~Vlissides },
+  title =        { {D}esign {P}atterns: {E}lements of {R}eusable
+                  {O}bject-{O}riented {S}oftware },
+  publisher =    { Addison-Wesley Professional Computing Series},
+  year =         1994,
+}
+
+@Book{book:projectmanagement,
+  author =       { D.~Lock},
+  title =        { {P}roject {P}hasing and {P}lanning },
+  publisher =    { Gower},
+  year =         2000,
+  edition =      7
+}
+
+@Book{book:sivia,
+  author =       { D.S.~Sivia},
+  title =        { {D}ata {A}nalysis. {A} {B}ayesian {T}utorial},
+  publisher =    { OUP},
+  year =         1996,
+  edition =      1
+}
+
+@book{collins2001good,
+  title =        {Good to Great: Why Some Companies Make the
+                  Leap...And Others Don't},
+  author =       {Collins, J.},
+  isbn =         9780066620992,
+  lccn =         00102481,
+  url =          {http://books.google.es/books?id=Q7ja95uwUT4C},
+  year =         2001,
+  publisher =    {HarperCollins}
+}
+
+@Book{deBoor:2001,
+  author =       {C.~de~Boor},
+  title =        {{A} {P}ractical {G}uide to {S}plines},
+  year =         2001,
+  publisher =    {Springer},
+  edition =      {Revised}
 }
 
 @Book{handy1993understanding,
- author = {Handy, Charles},
- title = {Understanding organizations},
- publisher = {Penguin Books},
- year = {1993},
- address = {London, England New York, N.Y., USA},
- isbn = {0140156038}
- }
-@book{Perryman2010,
-  title={The Making of History's Greatest Star Map},
-  author={Perryman, A.C.},
-  isbn={9783642116025},
-  lccn={2010922053},
-  series={Astronomers' universe},
-  url={http://books.google.es/books?id=P-5pZ8GNuPIC},
-  year={2010},
-  publisher={Springer}
+  author =       {Handy, Charles},
+  title =        {Understanding organizations},
+  publisher =    {Penguin Books},
+  year =         1993,
+  address =      {London, England New York, N.Y., USA},
+  isbn =         0140156038
 }
 
-
-@book{collins2001good,
-  title={Good to Great: Why Some Companies Make the Leap...And Others Don't},
-  author={Collins, J.},
-  isbn={9780066620992},
-  lccn={00102481},
-  url={http://books.google.es/books?id=Q7ja95uwUT4C},
-  year={2001},
-  publisher={HarperCollins}
+@Book{hip:catalogue,
+  author =       {ESA },
+  title =        { {T}he {H}ipparcos and {T}ycho {C}atalogues },
+  institution =  {ESA},
+  year =         1997,
+  note =         {ESA SP-1200},
+  publisher =    {ESA}
 }
 
+@Book{it:effectivejava,
+  author =       {J.~Bloch },
+  title =        {Writing Effective Java},
+  publisher =    { Addison-Wesley },
+  year =         2001,
+  edition =      {1st}
+}
+
+@Book{it:javaspec,
+  author =       {J.~Gosling and B.~Joy and G.~Steele },
+  title =        { {T}he {J}ava {L}anguage {S}pecification },
+  publisher =    { Addison-Wesley },
+  year =         2000,
+  edition =      {2nd}
+}
+
+@Book{it:rup,
+  author =       {Philippe Kruchten },
+  title =        { The Rational Unified Process: An Introduction },
+  publisher =    {Addison-Wesley Professional},
+  year =         2003,
+  edition =      {3rd}
+}
+
+@Book{it:uml,
+  author =       { Grady Booch and James Rumbaugh and Ivar Jacobson },
+  title =        { The Unified Modeling Language User Guide},
+  publisher =    {Addison-Wesley Professional},
+  year =         2005,
+  edition =      {2nd}
+}
+
+@Book{it:usdp,
+  author =       {Ivar Jacobson and Grady Booch and James Rumbaugh },
+  title =        { The Unified Software Development Process },
+  publisher =    {Addison-Wesley Professional},
+  year =         1999,
+  edition =      {1st}
+}
+
+@Book{it:xp,
+  author =       { K.~Beck },
+  title =        { {E}xtreme {P}rogramming {E}xplained: {E}mbrace
+                  {C}hange},
+  publisher =    { Addison-Wesley },
+  year =         1999,
+  edition =      {1st}
+}
+
+@Book{kane:1983,
+  author =       {T.~R.~Kane and P.~W.~Likins and D.~A.~Levinson},
+  title =        {{S}pacecraft dynamics},
+  year =         1983,
+  publisher =    {McGraw Hill Book Company},
+  edition =      1
+}
+
+@Book{korn:1961,
+  author =       {G.~A.~Korn and T.~M. Korn},
+  title =        {{M}athematical handbook for scientists and
+                  engineers},
+  year =         1961,
+  publisher =    {McGraw Hill Book Company},
+  edition =      1
+}
+
+@Book{vanDerVorst2003,
+  author =       {H.~van der Vorst},
+  title =        {{I}terative {K}rylov {M}ethods for {L}arge {L}inear
+                  {S}ystems},
+  year =         2003,
+  publisher =    {Cambridge University Press}
+}
+
+@Book{wertz:1978,
+  author =       {James.~R.~Wertz(Editor)},
+  title =        {{S}pacecraft {A}ttitude {D}etermination and
+                  {C}ontrol},
+  year =         1978,
+  publisher =    {Kluwer Academic Publishers},
+  edition =      1
+}

--- a/texmf/bibtex/bib/lsst.bib
+++ b/texmf/bibtex/bib/lsst.bib
@@ -1,316 +1,298 @@
 @DocuShare{LDM-,
-author = {},
-title={},
-year={20},
-month={Sept},
-note={},
-handle={LDM-},
-}
-
-@DocuShare{LDM-135,
-author = {Jacek Becla and Daniel Wang and Serge Monkewitz and K-T Lim and Douglas Smith and Bill Chickering},
-title={Database Design},
-year={2013},
-month=oct,
-note={},
-handle={LDM-135},
-}
-
-@DocuShare{LDM-156,
-author = {Jonathan Myers and Lynne Jones and Tim Axelrod},
-title={Moving Object Pipeline System Design},
-year={2013},
-month=oct,
-note={},
-handle={LDM-156},
-}
-
-@DocuShare{LDM-131,
-author = {Schuyler {van Dyk} and Deborah Levine},
-title={Science User Interface and Science User Tools Conceptual Design},
-year={2013},
-month=oct,
-note={},
-handle={LDM-131},
-}
-
-@DocuShare{LDM-134,
-author = {Mario Juric and Robyn Allsman and Jeff Kantor},
-title={Data Management Applications UML Use Case Model},
-year={2013},
-month=oct,
-note={},
-handle={LDM-134},
-}
-
-@DocuShare{LDM-133,
-author = {Mario Juric and Kian-Tat Lim and Jeff Kantor},
-title={Data Management UML Domain Model},
-year={2013},
-month=oct,
-note={},
-handle={LDM-133},
-}
-
-@DocuShare{LDM-240,
- author = {Jeff Kantor and Mario Juric and Kian-Tat Lim},
- title={Data Management Releases},
- year={2016},
- month=feb,
- note={},
- handle={LDM-240},
-}
-
-@DocuShare{LPM-17,
-author = {{\v Z}. {Ivezi{\'c}} and {The LSST Science Collaboration}},
-title={LSST Science Requirements Document},
-year={2011},
-month=jul,
-note={},
-handle={LPM-17},
-}
-
-@DocuShare{LSE-29,
-author = {Charles F. Claver and {The LSST Systems Engineering Integrated Project Team}},
-title={LSST System Requirements},
-year={2016},
-month=aug,
-note={},
-handle={LSE-29},
-}
-
-@DocuShare{LSE-30,
-author = {Charles F. Claver and {The LSST Systems Engineering Integrated Project Team}},
-title={LSST System Requirements},
-year={2016},
-month=aug,
-note={},
-handle={LSE-30},
-}
-
-@DocuShare{LSE-61,
-author = {Gregory Dubois-Felsmann},
-title={LSST Data Management Subsystem Requirements},
-year={2016},
-month=feb,
-note={},
-handle={LSE-61},
-}
-
-@DocuShare{LSE-63,
-author = {Tony Tyson and {DQA Team} and {Science Collaboration}},
-title={Data quality Assurance Plan: Requirements for hte LSST Data Quality Assessment Framework},
-year={2011},
-month=jul,
-note={},
-handle={LSE-63},
-}
-
-@DocuShare{LSE-81,
-author = {Gregory Dubois-Felsmann},
-title={LSST Science and Project Sizing Inputs},
-year={2013},
-month=oct,
-note={},
-handle={LSE-81},
-}
-
-@DocuShare{LSE-163,
- author = {Mario Juric and others},
- title={LSST Data Products Definition Document},
- year={2017},
- month={April},
- note={},
- handle={LSE-163},
-}
-
-@DocuShare{LSE-180,
-author = {Lynne Jones},
-title={Level 2 Photometric Calibration for the LSST Survey},
-year={2013},
-month=nov,
-note={},
-handle={LSE-180},
+  author =       {},
+  title =        {},
+  year =         20,
+  month =        {Sept},
+  handle =       {LDM-},
 }
 
 @DocuShare{Document-15125,
-author = {Peter Yoachim and Lynne Jones and {\v Z}. {Ivezi{\'c}}  and Tim Axelrod},
-title={Photometric Self Calibration Design and Prototype},
-year={2013},
-month=oct,
-note={},
-handle={Document-15125},
-}
-
-@DocuShare{SUIT-VISION,
-author = {David R. Ciardi and Xiuqin Wu and Gregory Dubois-Felsmann},
-title={A Vision for the Science User Interface and Tools},
-institution={IPAC},
-year={2016},
-month={Sept},
-note={},
-handle={LDM-492},
-}
-
-@DocuShare{LDM-130,
-author = {Unknown},
-title={LSST Science User Interface and Tools Requirements},
-institution={IPAC},
-year={2017},
-month={Sept},
-note={},
-handle={LDM-130},
-}
-
-@DocuShare{LDM-148,
-author = {Jeff Kantor and Tim Axelrod},
-title={Data Management System Design},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-148},
-}
-
-@DocuShare{LDM-230,
-author = {Kian-Tat Lim},
-title={Automated Operation of the LSST Data Management System},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-230},
+  author =       {Peter Yoachim and Lynne Jones and {\v
+                  Z}. {Ivezi{\'c}} and Tim Axelrod},
+  title =        {Photometric Self Calibration Design and Prototype},
+  year =         2013,
+  month =        oct,
+  handle =       {Document-15125},
 }
 
 @DocuShare{LDM-129,
-author = {Mike Freemon and Jeff Kantor},
-title={Data Management Infrastructure Design},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-129},
+  author =       {Mike Freemon and Jeff Kantor},
+  title =        {Data Management Infrastructure Design},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-129},
 }
 
-@DocuShare{LDM-152,
-author = {Kian-Tat Lim and Ray Plante and Gregory Dubois-Felsmann},
-title={Data Management Middleware Design},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-152},
+@DocuShare{LDM-130,
+  author =       {Unknown},
+  title =        {LSST Science User Interface and Tools Requirements},
+  institution =  {IPAC},
+  year =         2017,
+  month =        {Sept},
+  handle =       {LDM-130},
 }
 
-@DocuShare{LDM-146,
-author = {Kian-Tat Lim and Robyn Allsman and Jeff Kantor},
-title={Data Management Middleware UML Use Case and Activity Model},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-146},
+@DocuShare{LDM-131,
+  author =       {Schuyler {van Dyk} and Deborah Levine},
+  title =        {Science User Interface and Science User Tools
+                  Conceptual Design},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-131},
 }
 
-@DocuShare{LDM-140,
-author = {Kian-Tat Lim and Chris Smith and Tim Axelrod and Gregory Dubois-Felsmann and Mike Freemon},
-title={Data Management Compute Sizing Explanation},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-140},
+@DocuShare{LDM-133,
+  author =       {Mario Juric and Kian-Tat Lim and Jeff Kantor},
+  title =        {Data Management UML Domain Model},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-133},
+}
+
+@DocuShare{LDM-134,
+  author =       {Mario Juric and Robyn Allsman and Jeff Kantor},
+  title =        {Data Management Applications UML Use Case Model},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-134},
+}
+
+@DocuShare{LDM-135,
+  author =       {Jacek Becla and Daniel Wang and Serge Monkewitz and
+                  K-T Lim and Douglas Smith and Bill Chickering},
+  title =        {Database Design},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-135},
 }
 
 @DocuShare{LDM-138,
-author = {Jeff Kantor and Tim Axelrod and Kian-Tat Lim},
-title={Data Management Compute Sizing Model},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-138},
+  author =       {Jeff Kantor and Tim Axelrod and Kian-Tat Lim},
+  title =        {Data Management Compute Sizing Model},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-138},
 }
 
 @DocuShare{LDM-139,
-author = {Jacek Becla},
-title={Data Management Storage Sizing and I/O Model Explanation},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-139},
+  author =       {Jacek Becla},
+  title =        {Data Management Storage Sizing and I/O Model
+                  Explanation},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-139},
+}
+
+@DocuShare{LDM-140,
+  author =       {Kian-Tat Lim and Chris Smith and Tim Axelrod and
+                  Gregory Dubois-Felsmann and Mike Freemon},
+  title =        {Data Management Compute Sizing Explanation},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-140},
 }
 
 @DocuShare{LDM-141,
-author = {Unknown},
-title={Data Management Storage Sizing and I/O Model},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-141},
+  author =       {Unknown},
+  title =        {Data Management Storage Sizing and I/O Model},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-141},
 }
 
 @DocuShare{LDM-143,
-author = {Mike Freemon and Steve Pietrowicz},
-title={Site Specific Infrastructure Estimation Explanation},
-year={2013},
-month={Oct},
-note={},
-handle={LDM-143},
+  author =       {Mike Freemon and Steve Pietrowicz},
+  title =        {Site Specific Infrastructure Estimation Explanation},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-143},
 }
 
 @DocuShare{LDM-144,
-author = {Unknown},
-title={Site Specific Infrastructure Estimation Model},
-year={2016},
-month={Jan},
-note={},
-handle={LDM-144},
+  author =       {Unknown},
+  title =        {Site Specific Infrastructure Estimation Model},
+  year =         2016,
+  month =        {Jan},
+  handle =       {LDM-144},
 }
 
-@DocuShare{LPM-55,
-author = {Donald Sweeney and Robert McKercher },
-title={Project Quality Assurance Plan},
-year={2013},
-month={August},
-note={},
-handle={LPM-55},
+@DocuShare{LDM-146,
+  author =       {Kian-Tat Lim and Robyn Allsman and Jeff Kantor},
+  title =        {Data Management Middleware UML Use Case and Activity
+                  Model},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-146},
 }
 
-@DocuShare{LPM-20,
-author = {Victor Krabbendam and Brian Selvy},
-title={Risk \& Opportunity Management Plan},
-year={2015},
-month={August},
-note={},
-handle={LPM-20},
-}
-
-@DocuShare{LPM-51,
-author = {Robert McKercher },
-title={Document Management Plan },
-year={2013},
-month={August},
-note={},
-handle={LPM-51},
-}
-
-@DocuShare{LDM-512,
-author = {Tim Jenness and William O'Mullane},
-title={Data Management Risk Assessment Process },
-year={2017},
-month={April},
-note={},
-handle={LDM-512},
-}
-
-@DocuShare{LDM-503,
-author = {William O'Mullane and Mario Juri\'c and Frossie Economou},
-title={Data Management Test, Verificaiton and Validation Plan },
-year={2017},
-month={April},
-note={},
-handle={LDM-503},
+@DocuShare{LDM-148,
+  author =       {Jeff Kantor and Tim Axelrod},
+  title =        {Data Management System Design},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-148},
 }
 
 @DocuShare{LDM-151,
-author = {Mario Juri\'c and Robert Lupton and Tim Axelrod et al.},
-title={Data Management Applications Design},
-year={2013},
-month={October},
-note={},
-handle={LDM-151},
+  author =       {Mario Juri\'c and Robert Lupton and Tim Axelrod et
+                  al.},
+  title =        {Data Management Applications Design},
+  year =         2013,
+  month =        {October},
+  handle =       {LDM-151},
+}
+
+@DocuShare{LDM-152,
+  author =       {Kian-Tat Lim and Ray Plante and Gregory
+                  Dubois-Felsmann},
+  title =        {Data Management Middleware Design},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-152},
+}
+
+@DocuShare{LDM-156,
+  author =       {Jonathan Myers and Lynne Jones and Tim Axelrod},
+  title =        {Moving Object Pipeline System Design},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-156},
+}
+
+@DocuShare{LDM-230,
+  author =       {Kian-Tat Lim},
+  title =        {Automated Operation of the LSST Data Management
+                  System},
+  year =         2013,
+  month =        {Oct},
+  handle =       {LDM-230},
+}
+
+@DocuShare{LDM-240,
+  author =       {Jeff Kantor and Mario Juric and Kian-Tat Lim},
+  title =        {Data Management Releases},
+  year =         2016,
+  month =        feb,
+  handle =       {LDM-240},
+}
+
+@DocuShare{LDM-492,
+  author =       {David R. Ciardi and Xiuqin Wu and Gregory
+                  Dubois-Felsmann},
+  title =        {A Vision for the Science User Interface and Tools},
+  institution =  {IPAC},
+  year =         2016,
+  month =        {Sept},
+  handle =       {LDM-492},
+}
+
+@DocuShare{LDM-503,
+  author =       {William O'Mullane and Mario Juri\'c and Frossie
+                  Economou},
+  title =        {Data Management Test, Verificaiton and Validation
+                  Plan },
+  year =         2017,
+  month =        {April},
+  handle =       {LDM-503},
+}
+
+@DocuShare{LDM-512,
+  author =       {Tim Jenness and William O'Mullane},
+  title =        {Data Management Risk Assessment Process },
+  year =         2017,
+  month =        {April},
+  handle =       {LDM-512},
+}
+
+@DocuShare{LPM-17,
+  author =       {{\v Z}. {Ivezi{\'c}} and {The LSST Science
+                  Collaboration}},
+  title =        {LSST Science Requirements Document},
+  year =         2011,
+  month =        jul,
+  handle =       {LPM-17},
+}
+
+@DocuShare{LPM-20,
+  author =       {Victor Krabbendam and Brian Selvy},
+  title =        {Risk \& Opportunity Management Plan},
+  year =         2015,
+  month =        {August},
+  handle =       {LPM-20},
+}
+
+@DocuShare{LPM-51,
+  author =       {Robert McKercher },
+  title =        {Document Management Plan },
+  year =         2013,
+  month =        {August},
+  handle =       {LPM-51},
+}
+
+@DocuShare{LPM-55,
+  author =       {Donald Sweeney and Robert McKercher },
+  title =        {Project Quality Assurance Plan},
+  year =         2013,
+  month =        {August},
+  handle =       {LPM-55},
+}
+
+@DocuShare{LSE-163,
+  author =       {Mario Juric and others},
+  title =        {LSST Data Products Definition Document},
+  year =         2017,
+  month =        {April},
+  handle =       {LSE-163},
+}
+
+@DocuShare{LSE-180,
+  author =       {Lynne Jones},
+  title =        {Level 2 Photometric Calibration for the LSST Survey},
+  year =         2013,
+  month =        nov,
+  handle =       {LSE-180},
+}
+
+@DocuShare{LSE-29,
+  author =       {Charles F. Claver and {The LSST Systems Engineering
+                  Integrated Project Team}},
+  title =        {LSST System Requirements},
+  year =         2016,
+  month =        aug,
+  handle =       {LSE-29},
+}
+
+@DocuShare{LSE-30,
+  author =       {Charles F. Claver and {The LSST Systems Engineering
+                  Integrated Project Team}},
+  title =        {LSST System Requirements},
+  year =         2016,
+  month =        aug,
+  handle =       {LSE-30},
+}
+
+@DocuShare{LSE-61,
+  author =       {Gregory Dubois-Felsmann},
+  title =        {LSST Data Management Subsystem Requirements},
+  year =         2016,
+  month =        feb,
+  handle =       {LSE-61},
+}
+
+@DocuShare{LSE-63,
+  author =       {Tony Tyson and {DQA Team} and {Science
+                  Collaboration}},
+  title =        {Data quality Assurance Plan: Requirements for hte
+                  LSST Data Quality Assessment Framework},
+  year =         2011,
+  month =        jul,
+  handle =       {LSE-63},
+}
+
+@DocuShare{LSE-81,
+  author =       {Gregory Dubois-Felsmann},
+  title =        {LSST Science and Project Sizing Inputs},
+  year =         2013,
+  month =        oct,
+  handle =       {LSE-81},
 }

--- a/texmf/bibtex/bib/refs.bib
+++ b/texmf/bibtex/bib/refs.bib
@@ -2,197 +2,226 @@
 % Do not put books in this file
 %
 
-@ARTICLE{2012.Vuillermet.SPIE,
-   author = {Vuillermet, M. and Billon-Lanfrey, D. and Reibel, Y. and Manissadjian, A. and Mollard, L. and Baier, N. and Gravrand, O. and Destéfanis G.},
-    title = "{Status of MCT focal plane arrays in France}",
-  journal = {Proc. SPIE 8353, Infrared Technology and Applications XXXVIII},
-     year = 2012,
-    month = may,
-   volume = 38,
-    pages = {83532},
-      doi = {10.1117/12.921868},
+@ARTICLE{1991.Spyak.OpticalEngineering,
+  author =       {{Spyak}, P.R. and {Wolfe}, W.L.},
+  title =        "{Scatter from particulate-contaminated mirrors}",
+  journal =      {Optical Engineering},
+  year =         1991,
+  volume =       31,
+  pages =        {1746-1784}
 }
 
-@ARTICLE{Ana:AgisMain,
-   author = { L.~Lindegren and U.~Lammers and D.~Hobbs and W.~O'Mullane and U.~Bastian and J.~Hernandez},
-    title = {The astrometric core solution for the {Gaia} mission. {Overview} of models, algorithms, and software implementation},
-  journal = {Astronomy and Astrophysics},
-     year = 2012,
-	 month = {February},
-	volume = 538,
-  note = {A78, DOI: \url{http://dx.doi.org/10.1051/0004-6361/201117905}}
+@ARTICLE{1997.Fornies-Marquina.IEEE,
+  author =       {{Fornies-Marquina}, J.M. and {Letosa}, J. and
+                  {Garc{\'\i}a-Gracia}, M. and {Artacho}, J.M.},
+  title =        "{Error propagation for the transformation of time
+                  domain into frequency domain}",
+  journal =      {IEEE transactions on magnetics},
+  year =         1997,
+  month =        mar,
+  volume =       33,
+  pages =        {1456-1459}
 }
 
-@ARTICLE{Ana:AgisCg,
-   author = {A.~Bombrun and L.~Lindegren and D.~Hobbs and B.~Holl and U.~Lammers and U.~Bastian},
-    title = {A conjugate gradient algorithm for the astrometric core solution of {Gaia}},
-  journal = {Astronomy and Astrophysics},
-     year = 2012,
-    month = {February},
-	volume = 538,
-  note = {A77, DOI: \url{http://dx.doi.org/10.1051/0004-6361/201117904}}
+@ARTICLE{2003.Holland.IEEE,
+  author =       {{Holland}, S. E. and {Groom}, D. E. and {Palaio},
+                  N. P. and {Stover}, R. J.  and {Wei}, M.},
+  title =        "{Fully depleted, back-illuminated charge-coupled
+                  devices fabricated on high-resistivity silicon}",
+  journal =      {IEEE transactions on electron devices},
+  year =         2003,
+  month =        jan,
+  volume =       50,
+  pages =        {225-238}
 }
 
 % 2003AJ....125.1580Ka is in  gaia_refs_ads as it should be,
 
-@ARTICLE{2010arXiv1002.5016K,
-   author = {{Klioner}, S.~A. and {Zschocke}, S. and {Soffel}, M.~H. and
-	{Butkevich}, A.~G.},
-    title = "{Testing Local Lorentz Invariance with high-accuracy astrometric observations}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1002.5016},
- primaryClass = "astro-ph.CO",
- keywords = {Astrophysics - Cosmology and Extragalactic Astrophysics},
-     year = 2010,
-    month = feb,
-   adsurl = {http://adsabs.harvard.edu/abs/2010arXiv1002.5016K},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2005.Baccaro.IEEE,
+  author =       {{Baccaro}, S. and {Piegari}, A. and {Di Sarcina},
+                  I. and {Cecilia}, A.},
+  title =        "{Effect of Irradiation on Optical Components}",
+  journal =      {IEEE transactions on nuclear science},
+  year =         2005,
+  month =        oct,
+  volume =       52,
+  pages =        {1779-1784}
 }
 
 @INPROCEEDINGS{2008ASSL..349..399K,
-   author = {{Klioner}, S.~A.},
-    title = "{Testing Relativity with Space Astrometry Missions}",
-booktitle = {Lasers, Clocks and Drag-Free Control: Exploration of Relativistic Gravity in Space},
-     year = 2008,
-   series = {Astrophysics and Space Science Library},
-   volume = 349,
-   editor = "{H.~Dittus, C.~Lammerzahl, \& S.~G.~Turyshev}",
-    pages = {399},
-      doi = {10.1007/978-3-540-34377-6_19},
-   adsurl = {http://adsabs.harvard.edu/abs/2008ASSL..349..399K},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Klioner}, S.~A.},
+  title =        "{Testing Relativity with Space Astrometry Missions}",
+  booktitle =    {Lasers, Clocks and Drag-Free Control: Exploration of
+                  Relativistic Gravity in Space},
+  year =         2008,
+  series =       {Astrophysics and Space Science Library},
+  volume =       349,
+  editor =       "{H.~Dittus, C.~Lammerzahl, \& S.~G.~Turyshev}",
+  pages =        399,
+  doi =          {10.1007/978-3-540-34377-6_19},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008ASSL..349..399K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010.Seabroke.SPIE,
+  author =       { Seabroke, G. M. and Holland, A. D. and Burt, D. and
+                  Robbins, M. S.},
+  title =        "{Silvaco ATLAS model of ESA's Gaia satellite e2v
+                  CCD91-72 pixels}",
+  journal =      {Proc. SPIE},
+  year =         2010,
+  volume =       7742,
+  pages =        {774-14}
+}
+
+@ARTICLE{2010arXiv1002.5016K,
+  author =       {{Klioner}, S.~A. and {Zschocke}, S. and {Soffel},
+                  M.~H. and {Butkevich}, A.~G.},
+  title =        "{Testing Local Lorentz Invariance with high-accuracy
+                  astrometric observations}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1002.5016},
+  primaryClass = "astro-ph.CO",
+  keywords =     {Astrophysics - Cosmology and Extragalactic
+                  Astrophysics},
+  year =         2010,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2010arXiv1002.5016K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012.Vuillermet.SPIE,
+  author =       {Vuillermet, M. and Billon-Lanfrey, D. and Reibel,
+                  Y. and Manissadjian, A. and Mollard, L. and Baier,
+                  N. and Gravrand, O. and Destéfanis G.},
+  title =        "{Status of MCT focal plane arrays in France}",
+  journal =      {Proc. SPIE 8353, Infrared Technology and
+                  Applications XXXVIII},
+  year =         2012,
+  month =        may,
+  volume =       38,
+  pages =        83532,
+  doi =          {10.1117/12.921868},
+}
+
+@ARTICLE{Ana:AgisCg,
+  author =       {A.~Bombrun and L.~Lindegren and D.~Hobbs and B.~Holl
+                  and U.~Lammers and U.~Bastian},
+  title =        {A conjugate gradient algorithm for the astrometric
+                  core solution of {Gaia}},
+  journal =      {Astronomy and Astrophysics},
+  year =         2012,
+  month =        {February},
+  volume =       538,
+  note =         {A77, DOI:
+                  \url{http://dx.doi.org/10.1051/0004-6361/201117904}}
+}
+
+@ARTICLE{Ana:AgisMain,
+  author =       { L.~Lindegren and U.~Lammers and D.~Hobbs and
+                  W.~O'Mullane and U.~Bastian and J.~Hernandez},
+  title =        {The astrometric core solution for the {Gaia}
+                  mission. {Overview} of models, algorithms, and
+                  software implementation},
+  journal =      {Astronomy and Astrophysics},
+  year =         2012,
+  month =        {February},
+  volume =       538,
+  note =         {A78, DOI:
+                  \url{http://dx.doi.org/10.1051/0004-6361/201117905}}
+}
+
+@TechReport{CU6:AG-003,
+  author =       {A.~Guerrier},
+  title =        {{S}oftware {D}esign {D}ocument for {W}avelength
+                  {C}alibration},
+  note =         {GAIA-C6-TN-OPM-AG-003-1}
+}
+
+@TechReport{CU6:AG-004,
+  author =       {A.~Guerrier},
+  title =        {{S}oftware {D}esign {D}ocument for {A}pply
+                  {C}alibration},
+  note =         {GAIA-C6-SP-OPM-AG-004-1}
+}
+
+@TechReport{DOC:HEH-001,
+  author =       {H.~Huckle},
+  year =         2007,
+  title =        {Continuum {N}ormalisation},
+  note =         {GAIA-C6-SP-MSSL-HEH-001-D}
+}
+
+@article{Fraedrich:2009:TMV,
+  author =       {Roland Fraedrich and Jens Schneider and R\"{u}diger
+                  Westermann},
+  title =        {Exploring the "Millennium Run" - Scalable Rendering
+                  of Large-Scale Cosmological Datasets},
+  year =         2009,
+  month =        {November-December},
+  journal =      {IEEE Transactions on Visualization and Computer
+                  Graphics (Proceedings Visualization / Information
+                  Visualization 2009)},
+  volume =       15,
+  number =       6,
+  pages =        {to appear},
+  doi =          {xx.xxxx/xxxxxxx.xxxxxxx},
 }
 
 @TechReport{GAIA.ASF.SP.PLM.00174,
-   author = {{EADS~Astrium}},
-   title={GAIA PLM TB/TV test specification: functional and performance tests},
-   institution={},
-   year={2010},
-   month={June},
-   note = {GAIA.ASF.SP.PLM.00174}
+  author =       {{EADS~Astrium}},
+  title =        {GAIA PLM TB/TV test specification: functional and
+                  performance tests},
+  institution =  {},
+  year =         2010,
+  month =        {June},
+  note =         {GAIA.ASF.SP.PLM.00174}
 }
 
 @TechReport{GAIA.ASU.TCN.ESM.00153,
-   author = {{EADS~Astrium}},
-   title={Gaia Attitude- and Orbit-Control sub-System Normal Mode Final Tuning and Stability Analysis},
-   institution={},
-   year={2011},
-   month={July},
-   note = {GAIA.ASU.TCN.ESM.00153}
-}
-
-@ARTICLE{1997.Fornies-Marquina.IEEE,
-   author = {{Fornies-Marquina}, J.M. and {Letosa}, J. and {Garc{\'\i}a-Gracia}, M. and {Artacho}, J.M.},
-    title = "{Error propagation for the transformation of time domain into frequency domain}",
-  journal = {IEEE transactions on magnetics},
-     year = 1997,
-    month = mar,
-   volume = 33,
-    pages = {1456-1459}
-}
-
-@TechReport{NGST.BRDF.Lallo,
-   author = {{{Lallo}, M. and {Petro}, L.}},
-   title={Bidirectional reflectance distribution function for the NGST mirrors},
-   institution={Space Telescope Science Institute},
-   month={February},
-}
-
-@ARTICLE{1991.Spyak.OpticalEngineering,
-   author = {{Spyak}, P.R. and {Wolfe}, W.L.},
-    title = "{Scatter from particulate-contaminated mirrors}",
-  journal = {Optical Engineering},
-     year = 1991,
-   volume = 31,
-    pages = {1746-1784}
-}
-
-@ARTICLE{2005.Baccaro.IEEE,
-   author = {{Baccaro}, S. and {Piegari}, A. and {Di Sarcina}, I. and {Cecilia}, A.},
-    title = "{Effect of Irradiation on Optical Components}",
-  journal = {IEEE transactions on nuclear science},
-     year = 2005,
-    month = oct,
-   volume = 52,
-    pages = {1779-1784}
-}
-
-@ARTICLE{2003.Holland.IEEE,
-   author = {{Holland}, S. E. and {Groom}, D. E. and {Palaio}, N. P. and {Stover}, R. J.
-        and {Wei}, M.},
-    title = "{Fully depleted, back-illuminated charge-coupled devices fabricated
-              on high-resistivity silicon}",
-  journal = {IEEE transactions on electron devices},
-     year = 2003,
-    month = jan,
-   volume = 50,
-    pages = {225-238}
+  author =       {{EADS~Astrium}},
+  title =        {Gaia Attitude- and Orbit-Control sub-System Normal
+                  Mode Final Tuning and Stability Analysis},
+  institution =  {},
+  year =         2011,
+  month =        {July},
+  note =         {GAIA.ASU.TCN.ESM.00153}
 }
 
 @TechReport{GAIASYS.NT.00134.T.ASTR,
-   author = {{EADS~Astrium}},
-   title={GAIA Point Spread Function and internal straylight evaluation},
-   institution={},
-   year={2004},
-   month={February},
-   note = {GAIASYS.NT.00134.T.ASTR}
+  author =       {{EADS~Astrium}},
+  title =        {GAIA Point Spread Function and internal straylight
+                  evaluation},
+  institution =  {},
+  year =         2004,
+  month =        {February},
+  note =         {GAIASYS.NT.00134.T.ASTR}
 }
 
-@TechReport{ndac:nullspace,
-  author = { L.~Lindegren },
-  title = { {P}seudosolution and pseudocovariances of least-squares
-problems with known null space },
-  institution = { Lund Observatory },
-  year = { 1983 },
-  month = { April },
-  note = { NDAC/LO/018, Hipparcos NDAC }
-}
-@TechReport{compressoracle10g,
-  author =  { Oracle },
-  title =   { Data Compression in 10g },
-  institution = { Oracle Corporation },
-  year =    2005,
-  month =   {May},
-  note =    {\url{http://www.oracle.com/technology/products/bi/db/10g/pdf/twp_data_compression_10gr2_0505.pdf}}
-}
-@TechReport{compressoracle11g,
-  author =  { Oracle },
-  title =   { Data Compression in 11g },
-  institution = { Oracle Corporation },
-  year =    2007,
-  month =   {May},
-  note =    {\url{http://download.oracle.com/docs/cd/B28359_01/server.111/b28318/schema.htm#CNCPT1132}}
-}
-@InProceedings{hamilton1843,
-  author =              {W.~R.~Hamilton },
-  title =               {On a new Species of Imaginary Quantities connected with a theory of Quaternions},
-  year =                1843,
-  booktitle = {Proceedings of the Royal Irish Academy },
-  volume  = {2},
-  pages   = {424-434},
-  Note = {\url{http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/Quatern1/Quatern1.html}}
+@Article{IAU:2001,
+  author =       {IAU},
+  title =        {},
+  journal =      {{I}nformation {B}ulletin},
+  volume =       88,
+  year =         2001,
+  note =         {(errata in IAU Information Bulletin, 89)}
 }
 
-@InProceedings{hamilton1844,
-  author =              {W.~R.~Hamilton },
-  title =               {On Quaternions},
-  year =                1847,
-  booktitle = {Proceedings of the Royal Irish Academy },
-  volume  = {3},
-  pages   = {1-16},
-  Note = {\url{http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/Quatern2/Quatern2.html}}
-}
-
-@InProceedings{hamilton:onquat,
-  author =              {William Rowan Hamilton },
-  title =               {ON QUATERNIONS, OR ON A NEW SYSTEM OF
-IMAGINARIES IN ALGEBRA },
-  year =                1844,
-  booktitle = {Proceedings of the Royal Irish Academy },
-  volume  = {3},
-  pages   = {1-16},
-  Note = {\url{http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/OnQuat/OnQuat.pdf}}
+@article{LLGaiaStatus,
+  author =       {Lindegren,Lennart},
+  title =        {Gaia: Astrometric performance and current status of
+                  the project},
+  journal =      {Proceedings of the International Astronomical Union},
+  volume =       5,
+  number =       {Symposium S261},
+  pages =        {296-305},
+  year =         2009,
+  doi =          {10.1017/S1743921309990548},
+  URL =
+                  {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=6911372&fulltextType=RA&fileId=S1743921309990548},
+  eprint =
+                  {http://journals.cambridge.org/article_S1743921309990548},
 }
 
 
@@ -349,220 +378,351 @@ requirements},
   livelinkshortnumber =    {EISD-EPNS-00003}
 }
 
-@TechReport{esa:sogs,
-  author =              {D.~Texier},
-  title =               {Note on Science Operations Ground Segment Documentation},
-  institution = {ESA},
-  year =                2005,
-  note = { SOGS-TN-ESAC-DT-001 }
+@TechReport{Lindegren1993,
+  author =       {Lennart Lindegren and Michael Perryman et al },
+  title =        { GAIA : Global Astrometric Interferometer for
+                  Astrophysics },
+  institution =  { Lund },
+  year =         1993,
+  month =        {October},
+  url =
+                  {http://www.astro.lu.se/%7Elennart/Astrometry/gaia_proposal.PDF}
 }
 
-
-@TechReport{gaia:mird,
-  author =      { {GAIA} Project Team },
-  title =       { {Gaia} {M}ission {I}mplementation {R}equirement {D}ocument },
-  year =        2006,
-  month =       {May},
-  note =        {{G}AIA-EST-RQ-00457}
+@TechReport{NGST.BRDF.Lallo,
+  author =       {{{Lallo}, M. and {Petro}, L.}},
+  title =        {Bidirectional reflectance distribution function for
+                  the NGST mirrors},
+  institution =  {Space Telescope Science Institute},
+  month =        {February},
 }
 
-
-@Article{IAU:2001,
-   author = {IAU},
-   title = {},
-   journal = {{I}nformation {B}ulletin},
-   volume = {88},
-   year = {2001},
-   note = {(errata in IAU Information Bulletin, 89)}
- }
-
-
-@ARTICLE{bucc1,
-   author = {{Bucciarelli}, B. and {Taff}, L.~G. and {Lattanzi}, M.~G.},
-   title = "{A generalization of the moving mean}",
-    year = 1993,
-    journal = {J. Statist. Comput. Simul.},
-    volume = 48,
-    pages = {29}
+@TechReport{REC-ADQL-2.0,
+  author =       { Ortiz I., Lusted J., Dowler P. },
+  title =        { Astronomical Data Query Language },
+  institution =  { IVOA },
+  year =         2008,
+  month =        {October},
+  note =         {REC-ADQL-2.0}
 }
 
+@TechReport{REC-SSO-1.01,
+  author =       { Rixon G., Graham M. },
+  title =        { Single-Sign-On Profile: Authentication Mechanisms },
+  institution =  { IVOA },
+  year =         2008,
+  month =        {January},
+  note =         {REC-SSO-1.01}
+}
+
+@TechReport{REC-TAP-1.0,
+  author =       { Dowler P., Rixon G., Tody D. },
+  title =        { Table Access Protocol },
+  institution =  { IVOA },
+  year =         2010,
+  month =        {March},
+  note =         {REC-TAP-1.0}
+}
+
+@TechReport{REC-UWS-1.0,
+  author =       { Harrison P., Rixon G. },
+  title =        { Universal Worker Service Pattern },
+  institution =  { IVOA },
+  year =         2010,
+  month =        {October},
+  note =         {REC-UWS-1.0}
+}
+
+@TechReport{REC-VOSpace-1.15,
+  author =       { Graham M., Morris D., Rixon G. },
+  title =        { VOSpace specification },
+  institution =  { IVOA },
+  year =         2009,
+  month =        {October},
+  note =         {REC-VOSpace-1.15}
+}
+
+@TechReport{REC-VOSpace-2.0,
+  author =       { Graham M., Morris D., Rixon G. },
+  title =        { VOSpace specification },
+  institution =  { IVOA },
+  year =         2011,
+  month =        {June},
+  note =         {REC-VOSpace-2.0}
+}
 
 @INPROCEEDINGS{Schneider-2005:a,
-  author = {{Schneider}, J.},
-  title = "{Can the Perturbation of a Stellar Motion in a Triple System Mimic
-            a Planet}",
-  booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-  year = 2005,
-  editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-            },
-  month = jan,
-   pages = {263--266}
+  author =       {{Schneider}, J.},
+  title =        "{Can the Perturbation of a Stellar Motion in a
+                  Triple System Mimic a Planet}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {263--266}
 }
 
-
-@TechReport{gaia:ttcanal,
-  author =      { M.~Martinez Fernandez },
-  title =       { {G}aia {TT\&C} {S}ubsystem {A}nalysis },
-  year =        2005,
-  month =       {January},
-  note =        { Note prepared at request of Project team}
+@misc{WS2CU6:extraction,
+  author =       {M.~Cropper and S.R.~Rosen},
+  title =        { Spectra Extraction},
+  note =         {\raggedright {CU6 W}orkshop2,
+                  {http://wwwhip.obspm.fr/gaia/cu6/workshop\_2/\CU6\_w2\_Cropper\_extraction.pdf}}
 }
 
-@Misc{gaia:ssmobjattribs,
-  note =        {F.~Arenou and F.~Ch\'ereau, private communications}
+@misc{WS2CU6:intro,
+  author =       {D.~Katz},
+  title =        { {G}aia - {RVS}: {DPAC} and {CU6}},
+  note =         {\raggedright {CU6 W}orkshop2,
+                  {http://wwwhip.obspm.fr/gaia/cu6/workshop\_2/CU6\_w2\_Katz\_intro.pdf}}
 }
 
-
-@TechReport{gaia:e2vccddesignreport,
-  author =      { D.~Burt },
-  title =       { Gaia {T}echnology {D}emonstrator: {AF} {CCD} {DESIGN} {REPORT} },
-  institution = { e2v },
-  year =        2003,
-  month =       {January},
-  note =        {GAIA-E2V-RP-020}
-}
-
-@TechReport{gaia:AstroFPAGenDesign,
-  author =      { Astrium GAIA FPA team },
-  title =       { {GAIA} {CCD} and {F}ocal {P}lan {T}echnology {D}emonstrators: {ASTRO} {FPA} {G}eneral {D}esign {Description} },
-  institution = { EADS/Astrium },
-  year =        2003,
-  month =       {December},
-  note =        {GAIAFPA.NT.00120.T.ASTR}
-}
-
-@TechReport{gaia:astriumdefstudy,
-  author =      { EADS Astrium Gaia team },
-  title =       { {GAIA} {D}efinition {S}tudy },
-  institution = { EADS/Astrium },
-  year =        2005,
-  month =       {June},
-  note =        {Final Presentation, Noordwijk, June 8, 2005}
-}
-
-@Misc{gaia:nu0opt,
-  note =        {U.~Lammers, unpublished results}
-}
-
-@Misc{gaia:lattanzipriv,
-  note =        {M.~Lattanzi and R.~Drimmel, private communcations, October 2003}
-}
-
-@TechReport{gaia:soderhjelm,
-  author =      {S.~Soderhjelm},
-  title =       {Theoretical modelling of observational double-star distribution functions.},
-  institution = {},
-  year =        2004,
-  month =       {},
-  note =        {DMS-SS-05}
-}
-
-@Misc{gaia:jospriv,
-  note =        {J.~de~Bruijne, private communication, May 2004}
-}
-
-@Misc{gaia:joscarmepriv,
-  note =        {J.~de~Bruijne and C.~Jordi, private communcations, May 2004,
-see also \url{http://gaia.am.ub.es/\-PWG/\-common/\-instrumGAIA2.html}}
-}
-
-@Misc{gaia:elevreductcalc,
-  note =        {U.~Lammers, unpublished results - see also \url{http://www.rssd.esa.int/\-GAIA/\-PoW\_ground\_station\_visibility.html}}
-}
-
-@Misc{gaia:fmphaseangleopt,
-  note =        {F.~Mignard, Observatoire de la C\^{o}te D'Azur/CERGA,
-private communcations, May 2004}
-}
-
-@Misc{gaia:elevreductesoc,
-  note =        {M.~Hechler, ESOC, private communcations, April 2004}
-}
-
-@TechReport{gaia:crema,
-  author =      {M.~Hechler},
-  title =       {{G}AIA {C}onsolidated {R}eport on {M}ission {A}nalysis {(CReMA)}},
-  institution = {ESA, European Space Operations Cenre},
-  year =        2006,
-  month =       {March},
-  note =        {GAIA-ESC-RP-0001, Issue 2.0}
-}
-
-@TechReport{gaia:astriumreass,
-  author =      {Astrium SLTRS project team},
-  title =       {{G}aia {S}ystem {L}evel {T}echnical {R}eassessment {S}tudy},
-  institution = {EADS Astrium},
-  year =        2002,
-  month =       {June},
-  note =        {EF5/FR/PC/038.02}
-}
-
-@TechReport{gaia:srd,
-  author =      {G.~Colangelo},
-  title =       {{G}aia {S}ystem {R}equirements {D}ocument for {T}echnical {A}ssistance \& {D}efinition {P}hase},
-  institution = {ESA},
-  year =        2004,
-  month =       {March},
-  note =        {Gaia-SRC-001, Issue 1.0}
-}
-
-@Misc{gaia:pdbonline,
-  note =        {{G}aia {P}arameter {D}atabase at \url{http://www.rssd.esa.int/\-Gaia/\-paramdb}}
-}
-
-@Misc{gaia:acronyms,
-  note =        {{G}aia {A}cronyms {L}ist, http://www.rssd.esa.int/A\-general/Projects/GAIA/paramdb/glossary.txt}
-}
-
-
-@TechReport{ccsds:timecodeformats,
-  author =      {},
-  title =       {Time Code Formats, {B}lue {B}ook},
-  institution = {Consultative Committee for Space Data Systems},
-  year =        {2002},
-  month =       {January},
-  note =        {CCSDS 301.0-B-3, {\tt http://www.ccsds.org/documents/301x0b3.pdf}}
+@ARTICLE{bucc1,
+  author =       {{Bucciarelli}, B. and {Taff}, L.~G. and {Lattanzi},
+                  M.~G.},
+  title =        "{A generalization of the moving mean}",
+  year =         1993,
+  journal =      {J. Statist. Comput. Simul.},
+  volume =       48,
+  pages =        29
 }
 
 @TechReport{ccsds:packettelemetry,
-  author =      {},
-  title =       {Packet Telemetry, {B}lue {B}ook},
-  institution = {Consultative Committee for Space Data Systems},
-  year =        {2000},
-  month =       {November},
-  note =        {CCSDS 102.0-B-5, {\tt http://www.ccsds.org/documents/102x0b5.pdf}}
+  author =       {},
+  title =        {Packet Telemetry, {B}lue {B}ook},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         2000,
+  month =        {November},
+  note =         {CCSDS 102.0-B-5, {\tt
+                  http://www.ccsds.org/documents/102x0b5.pdf}}
 }
 
-@TechReport{ccsds:tmconcept,
-  author =      {},
-  title =       {Telemetry Summary of Concept and Rationale, {G}reen {Book}},
-  institution = {Consultative Committee for Space Data Systems},
-  year =        {1987},
-  month =       {December},
-  note =        {CCSDS 100.0-G-1, {\tt http://www.ccsds.org/documents/100x0g1.pdf}}
+@TechReport{ccsds:timecodeformats,
+  author =       {},
+  title =        {Time Code Formats, {B}lue {B}ook},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         2002,
+  month =        {January},
+  note =         {CCSDS 301.0-B-3, {\tt
+                  http://www.ccsds.org/documents/301x0b3.pdf}}
 }
 
 @TechReport{ccsds:tmchannelcoding,
-  author =      {},
-  title =       {Telemetry Channel Coding, {B}lue {Book}},
-  institution = {Consultative Committee for Space Data Systems},
-  year =        {2002},
-  month =       {October},
-  note =        {CCSDS 101.0-B-6, {\tt http://www.ccsds.org/documents/101x0b6.pdf}}
+  author =       {},
+  title =        {Telemetry Channel Coding, {B}lue {Book}},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         2002,
+  month =        {October},
+  note =         {CCSDS 101.0-B-6, {\tt
+                  http://www.ccsds.org/documents/101x0b6.pdf}}
 }
 
-@TechReport{omg:tmtcxml,
-  author =      {},
-  title =       {Telemetric and Command Data Specification},
-  institution = {Object Management Group --- Space Domain Task Force},
-  year =        {2003},
-  month =       {March},
-  note =        {space/2003-03-04, {\tt http://www.omg.org/docs/space/03-03-12.pdf}}
+@TechReport{ccsds:tmconcept,
+  author =       {},
+  title =        {Telemetry Summary of Concept and Rationale, {G}reen
+                  {Book}},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         1987,
+  month =        {December},
+  note =         {CCSDS 100.0-G-1, {\tt
+                  http://www.ccsds.org/documents/100x0g1.pdf}}
+}
+
+@TechReport{compressoracle10g,
+  author =       { Oracle },
+  title =        { Data Compression in 10g },
+  institution =  { Oracle Corporation },
+  year =         2005,
+  month =        {May},
+  note =
+                  {\url{http://www.oracle.com/technology/products/bi/db/10g/pdf/twp_data_compression_10gr2_0505.pdf}}
+}
+
+@TechReport{compressoracle11g,
+  author =       { Oracle },
+  title =        { Data Compression in 11g },
+  institution =  { Oracle Corporation },
+  year =         2007,
+  month =        {May},
+  note =
+                  {\url{http://download.oracle.com/docs/cd/B28359_01/server.111/b28318/schema.htm#CNCPT1132}}
+}
+
+@Inproceedings{conf:casjobs,
+  author =       { W.~O'Mullane and N.~Li and M.~Nieto-Santisteban and
+                  A.~Szalay and A.~Thakar and J.~Gray},
+  title =        { Batch is back: CasJobs, serving multi-TB data on
+                  the Web },
+  booktitle =    { International Conference on Web Services },
+  year =         { 2005 },
+  month =        { July },
+  note =         { Also MS technote
+                  \url{http://arxiv.org/pdf/cs.DC/0502072} },
+  adsurl =       {https://arxiv.org/abs/cs/0502072}
+}
+
+@Inproceedings{conf:monterosa,
+  author =       { S.~G.~Ansari and J.~Torra and X.~Luri and
+                  F.~Figueras and C.~Jordi and E.~Masana },
+  title =        { {Gaia} {Spectroscopy} },
+  booktitle =    { {Science} and {Technology}, {ASP} {Conference}
+                  {Series} },
+  volume =       { 298 },
+  year =         { 2003 },
+  month =        { September },
+  note =         { page 97 }
+}
+
+@proceedings{doi:10.1117/12.2233380,
+  author =       {Kantor, Jeffrey and Long, Kevin and Becla, Jacek and
+                  Economou, Frossie and Gelman, Margaret and Juric,
+                  Mario and Lambert, Ron and Krughoff, Simon and
+                  Swinbank, John D. and Wu, Xiuqin},
+  title =        { Agile software development in an earned value
+                  world: a survival guide },
+  journal =      {Proc. SPIE},
+  volume =       9911,
+  pages =        {99110N-99110N-18},
+  abstract =     { Agile methodologies are current best practice in
+                  software development. They are favored for, among
+                  other reasons, preventing premature optimization by
+                  taking a somewhat short-term focus, and allowing
+                  frequent replans/reprioritizations of upcoming
+                  development work based on recent results and current
+                  backlog. At the same time, funding agencies
+                  prescribe earned value management accounting for
+                  large projects which, these days, inevitably include
+                  substantial software components. Earned Value
+                  approaches emphasize a more comprehensive and
+                  typically longer-range plan, and tend to
+                  characterize frequent replans and reprioritizations
+                  as indicative of problems. Here we describe the
+                  planning, execution and reporting framework used by
+                  the LSST Data Management team, that navigates these
+                  opposite tensions.  },
+  year =         2016,
+  doi =          {10.1117/12.2233380},
+  URL =          { http://dx.doi.org/10.1117/12.2233380}
+}
+
+@proceedings{doi:10.1117/12.2233619,
+  author =       {Vagg, Daniel and O'Callaghan, Derek and Ó hÓgáin,
+                  Fionn and McBreen, Sheila and Hanlon, Lorraine and
+                  Lynn, David and O'Mullane, William},
+  title =        { GAVIP: a platform for Gaia data analysis },
+  journal =      {Proc. SPIE},
+  volume =       9913,
+  pages =        {99131V-99131V-19},
+  abstract =     { Gaia is a major European Space Agency (ESA)
+                  astrophysics mission designed to map and analyse 109
+                  stars, ultimately generating more than 1 PetaByte of
+                  data-products. As Gaia data becomes publicly
+                  available and reaches a wider audience, there is an
+                  increasing need to facilitate the further use of
+                  Gaia products without needing to download large
+                  datasets. The Gaia Added Value Interface Platform
+                  (GAVIP) is designed to address this challenge by
+                  providing an innovative platform within which
+                  scientists can submit and deploy code, packaged as
+                  "Added Value Interfaces" (AVIs), which will be
+                  executed close to the data. Deployed AVIs and
+                  associated outputs may also be made available to
+                  other GAVIP platform users, thus providing a
+                  mechanism for scientific experiment
+                  reproducibility. This paper describes the
+                  capabilities and features of GAVIP.  },
+  year =         2016,
+  doi =          {10.1117/12.2233619},
+  URL =          { http://dx.doi.org/10.1117/12.2233619}
+}
+
+@TechReport{esa:javastandard,
+  author =       {ESA Board for Software Standarisation and Control},
+  title =        {Java Coding Standards},
+  institution =  {ESA},
+  year =         2004,
+  note =
+                  {\url{http://www.rssd.esa.int/llink/livelink/Java\_coding\_standards.pdf?func=doc.Fetch\&nodeId=504569\&docTitle=Java+coding+standards\&vernum=1}}
+}
+
+@TechReport{esa:sogs,
+  author =       {D.~Texier},
+  title =        {Note on Science Operations Ground Segment
+                  Documentation},
+  institution =  {ESA},
+  year =         2005,
+  note =         { SOGS-TN-ESAC-DT-001 }
+}
+
+@TechReport{esoc:sgicdvol1,
+  author =       {R.~Furnell},
+  title =        {{G}aia {S}pace/{G}round {I}nterface {C}ontrol
+                  {D}ocument {V}olume 1: {RF} {I}nterface},
+  institution =  {ESA/ESOC},
+  year =         2005,
+  month =        {April},
+  note =         {GAIA-ESC-ICD-515}
+}
+
+@TechReport{esoc:sgicdvol2,
+  author =       {R.~Furnell},
+  title =        {{G}aia {S}pace/{G}round {I}nterface {C}ontrol
+                  {D}ocument {V}olume 2: {G}eneric {P}acket
+                  {S}tructure},
+  institution =  {ESA/ESOC},
+  year =         2005,
+  month =        {April},
+  note =         {GAIA-ESC-ICD-516}
+}
+
+@ARTICLE{eyer1998,
+  author =       {{Eyer}, L.},
+  title =        "{Les \'etoiles variables de la mission {HIPPARCOS}}",
+  journal =      {Ph.D.~Thesis},
+  year =         1998,
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1998PhDT.........8E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@TechReport{gaia:AstroFPAGenDesign,
+  author =       { Astrium GAIA FPA team },
+  title =        { {GAIA} {CCD} and {F}ocal {P}lan {T}echnology
+                  {D}emonstrators: {ASTRO} {FPA} {G}eneral {D}esign
+                  {Description} },
+  institution =  { EADS/Astrium },
+  year =         2003,
+  month =        {December},
+  note =         {GAIAFPA.NT.00120.T.ASTR}
+}
+
+@Misc{gaia:DATATAG,
+  title =        {DataTag, Research \& technological development for a
+                  Data TransAtlantic Grid,
+                  http://datatag.web.cern.ch/datatag/project.html},
+  text =         {DataTag, Research \& technological development for a
+                  Data TransAtlantic Grid,
+                  http://datatag.web.cern.ch/datatag/project.html},
+  url =          {http://datatag.web.cern.ch/datatag/project.html}
+}
+
+@Misc{gaia:GRIDFTP,
+  title =        {Universal Data Transfer for the Grid,
+                  http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf},
+  text =         {Universal Data Transfer for the Grid,
+                  http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf},
+  year =         2005,
+  month =        {September},
+  url =
+                  {http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf}
 }
 
 @TechReport{gaia:NOSTFITS,
   author =       {{NASA/Science Office of Standards and Technology}},
-  title =        {{Definition of the Flexible Image Transport System (FITS)}},
+  title =        {{Definition of the Flexible Image Transport System
+                  (FITS)}},
   institution =  {NASA/NOST},
   year =         1995,
   number =       {NOST 100-1.1},
@@ -570,419 +730,408 @@ private communcations, May 2004}
 }
 
 @Article{gaia:UDTICD,
-  author = {R.~Grossman and Y.~Gu and X.~Hong and A.~Antony and J.~Blom and F.~Dijkstra and C.~de~Laat},
-  title = {Teraflows over Gigabit WANs with UDT},
-  text = {R.L. Grossman, Y. Gu, X. Hong, A. Antony, J. Blom, F. Dijkstra and C. de
-    Laat, Teraflows over Gigabit WANs with UDT, Future Generation Computer Systems,
-    December 2004.},
-  year = {2004},
-  url = {citeseer.ist.psu.edu/729500.html}
+  author =       {R.~Grossman and Y.~Gu and X.~Hong and A.~Antony and
+                  J.~Blom and F.~Dijkstra and C.~de~Laat},
+  title =        {Teraflows over Gigabit WANs with UDT},
+  text =         {R.L. Grossman, Y. Gu, X. Hong, A. Antony, J. Blom,
+                  F. Dijkstra and C. de Laat, Teraflows over Gigabit
+                  WANs with UDT, Future Generation Computer Systems,
+                  December 2004.},
+  year =         2004,
+  url =          {citeseer.ist.psu.edu/729500.html}
 }
 
-@Misc{gaia:DATATAG,
-  author = {},
-  title = {DataTag, Research \& technological development for a Data TransAtlantic Grid, http://datatag.web.cern.ch/datatag/project.html},
-  text = {DataTag, Research \& technological development for a Data TransAtlantic Grid, http://datatag.web.cern.ch/datatag/project.html},
-  url = {http://datatag.web.cern.ch/datatag/project.html}
+@Misc{gaia:acronyms,
+  note =         {{G}aia {A}cronyms {L}ist,
+                  http://www.rssd.esa.int/A\-general/Projects/GAIA/paramdb/glossary.txt}
 }
 
-@Misc{gaia:GRIDFTP,
-  author = {},
-  title = {Universal Data Transfer for the Grid, http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf},
-  text = {Universal Data Transfer for the Grid, http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf},
-  year = {2005},
-  month = {September},
-  url = {http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf}
+@TechReport{gaia:astriumdefstudy,
+  author =       { EADS Astrium Gaia team },
+  title =        { {GAIA} {D}efinition {S}tudy },
+  institution =  { EADS/Astrium },
+  year =         2005,
+  month =        {June},
+  note =         {Final Presentation, Noordwijk, June 8, 2005}
 }
 
-@TechReport{gdaas:gnucodingstd,
-  author =      {R.~Stallman},
-  title =       {{GNU} {C}oding {Standards}},
-  institution = {GNU},
-  year =        2001,
-  month =       {March},
-  note =        {}
-}
-
-@TechReport{gdaas:javacodingstd,
-  author =      {P.~P.~L\'opez and X.~Luri and I.~Serraller},
-  title =       {{J}ava {C}ode {C}onventions},
-  institution = {GMV/UB},
-  year =        2003,
-  month =       {March},
-  note =        {GMV-GDAAS2-SCG-004}
-}
-
-@TechReport{gdaas:prototypepaper,
-  author =      {W.~O'Mullane and L.~Lindegren},
-  title =       {{A}n {O}bject-{O}riented {F}ramework for {GAIA} {D}ata
-{P}rocessing},
-  institution = {ESA},
-  year =        1999,
-  month =       {},
-  note =        {}
-}
-
-@TechReport{gdaas:algoprep,
-  author =      {C.~Fabricius and J.~Torra},
-  title =       {{GDAAS} {A}lgorithm {P}reparation {G}uidelines},
-  institution = {GDAAS Configuration Conrol Board},
-  note =        {CCB-GDAAS-002}
-}
-
-@TechReport{gdaas:algoicd,
-  author =      {S.~Ansari and J.~Torra and P.~P.~L\'opez and X.~Luri
-and I.~Serraller and Y.~Balague},
-  title =       {{A}lgorithm {I}nterface {C}ontrol {D}ocument},
-  institution = {Confiuration Control Board},
-  note =        {CCB-GDAAS-ICD-001}
-}
-
-@TechReport{gdaas:giscalib,
-  author =      {H.~Lenhardt},
-  title =       {{GIS} implementation in {GDAAS2}: {D}etailed {G}eometrical
-{C}alibration},
-  institution = {ARI},
-  year =        2003,
-  month =       {November},
-  note =        {GAIA-ARI-HL-001}
-}
-
-@TechReport{planck:dbtestreport,
-  author =      {C.~Vuerli and W.~O'Mullane},
-  title =       {{DBMS-COTS} test week report},
-  institution = {ESA},
-  year =        2000,
-  month =       {February},
-  note =        {PL-COM-OAT-TN-009}
-}
-
-@TechReport{gaia:practscanlaw,
-  author =      {F.~Mignard},
-  title =       {A practical scanning law for {GAIA} simulations},
-  institution = {CERGA},
-  year =        2001,
-  month =       {December},
-  note =        {GAIA-FM-010}
-}
-
-
-
-@TechReport{esoc:sgicdvol1,
-  author =      {R.~Furnell},
-  title =       {{G}aia {S}pace/{G}round {I}nterface {C}ontrol {D}ocument
-{V}olume 1: {RF} {I}nterface},
-  institution = {ESA/ESOC},
-  year =        2005,
-  month =       {April},
-  note =        {GAIA-ESC-ICD-515}
-}
-
-@TechReport{esoc:sgicdvol2,
-  author =      {R.~Furnell},
-  title =       {{G}aia {S}pace/{G}round {I}nterface {C}ontrol {D}ocument
-{V}olume 2: {G}eneric {P}acket {S}tructure},
-  institution = {ESA/ESOC},
-  year =        2005,
-  month =       {April},
-  note =        {GAIA-ESC-ICD-516}
-}
-
-@TechReport{gaia:llorbit,
-  author =      {F.~Mignard},
-  title =       {{C}onsiderations on the orbit of {G}aia for simulations},
-  institution = {Observatoire de la C\^{o}te D'Azur/CERGA},
-  year =        2002,
-  month =       {March},
-  note =        {GAIA-FM-011}
-}
-
-@Inproceedings{conf:monterosa,
-    author =    { S.~G.~Ansari and J.~Torra and X.~Luri and F.~Figueras and
-C.~Jordi and E.~Masana },
-    title =     { {Gaia} {Spectroscopy} },
-    booktitle = { {Science} and {Technology}, {ASP} {Conference} {Series} },
-    volume =    { 298 },
-    year =      { 2003 },
-    month =     { September },
-    note =      { page 97 }
-}
-
-@Inproceedings{conf:casjobs,
-    author =    {  W.~O'Mullane and  N.~Li and  M.~Nieto-Santisteban and  A.~Szalay and  A.~Thakar and J.~Gray},
-    title =     { Batch is back: CasJobs, serving multi-TB data on the Web },
-    booktitle = { International Conference on Web Services },
-    year =      { 2005 },
-    month =     { July },
-    note =      { Also MS technote \url{http://arxiv.org/pdf/cs.DC/0502072} },
-    adsurl=    {https://arxiv.org/abs/cs/0502072}
-}
-
-@techReport{it:agile,
-  author =      {C.~Larman and V.~R.~Basili},
-  title =       {{I}terative and {I}ncremental {D}evelopment: {A} {B}rief {H}istory},
-  journal =     {IEEE Computer},
-    month =     { June },
-  year =        2003,
-    note =      { \url{http://www2.umassd.edu/SWPI/xp/articles/r6047.pdf} }
-}
-
-@TechReport{herschel:codingstandards,
-  author =      {J.~Brumfit},
-  title =       {{J}ava {C}oding {S}tandard and {G}uidelines for the
-{H}erschel {C}ommon {S}cience {S}ystem},
-  institution = {ESTEC},
-  year =        2002,
-  month =       {October},
-  note =        {HSCDT/TN009}
-}
-
-@TechReport{sun:style,
-  author =      {Sun Microsystems},
-  title =       {Java Look and Feel Design Guidelines},
-  institution = {Sun},
-  year =        1999,
-  month =       {October},
-  note =        {http://java.sun.com/products/jlf/dg/index.htm}
-}
-
-
-
-@TechReport{sun:codingstandards,
-  author =      {Sun Microsystems},
-  title =       {Code Conventions  for the Java Programming Language },
-  institution = {Sun},
-  publisher =   {Addison Wesley},
-  year =        1999,
-  month =       {December},
-  note =        {http://java.sun.com/docs/codeconv}
-}
-
-@TechReport{sun:doccomments,
-  author =      {Sun Microsystems},
-  title =       {How to write Doc Comments for JavaDoc},
-  institution = {Sun},
-  year =        2000,
-  note =        {http://java.sun.com/products/jdk/javadoc/writingdoccomments/index.html}
-}
-
-@TechReport{esa:javastandard,
-  author =              {ESA Board for Software Standarisation and Control},
-  title =               {Java Coding Standards},
-  institution = {ESA},
-  year =                2004,
-  note =        {\url{http://www.rssd.esa.int/llink/livelink/Java\_coding\_standards.pdf?func=doc.Fetch\&nodeId=504569\&docTitle=Java+coding+standards\&vernum=1}}
-}
-
-@TechReport{it:javapopular,
-  author =              {TIOBE Software },
-  title =               {TIOBE Programming Community Index },
-  year =                2005,
-  note =        {{http://www.tiobe.com/index.htm?tiobe\_index} \normalsize}
-}
-
-@TechReport{gaia:toolbox,
-  author =              {F.~De~Angeli},
-  title =               {The {G}aia {S}oftware {T}oolbox - {U}ser guide},
-  institution = {IoA},
-  year =                2005,
-  note =                {\url{http://www.rssd.esa.int/SA-general/Projects/GAIA/wiki/index.php?title=CU1:\_GaiaTools}}
-}
-
-@InProceedings{gaia:gaiagrid,
-  author =              {S.~G.~Ansari  and U.~Lammers  and  M.~ter~Linden },
-  title =               {GaiaGrid : Its Implications and Implementation},
-  year =                2005,
-  booktitle = {Proc. Astronomical Data Analysis Software and Systems XIV},
-  volume  = {347},
-  pages   = {429--},
-  publisher = {Astronomical Society of the Pacific }
-}
-
-@InProceedings{terLinden05,
-  author =              {M.~ter~Linden and H.~de~Wolf and R.~Grim },
-  title =               { GridAssist, a User Friendly
-Grid-based Workflow Management Tool},
-  year =                2005,
-  booktitle = {2005 International Conference on Parallel Processing Workshops (ICPPW'05)},
-  volume  = {icppw},
-  pages   = {5-10},
-  publisher = {IEEE Computer Society}
-}
-
-
-
-@InProceedings{munari2000,
-  author =              {U.~Munari },
-  title =               { The diffuse interstellar band at 8620 Å: A good reddening tracer for GAIA},
-  year =                2000,
-  booktitle = {Molecules in Space and in the Laboratory, Proceedings of a workshop held 2-5 June 1999 in Carloforte, Cagliari.},
-  volume  = {67},
-  pages   = {179--},
-  publisher = {I. Porceddu, and S. Aiello. Bologna, Italy: Italian Physical Society, Conference Proceedings}
-}
-
-
-
-
-
-@InProceedings{hipparcos:history,
-  author =              {E.~H{\o}g and P.~L.~Bernacca and L.~Emiliani},
-  title =               {Early Phases of the Hipparcos Project},
-  year =                {1997},
-  booktitle =           {Proc.\ of Hipparcos Venice 97},
-  editor =              {M.A.C.~Perryman and P.L.~Bernacca},
-  pages  =              {xxvii--xxxv}
-}
-
-
-@TechReport{hipparcos:threestep,
-  author =              {L.~Lindegren},
-  title =               {A three-step procedure for deriving positions, proper motions, and parallaxes of stars observed by scanning great circles },
-  institution = {Lund Observatory},
-  year =                1976,
-  month =               {October},
-  note =                {Lund Observatory Technical note}
-}
-
-
-@TechReport{roemer:submit,
-  author =              {U.~Bastian and  G.~Gilmore and  J.L.~Halbwachs and  E.~H{\o}g and  J.~Knude and  J.~Kovalevsky and  A.~Labeyrie and  F.~van~Leeuwen and  L.~Lindegren and  J.~W.~Pel and  H.~Schrijver and  R.~Stabell and P.~Thejll},
-  title =               {ROEMER},
-  institution = {Lund Observatory},
-  year =                1993,
-  month =               {July},
-  note =                {Proposal for a Third Medium Size ESA Mission (M3), Lund 1993}
-}
-
-@TechReport{roemer:proposal,
-  author =              {E.~H{\o}g},
-  title =               {A new era of global astrometry and photometry from space and ground},
-  institution = {CUO},
-  year =                1994,
-  month =               {February},
-  note =                {Contribution at the G. Colombo Memorial Conference : Ideas for Space Research after the Year 2000.}
-}
-
-@TechReport{gaia:horizon2000,
-  author =              {L.~Lindegren and  M.~A.~C.~Perryman and  U.~Bastian and  J.~C.~Dainty and  E.~H{\o}g and  F.~van~Leeuwen and  J.~Kovalevsky and  A.~Labeyrie and  F.~Mignard and  J.~E.~Noordam and  R.~S.~Le~Poole and  P.~Thejll and F.~Vakili},
-  title =               {GAIA: Global Astrometric Interferometer for Astrophysics},
-  institution = {Lund Observatory},
-  year =                1993,
-  month =               {October},
-  note =                {Response to Call for Mission Concepts for Horizon 2000 Follow UP: Proposal for an astrometric interferometer as an ESA Cornerstone Mission}
-}
-
-@TechReport{gaia:spieconf,
-  author =              {L.~Lindegren and  M.~A.~C.~Perryman and  U.~Bastian and  J.~C.~Dainty and  E.~H{\o}g and  F.~van~Leeuwen and  J.~Kovalevsky and  A.~Labeyrie and  S.\~Loiseau and  F.~Mignard and  J.~E.~Noordam and  R.~S.~Le~Poole and  P.~Thejll and F.~Vakili},
-  title =               {GAIA: Global Astrometric Interferometer for Astrophysics},
-  institution = {Lund Observatory},
-  year =                1994,
-  month =               {March},
-  note =                {Proc. of Astronomical Telescopes and Instrumentation for the 21st Century. Technical Conference 2200, SPIE Symposium in Kona, 13--18 March 1994}
-}
-
-@TechReport{gaia:surveycom,
-  author =              {L.~Lindegren and M.~A.~C.~Perryman},
-  title =               {GAIA: Global Astrometric Interferometer for Astrophysics},
-  institution = {Lund Observatory},
-  year =                1994,
-  month =               {September},
-  note =                {Supplementary Information Submitted to the Horizon2000+ Survey Committee}
-}
-
-@TechReport{gaia:interfero,
-  author =              {L.~Lindegren and M.~A.~C.~Perryman},
-  title =               {A Small Interferometer in Space for Global Astrometry: the Gaia Concept},
-  institution = {Lund Observatory},
-  year =                1994,
-  month =               {August},
-  note =                {IAU Symp. No 166, Astronomical and Astrophysical Objectives of sub-milliarcsecon Optical Astronomy, The Hague, 15--19 August 1994}
-}
-
-% Obsolete use gaia_livelink_valied and \citell{LL:ESA-SCI(2000)4)
-@TechReport{gaia:studyreport,
-  author =      {ESA},
-  title =       {{GAIA --- {C}omposition, {F}ormation and {E}volution of the {G}alaxy}},
-  year =        2000,
-  month =       {July},
-  note =        {Concept and Technology Study Report, ESA-SCI(2000)4}
+@TechReport{gaia:astriumreass,
+  author =       {Astrium SLTRS project team},
+  title =        {{G}aia {S}ystem {L}evel {T}echnical {R}eassessment
+                  {S}tudy},
+  institution =  {EADS Astrium},
+  year =         2002,
+  month =        {June},
+  note =         {EF5/FR/PC/038.02}
 }
 
 @TechReport{gaia:bprpoptimization,
-  author = {C.~Jordi and E.~H{\o}g and A.~G.~A.~Brown and J.~de~Bruijne},
-  title={Gaia spectrophometers: optimization study},
-  year = 2006,
-  month = {April},
-  institution = {},
-  note = {GAIA-CH-TN-UB-CJ-037}
+  author =       {C.~Jordi and E.~H{\o}g and A.~G.~A.~Brown and
+                  J.~de~Bruijne},
+  title =        {Gaia spectrophometers: optimization study},
+  year =         2006,
+  month =        {April},
+  institution =  {},
+  note =         {GAIA-CH-TN-UB-CJ-037}
 }
 
-@article{paper:vodm,
-  author = {J.~McDowell },
-  title = {Data models for the VO},
-  year = 2004,
-  journal =             {Toward an International Virtual Observatory: Proceedings of the ESO/ESA/NASA/NSF Conference Held at Garching, Germany, 10-14 June 2002, ESO ASTROPHYSICS SYMPOSIA. ISBN 3-540-21001-6},
+@TechReport{gaia:crema,
+  author =       {M.~Hechler},
+  title =        {{G}AIA {C}onsolidated {R}eport on {M}ission
+                  {A}nalysis {(CReMA)}},
+  institution =  {ESA, European Space Operations Cenre},
+  year =         2006,
+  month =        {March},
+  note =         {GAIA-ESC-RP-0001, Issue 2.0}
 }
 
-@article{paper:skyservermining,
-  author = {J.~Gray and  A.~S.~Szalay and  A.~Thakar and  P.~Kunszt and  C.~Stoughton and  D.~Slutz and J.~Vandenberg},
-  title = {Data {M}ining in the {SDSS} {S}ky{S}erver {D}atabase},
-  year = 2003,
-  journal =             {Distributed Data and Structures 4: Records of the 4th International Meeting, W. Litwin, G.Levy (eds), Paris France March 2002},
+@TechReport{gaia:e2vccddesignreport,
+  author =       { D.~Burt },
+  title =        { Gaia {T}echnology {D}emonstrator: {AF} {CCD}
+                  {DESIGN} {REPORT} },
+  institution =  { e2v },
+  year =         2003,
+  month =        {January},
+  note =         {GAIA-E2V-RP-020}
+}
+
+@Misc{gaia:elevreductcalc,
+  note =         {U.~Lammers, unpublished results - see also
+                  \url{http://www.rssd.esa.int/\-GAIA/\-PoW\_ground\_station\_visibility.html}}
+}
+
+@Misc{gaia:elevreductesoc,
+  note =         {M.~Hechler, ESOC, private communcations, April 2004}
+}
+
+@Misc{gaia:fmphaseangleopt,
+  note =         {F.~Mignard, Observatoire de la C\^{o}te
+                  D'Azur/CERGA, private communcations, May 2004}
+}
+
+@InProceedings{gaia:gaiagrid,
+  author =       {S.~G.~Ansari and U.~Lammers and M.~ter~Linden },
+  title =        {GaiaGrid : Its Implications and Implementation},
+  year =         2005,
+  booktitle =    {Proc. Astronomical Data Analysis Software and
+                  Systems XIV},
+  volume =       347,
+  pages =        {429--},
+  publisher =    {Astronomical Society of the Pacific }
+}
+
+@TechReport{gaia:horizon2000,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman and U.~Bastian
+                  and J.~C.~Dainty and E.~H{\o}g and F.~van~Leeuwen
+                  and J.~Kovalevsky and A.~Labeyrie and F.~Mignard and
+                  J.~E.~Noordam and R.~S.~Le~Poole and P.~Thejll and
+                  F.~Vakili},
+  title =        {GAIA: Global Astrometric Interferometer for
+                  Astrophysics},
+  institution =  {Lund Observatory},
+  year =         1993,
+  month =        {October},
+  note =         {Response to Call for Mission Concepts for Horizon
+                  2000 Follow UP: Proposal for an astrometric
+                  interferometer as an ESA Cornerstone Mission}
+}
+
+@TechReport{gaia:interfero,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman},
+  title =        {A Small Interferometer in Space for Global
+                  Astrometry: the Gaia Concept},
+  institution =  {Lund Observatory},
+  year =         1994,
+  month =        {August},
+  note =         {IAU Symp. No 166, Astronomical and Astrophysical
+                  Objectives of sub-milliarcsecon Optical Astronomy,
+                  The Hague, 15--19 August 1994}
+}
+
+@Misc{gaia:joscarmepriv,
+  note =         {J.~de~Bruijne and C.~Jordi, private communcations,
+                  May 2004, see also
+                  \url{http://gaia.am.ub.es/\-PWG/\-common/\-instrumGAIA2.html}}
+}
+
+@Misc{gaia:jospriv,
+  note =         {J.~de~Bruijne, private communication, May 2004}
+}
+
+@Misc{gaia:lattanzipriv,
+  note =         {M.~Lattanzi and R.~Drimmel, private communcations,
+                  October 2003}
+}
+
+@TechReport{gaia:llorbit,
+  author =       {F.~Mignard},
+  title =        {{C}onsiderations on the orbit of {G}aia for
+                  simulations},
+  institution =  {Observatoire de la C\^{o}te D'Azur/CERGA},
+  year =         2002,
+  month =        {March},
+  note =         {GAIA-FM-011}
+}
+
+@TechReport{gaia:mird,
+  author =       { {GAIA} Project Team },
+  title =        { {Gaia} {M}ission {I}mplementation {R}equirement
+                  {D}ocument },
+  year =         2006,
+  month =        {May},
+  note =         {{G}AIA-EST-RQ-00457}
+}
+
+@Misc{gaia:nu0opt,
+  note =         {U.~Lammers, unpublished results}
+}
+
+@Misc{gaia:pdbonline,
+  note =         {{G}aia {P}arameter {D}atabase at
+                  \url{http://www.rssd.esa.int/\-Gaia/\-paramdb}}
+}
+
+@TechReport{gaia:practscanlaw,
+  author =       {F.~Mignard},
+  title =        {A practical scanning law for {GAIA} simulations},
+  institution =  {CERGA},
+  year =         2001,
+  month =        {December},
+  note =         {GAIA-FM-010}
+}
+
+@TechReport{gaia:soderhjelm,
+  author =       {S.~Soderhjelm},
+  title =        {Theoretical modelling of observational double-star
+                  distribution functions.},
+  institution =  {},
+  year =         2004,
+  note =         {DMS-SS-05}
+}
+
+@TechReport{gaia:spieconf,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman and U.~Bastian
+                  and J.~C.~Dainty and E.~H{\o}g and F.~van~Leeuwen
+                  and J.~Kovalevsky and A.~Labeyrie and S.\~Loiseau
+                  and F.~Mignard and J.~E.~Noordam and R.~S.~Le~Poole
+                  and P.~Thejll and F.~Vakili},
+  title =        {GAIA: Global Astrometric Interferometer for
+                  Astrophysics},
+  institution =  {Lund Observatory},
+  year =         1994,
+  month =        {March},
+  note =         {Proc. of Astronomical Telescopes and Instrumentation
+                  for the 21st Century. Technical Conference 2200,
+                  SPIE Symposium in Kona, 13--18 March 1994}
+}
+
+@TechReport{gaia:srd,
+  author =       {G.~Colangelo},
+  title =        {{G}aia {S}ystem {R}equirements {D}ocument for
+                  {T}echnical {A}ssistance \& {D}efinition {P}hase},
+  institution =  {ESA},
+  year =         2004,
+  month =        {March},
+  note =         {Gaia-SRC-001, Issue 1.0}
+}
+
+@Misc{gaia:ssmobjattribs,
+  note =         {F.~Arenou and F.~Ch\'ereau, private communications}
+}
+
+@TechReport{gaia:studyreport,
+  author =       {ESA},
+  title =        {{GAIA --- {C}omposition, {F}ormation and {E}volution
+                  of the {G}alaxy}},
+  year =         2000,
+  month =        {July},
+  note =         {Concept and Technology Study Report, ESA-SCI(2000)4}
+}
+
+@TechReport{gaia:surveycom,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman},
+  title =        {GAIA: Global Astrometric Interferometer for
+                  Astrophysics},
+  institution =  {Lund Observatory},
+  year =         1994,
+  month =        {September},
+  note =         {Supplementary Information Submitted to the
+                  Horizon2000+ Survey Committee}
+}
+
+@TechReport{gaia:toolbox,
+  author =       {F.~De~Angeli},
+  title =        {The {G}aia {S}oftware {T}oolbox - {U}ser guide},
+  institution =  {IoA},
+  year =         2005,
+  note =
+                  {\url{http://www.rssd.esa.int/SA-general/Projects/GAIA/wiki/index.php?title=CU1:\_GaiaTools}}
+}
+
+@TechReport{gaia:ttcanal,
+  author =       { M.~Martinez Fernandez },
+  title =        { {G}aia {TT\&C} {S}ubsystem {A}nalysis },
+  year =         2005,
+  month =        {January},
+  note =         { Note prepared at request of Project team}
+}
+
+@TechReport{gdaas:algoicd,
+  author =       {S.~Ansari and J.~Torra and P.~P.~L\'opez and X.~Luri
+                  and I.~Serraller and Y.~Balague},
+  title =        {{A}lgorithm {I}nterface {C}ontrol {D}ocument},
+  institution =  {Confiuration Control Board},
+  note =         {CCB-GDAAS-ICD-001}
+}
+
+@TechReport{gdaas:algoprep,
+  author =       {C.~Fabricius and J.~Torra},
+  title =        {{GDAAS} {A}lgorithm {P}reparation {G}uidelines},
+  institution =  {GDAAS Configuration Conrol Board},
+  note =         {CCB-GDAAS-002}
+}
+
+@TechReport{gdaas:giscalib,
+  author =       {H.~Lenhardt},
+  title =        {{GIS} implementation in {GDAAS2}: {D}etailed
+                  {G}eometrical {C}alibration},
+  institution =  {ARI},
+  year =         2003,
+  month =        {November},
+  note =         {GAIA-ARI-HL-001}
+}
+
+@TechReport{gdaas:gnucodingstd,
+  author =       {R.~Stallman},
+  title =        {{GNU} {C}oding {Standards}},
+  institution =  {GNU},
+  year =         2001,
+  month =        {March}
+}
+
+% Obsolete use gaia_livelink_valied and \citell{LL:ESA-SCI(2000)4)
+
+@TechReport{gdaas:javacodingstd,
+  author =       {P.~P.~L\'opez and X.~Luri and I.~Serraller},
+  title =        {{J}ava {C}ode {C}onventions},
+  institution =  {GMV/UB},
+  year =         2003,
+  month =        {March},
+  note =         {GMV-GDAAS2-SCG-004}
+}
+
+@TechReport{gdaas:prototypepaper,
+  author =       {W.~O'Mullane and L.~Lindegren},
+  title =        {{A}n {O}bject-{O}riented {F}ramework for {GAIA}
+                  {D}ata {P}rocessing},
+  institution =  {ESA},
+  year =         1999
+}
+
+@ARTICLE{gor05,
+  author =       {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday},
+                  A.~J. and {Wandelt}, B.~D. and {Hansen}, F.~K. and
+                  {Reinecke}, M. and {Bartelmann}, M.},
+  title =        {HEALPix: A Framework for High-Resolution
+                  Discretization and Fast A nalysis of Data
+                  Distributed on the Sphere},
+  journal =      {\apj},
+  eprint =       {astro-ph/0409513},
+  year =         2005,
+  month =        apr,
+  volume =       622,
+  pages =        {759-771},
+  doi =          {10.1086/427976},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005ApJ...
+                  622..759G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@TechReport{greenplum:adminguide41,
+  title =        { Greenplum Database 4.1 Administrator Guide },
+  institution =  { EMC Corporation },
+  year =         2011,
+  note =
+                  {\url{http://www.greenplum.com/community/downloads/documentation/}}
 }
 
 %----------------------------------------------------------------------------
 %  CU6
 %----------------------------------------------------------------------------
 
-@TechReport{DOC:HEH-001,
-  author = {H.~Huckle},
-  year   = 2007,
-  title  = {Continuum {N}ormalisation},
-  note = {GAIA-C6-SP-MSSL-HEH-001-D}
+@TechReport{greenplum:installguide41,
+  title =        { Greenplum Database 4.1 Installation Guide },
+  institution =  { EMC Corporation },
+  year =         2011,
+  note =
+                  {\url{http://www.greenplum.com/community/downloads/documentation/}}
 }
 
-@article{zucker:2004,
-  author =  { S.~Zucher and T.~Mazech and N.C.~Santos and S.~Udry and M.~Mayor},
-  title =   { {A\&A} },
-  year =    2004,
-  note =    {420 806}
+@InProceedings{hamilton1843,
+  author =       {W.~R.~Hamilton },
+  title =        {On a new Species of Imaginary Quantities connected
+                  with a theory of Quaternions},
+  year =         1843,
+  booktitle =    {Proceedings of the Royal Irish Academy },
+  volume =       2,
+  pages =        {424-434},
+  Note =
+                  {\url{http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/Quatern1/Quatern1.html}}
 }
 
-@article{zucker:1994,
-  author =  { S.~Zucher and T.~Mazech },
-  title =   { ApJ },
-  year =    1994,
-  note =    {420 806}
+@InProceedings{hamilton1844,
+  author =       {W.~R.~Hamilton },
+  title =        {On Quaternions},
+  year =         1847,
+  booktitle =    {Proceedings of the Royal Irish Academy },
+  volume =       3,
+  pages =        {1-16},
+  Note =
+                  {\url{http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/Quatern2/Quatern2.html}}
 }
 
-@misc{WS2CU6:intro,
- author = {D.~Katz},
- title = { {G}aia - {RVS}: {DPAC} and {CU6}},
- note= {\raggedright {CU6 W}orkshop2,
- {http://wwwhip.obspm.fr/gaia/cu6/workshop\_2/CU6\_w2\_Katz\_intro.pdf}}
+@InProceedings{hamilton:onquat,
+  author =       {William Rowan Hamilton },
+  title =        {ON QUATERNIONS, OR ON A NEW SYSTEM OF IMAGINARIES IN
+                  ALGEBRA },
+  year =         1844,
+  booktitle =    {Proceedings of the Royal Irish Academy },
+  volume =       3,
+  pages =        {1-16},
+  Note =
+                  {\url{http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/OnQuat/OnQuat.pdf}}
 }
 
-@misc{WS2CU6:extraction,
- author = {M.~Cropper and S.R.~Rosen},
- title = { Spectra Extraction},
- note= {\raggedright {CU6 W}orkshop2,
- {http://wwwhip.obspm.fr/gaia/cu6/workshop\_2/\CU6\_w2\_Cropper\_extraction.pdf}}
+@TechReport{herschel:codingstandards,
+  author =       {J.~Brumfit},
+  title =        {{J}ava {C}oding {S}tandard and {G}uidelines for the
+                  {H}erschel {C}ommon {S}cience {S}ystem},
+  institution =  {ESTEC},
+  year =         2002,
+  month =        {October},
+  note =         {HSCDT/TN009}
 }
 
-@TechReport{CU6:AG-003,
-  author =      {A.~Guerrier},
-  title =       {{S}oftware {D}esign {D}ocument for
-                 {W}avelength {C}alibration},
-  note =        {GAIA-C6-TN-OPM-AG-003-1}
+@InProceedings{hipparcos:history,
+  author =       {E.~H{\o}g and P.~L.~Bernacca and L.~Emiliani},
+  title =        {Early Phases of the Hipparcos Project},
+  year =         1997,
+  booktitle =    {Proc.\ of Hipparcos Venice 97},
+  editor =       {M.A.C.~Perryman and P.L.~Bernacca},
+  pages =        {xxvii--xxxv}
 }
 
-@TechReport{CU6:AG-004,
-  author =      {A.~Guerrier},
-  title =       {{S}oftware {D}esign {D}ocument for
-                 {A}pply {C}alibration},
-  note =        {GAIA-C6-SP-OPM-AG-004-1}
+@TechReport{hipparcos:threestep,
+  author =       {L.~Lindegren},
+  title =        {A three-step procedure for deriving positions,
+                  proper motions, and parallaxes of stars observed by
+                  scanning great circles },
+  institution =  {Lund Observatory},
+  year =         1976,
+  month =        {October},
+  note =         {Lund Observatory Technical note}
 }
 
 
@@ -991,273 +1140,302 @@ Grid-based Workflow Management Tool},
 %  WWW
 %----------------------------------------------------------------------------
 
-@misc{www:top500,
-  note = { {TOP500} {S}upercomputer {S}ites, {\tt http://www.top500.org} }
+@TechReport{intersystems:chartingthegalaxy,
+  author =       { O'Mullane W., Nagjee V. },
+  title =        { Charting the Galaxy with the Gaia Satellite and
+                  InterSystems Cach\'{e} },
+  institution =  { InterSystems and DPAC },
+  year =         2010,
+  note =
+                  {\url{http://www.intersystems.com/cache/whitepapers/charting_the_galaxy.html}}
 }
 
-@misc{www:linpack,
-  note = { Linpack standard numerical benchmark, {\tt http://www.top500.org/lists/linpack.php} }
+@techReport{it:agile,
+  author =       {C.~Larman and V.~R.~Basili},
+  title =        {{I}terative and {I}ncremental {D}evelopment: {A}
+                  {B}rief {H}istory},
+  journal =      {IEEE Computer},
+  month =        { June },
+  year =         2003,
+  note =         {
+                  \url{http://www2.umassd.edu/SWPI/xp/articles/r6047.pdf}
+                  }
 }
 
 %-----
 % CU7 referenced entries start
 %-----
 
-@ARTICLE{eyer1998,
-   author = {{Eyer}, L.},
-    title = "{Les \'etoiles variables de la mission {HIPPARCOS}}",
-  journal = {Ph.D.~Thesis},
-     year = 1998,
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1998PhDT.........8E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@TechReport{it:javapopular,
+  author =       {TIOBE Software },
+  title =        {TIOBE Programming Community Index },
+  year =         2005,
+  note =         {{http://www.tiobe.com/index.htm?tiobe\_index}
+                  \normalsize}
 }
 
-
-
-@Article{mpclass:bus2002a,
-   author = {S.~J.~Bus and R.~P.~Binzel},
-   title = {Phase II of the Small Main-Belt Asteroid Spectroscopic Survey: The Observations},
-   journal = {Icarus},
-   volume = {158},
-   pages = {106--145},
-   year = {2002}
- }
-
-@Article{mpclass:warell,
-   author = {J.~Warell and C.-I.~Lagerkvist},
-   title = {Asteroid taxonomy in the Gaia photometric system},
-   journal = {\aap},
-   volume = {submitted},
-   year = {2006}
- }
+@INPROCEEDINGS{moore65,
+  author =       {{M}oore, Gordon E.},
+  title =        {Cramming more components onto integrated circuits},
+  journal =      {Electronics},
+  year =         1965,
+  month =        apr,
+  volume =       38
+}
 
 @ARTICLE{mpclass:Tholen,
-   author = {D.~J.~Tholen},
-    title = {Asteroid taxonomy from cluster analysis of photometry},
-  journal = {Ph.D.~Thesis},
-     year = {1984}
+  author =       {D.~J.~Tholen},
+  title =        {Asteroid taxonomy from cluster analysis of
+                  photometry},
+  journal =      {Ph.D.~Thesis},
+  year =         1984
 }
 
-@INPROCEEDINGS{omu01,
-   author = {{O'Mullane}, W. and {Banday}, A.~J. and {G{\'o}rski}, K.~M. and
-        {Kunszt}, P. and {Szalay}, A.~S.},
-    title = {{S}plitting the {S}ky - {HTM} and {HEALP}ix},
-booktitle = {Mining the Sky},
-     year = 2001,
-   editor = {{Banday}, A.~J. and {Zaroubi}, S. and {Bartelmann}, M.},
-    pages = {638-+},
-      doi = {10.1007/10849171_84},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001misk.c
-onf..638O&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@Article{mpclass:bus2002a,
+  author =       {S.~J.~Bus and R.~P.~Binzel},
+  title =        {Phase II of the Small Main-Belt Asteroid
+                  Spectroscopic Survey: The Observations},
+  journal =      {Icarus},
+  volume =       158,
+  pages =        {106--145},
+  year =         2002
 }
 
-@ARTICLE{gor05,
-   author = {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday}, A.~J. and
-        {Wandelt}, B.~D. and {Hansen}, F.~K. and {Reinecke}, M. and
-        {Bartelmann}, M.},
-    title = {HEALPix: A Framework for High-Resolution Discretization and Fast A
-nalysis of Data Distributed on the Sphere},
-  journal = {\apj},
-   eprint = {astro-ph/0409513},
-     year = 2005,
-    month = apr,
-   volume = 622,
-    pages = {759-771},
-      doi = {10.1086/427976},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005ApJ...
-622..759G&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@Article{mpclass:warell,
+  author =       {J.~Warell and C.-I.~Lagerkvist},
+  title =        {Asteroid taxonomy in the Gaia photometric system},
+  journal =      {\aap},
+  volume =       {submitted},
+  year =         2006
+}
+
+@InProceedings{munari2000,
+  author =       {U.~Munari },
+  title =        { The diffuse interstellar band at 8620 Å: A good
+                  reddening tracer for GAIA},
+  year =         2000,
+  booktitle =    {Molecules in Space and in the Laboratory,
+                  Proceedings of a workshop held 2-5 June 1999 in
+                  Carloforte, Cagliari.},
+  volume =       67,
+  pages =        {179--},
+  publisher =    {I. Porceddu, and S. Aiello. Bologna, Italy: Italian
+                  Physical Society, Conference Proceedings}
 }
 %----------------------------------------------------------------------------
 %  Oracle
 %----------------------------------------------------------------------------
 
+@TechReport{ndac:nullspace,
+  author =       { L.~Lindegren },
+  title =        { {P}seudosolution and pseudocovariances of
+                  least-squares problems with known null space },
+  institution =  { Lund Observatory },
+  year =         { 1983 },
+  month =        { April },
+  note =         { NDAC/LO/018, Hipparcos NDAC }
+}
+
+@TechReport{omg:tmtcxml,
+  author =       {},
+  title =        {Telemetric and Command Data Specification},
+  institution =  {Object Management Group --- Space Domain Task Force},
+  year =         2003,
+  month =        {March},
+  note =         {space/2003-03-04, {\tt
+                  http://www.omg.org/docs/space/03-03-12.pdf}}
+}
+
+@INPROCEEDINGS{omu01,
+  author =       {{O'Mullane}, W. and {Banday}, A.~J. and
+                  {G{\'o}rski}, K.~M. and {Kunszt}, P. and {Szalay},
+                  A.~S.},
+  title =        {{S}plitting the {S}ky - {HTM} and {HEALP}ix},
+  booktitle =    {Mining the Sky},
+  year =         2001,
+  editor =       {{Banday}, A.~J. and {Zaroubi}, S. and {Bartelmann},
+                  M.},
+  pages =        {638-+},
+  doi =          {10.1007/10849171_84},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001misk.c
+                  onf..638O&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
 @TechReport{oracle:RAC,
-  author =  {Oracle Corporation },
-  title =   {Installing Oracle RAC 10g on Linux x86} ,
-  year =    2006,
-  month =   {September},
-  note =    {http://www.oracle.com/technology/pub/articles/smiley\_rac10g\_install.html}
+  author =       {Oracle Corporation },
+  title =        {Installing Oracle RAC 10g on Linux x86},
+  year =         2006,
+  month =        {September},
+  note =
+                  {http://www.oracle.com/technology/pub/articles/smiley\_rac10g\_install.html}
 }
 
 @TechReport{oracle:dell,
-  author =      {Dell support },
-  title =       {Linux Deployment guide },
-  year =        2006,
-  month =       {September},
-  note =        {http://support.dell.com/support/edocs/software/appora10/lin10g/en/dg/10g21en0.pdf}
+  author =       {Dell support },
+  title =        {Linux Deployment guide },
+  year =         2006,
+  month =        {September},
+  note =
+                  {http://support.dell.com/support/edocs/software/appora10/lin10g/en/dg/10g21en0.pdf}
 }
 
-
-
-@INPROCEEDINGS{royce70,
-   author = {{R}oyce, Winston},
-    title = {{M}anaging the {D}evelopment of {L}arge {S}oftware {S}ystems},
-booktitle = {Proceedings of IEEE WESCON },
-     year = 1970,
-     month= {August},
-    pages = {1-9},
-    note = {\url{http://www.cs.umd.edu/class/spring2003/cmsc838p/Process/waterfall.pdf}}
+@article{paper:skyservermining,
+  author =       {J.~Gray and A.~S.~Szalay and A.~Thakar and P.~Kunszt
+                  and C.~Stoughton and D.~Slutz and J.~Vandenberg},
+  title =        {Data {M}ining in the {SDSS} {S}ky{S}erver
+                  {D}atabase},
+  year =         2003,
+  journal =      {Distributed Data and Structures 4: Records of the
+                  4th International Meeting, W. Litwin, G.Levy (eds),
+                  Paris France March 2002},
 }
 
-@INPROCEEDINGS{moore65,
-   author = {{M}oore, Gordon E.},
-    title = {Cramming more components onto integrated circuits},
-  journal = {Electronics},
-     year = 1965,
-    month = apr,
-   volume = 38
-}
-
-@INPROCEEDINGS{shuster93,
-   author = {{S}huster, Malcom, D.  },
-   title = {A survey of attitude representations},
-   journal = {{J}ournal of the astronautical sciences },
-   volume = {41, n.4},
-   year = {1993},
-   pages = {439-517}
- }
-@article{LLGaiaStatus,
-author = {Lindegren,Lennart},
-title = {Gaia: Astrometric performance and current status of the project},
-journal = {Proceedings of the International Astronomical Union},
-volume = {5},
-number = {Symposium S261},
-pages = {296-305},
-year = {2009},
-doi = {10.1017/S1743921309990548},
-URL = {http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=6911372&fulltextType=RA&fileId=S1743921309990548},
-eprint = {http://journals.cambridge.org/article_S1743921309990548},
+@article{paper:vodm,
+  author =       {J.~McDowell },
+  title =        {Data models for the VO},
+  year =         2004,
+  journal =      {Toward an International Virtual Observatory:
+                  Proceedings of the ESO/ESA/NASA/NSF Conference Held
+                  at Garching, Germany, 10-14 June 2002, ESO
+                  ASTROPHYSICS SYMPOSIA. ISBN 3-540-21001-6},
 }
 
 @phdthesis{phd:swb,
-author = {Brown, S.W.},
-title = {Characterisation and {M}itigation of {R}adiation {D}amage on the {G}aia {A}strometric {F}ield},
-year = {2010},
-school = {Institute of {A}stronomy, {U}niversity of {C}ambridge},
-address = {Madingley Road, Cambridge, CB3 0HA, United Kingdom}
+  author =       {Brown, S.W.},
+  title =        {Characterisation and {M}itigation of {R}adiation
+                  {D}amage on the {G}aia {A}strometric {F}ield},
+  year =         2010,
+  school =       {Institute of {A}stronomy, {U}niversity of
+                  {C}ambridge},
+  address =      {Madingley Road, Cambridge, CB3 0HA, United Kingdom}
 }
 
-@ARTICLE{2010.Seabroke.SPIE,
-author = { Seabroke, G. M. and Holland, A. D. and Burt, D. and Robbins, M. S.},
-title = "{Silvaco ATLAS model of ESA's Gaia satellite e2v CCD91-72 pixels}",
-journal = {Proc. SPIE},
-year = 2010,
-month = {},
-volume = 7742,
-pages = {774-14}
-}
-
-@ARTICLE{tapiador2014,
-  author = {Tapiador, D. and  O'Mullane, W. and  Browni, A. G. A. and  Luri Carrascoso, X. and  Huedo, E. and  Osuna, P.},
-  title = {A Framework for Building Hypercubes Using MapReduce},
-  year = {2014},
-  journal = {Computer Physics Communications},
-  volume = {185},
-  number = {5},
-  doi = {http://dx.doi.org/10.1016/j.cpc.2014.02.010}
+@TechReport{planck:dbtestreport,
+  author =       {C.~Vuerli and W.~O'Mullane},
+  title =        {{DBMS-COTS} test week report},
+  institution =  {ESA},
+  year =         2000,
+  month =        {February},
+  note =         {PL-COM-OAT-TN-009}
 }
 
 %----------------------------------------------------------------------------
 %  IVOA Standards
 %----------------------------------------------------------------------------
 
-@TechReport{REC-TAP-1.0,
-  author =      { Dowler P., Rixon G., Tody D. },
-  title =       { Table Access Protocol },
-  institution = { IVOA },
-  year =        2010,
-  month =       {March},
-  note =        {REC-TAP-1.0}
+@TechReport{roemer:proposal,
+  author =       {E.~H{\o}g},
+  title =        {A new era of global astrometry and photometry from
+                  space and ground},
+  institution =  {CUO},
+  year =         1994,
+  month =        {February},
+  note =         {Contribution at the G. Colombo Memorial Conference :
+                  Ideas for Space Research after the Year 2000.}
 }
 
-@TechReport{REC-ADQL-2.0,
-  author =      { Ortiz I., Lusted J., Dowler P. },
-  title =       { Astronomical Data Query Language },
-  institution = { IVOA },
-  year =        2008,
-  month =       {October},
-  note =        {REC-ADQL-2.0}
+@TechReport{roemer:submit,
+  author =       {U.~Bastian and G.~Gilmore and J.L.~Halbwachs and
+                  E.~H{\o}g and J.~Knude and J.~Kovalevsky and
+                  A.~Labeyrie and F.~van~Leeuwen and L.~Lindegren and
+                  J.~W.~Pel and H.~Schrijver and R.~Stabell and
+                  P.~Thejll},
+  title =        {ROEMER},
+  institution =  {Lund Observatory},
+  year =         1993,
+  month =        {July},
+  note =         {Proposal for a Third Medium Size ESA Mission (M3),
+                  Lund 1993}
 }
 
-@TechReport{REC-SSO-1.01,
-  author =      { Rixon G., Graham M. },
-  title =       { Single-Sign-On Profile: Authentication Mechanisms },
-  institution = { IVOA },
-  year =        2008,
-  month =       {January},
-  note =        {REC-SSO-1.01}
-}
-
-@TechReport{REC-UWS-1.0,
-  author =      { Harrison P., Rixon G. },
-  title =       { Universal Worker Service Pattern },
-  institution = { IVOA },
-  year =        2010,
-  month =       {October},
-  note =        {REC-UWS-1.0}
-}
-
-@TechReport{REC-VOSpace-1.15,
-  author =      { Graham M., Morris D., Rixon G. },
-  title =       { VOSpace specification },
-  institution = { IVOA },
-  year =        2009,
-  month =       {October},
-  note =        {REC-VOSpace-1.15}
-}
-
-@TechReport{REC-VOSpace-2.0,
-  author =      { Graham M., Morris D., Rixon G. },
-  title =       { VOSpace specification },
-  institution = { IVOA },
-  year =        2011,
-  month =       {June},
-  note =        {REC-VOSpace-2.0}
-}
-
-@TechReport{intersystems:chartingthegalaxy,
-  author =      { O'Mullane W., Nagjee V. },
-  title =       { Charting the Galaxy with the Gaia Satellite and InterSystems Cach\'{e} },
-  institution = { InterSystems and DPAC },
-  year =        2010,
-  note =    {\url{http://www.intersystems.com/cache/whitepapers/charting_the_galaxy.html}}
+@INPROCEEDINGS{royce70,
+  author =       {{R}oyce, Winston},
+  title =        {{M}anaging the {D}evelopment of {L}arge {S}oftware
+                  {S}ystems},
+  booktitle =    {Proceedings of IEEE WESCON },
+  year =         1970,
+  month =        {August},
+  pages =        {1-9},
+  note =
+                  {\url{http://www.cs.umd.edu/class/spring2003/cmsc838p/Process/waterfall.pdf}}
 }
 
 @TechReport{sequel,
-  author =      { Chamberlin D., Boyce R. },
-  title =       { SEQUL: A Structured English Query Language },
-  institution = { IBM research laboratory},
-  year =        1974,
-  note =    {\url{http://faculty.cse.tamu.edu/yurttas/PL/DBL/docs/sequel-1974.pdf}}
+  author =       { Chamberlin D., Boyce R. },
+  title =        { SEQUL: A Structured English Query Language },
+  institution =  { IBM research laboratory},
+  year =         1974,
+  note =
+                  {\url{http://faculty.cse.tamu.edu/yurttas/PL/DBL/docs/sequel-1974.pdf}}
 }
 
-@TechReport{greenplum:installguide41,
-  title =       { Greenplum Database 4.1 Installation Guide },
-  institution = { EMC Corporation },
-  year =        2011,
-  note =    {\url{http://www.greenplum.com/community/downloads/documentation/}}
+@INPROCEEDINGS{shuster93,
+  author =       {{S}huster, Malcom, D.  },
+  title =        {A survey of attitude representations},
+  journal =      {{J}ournal of the astronautical sciences },
+  volume =       {41, n.4},
+  year =         1993,
+  pages =        {439-517}
 }
 
-@TechReport{greenplum:adminguide41,
-  title =       { Greenplum Database 4.1 Administrator Guide },
-  institution = { EMC Corporation },
-  year =        2011,
-  note =    {\url{http://www.greenplum.com/community/downloads/documentation/}}
+@TechReport{sun:codingstandards,
+  author =       {Sun Microsystems},
+  title =        {Code Conventions for the Java Programming Language },
+  institution =  {Sun},
+  publisher =    {Addison Wesley},
+  year =         1999,
+  month =        {December},
+  note =         {http://java.sun.com/docs/codeconv}
 }
 
-@article{Fraedrich:2009:TMV,
-  author = {Roland Fraedrich and Jens Schneider and R\"{u}diger Westermann},
-  title = {Exploring the "Millennium Run" - Scalable Rendering of Large-Scale Cosmological Datasets},
-  year = {2009},
-     month = {November-December},
-  journal = {IEEE Transactions on Visualization and Computer Graphics
- (Proceedings Visualization / Information Visualization 2009)},
-  volume = {15},
-  number = {6},
-  pages = {to appear},
-  doi = {xx.xxxx/xxxxxxx.xxxxxxx},
+@TechReport{sun:doccomments,
+  author =       {Sun Microsystems},
+  title =        {How to write Doc Comments for JavaDoc},
+  institution =  {Sun},
+  year =         2000,
+  note =
+                  {http://java.sun.com/products/jdk/javadoc/writingdoccomments/index.html}
+}
+
+@TechReport{sun:style,
+  author =       {Sun Microsystems},
+  title =        {Java Look and Feel Design Guidelines},
+  institution =  {Sun},
+  year =         1999,
+  month =        {October},
+  note =         {http://java.sun.com/products/jlf/dg/index.htm}
+}
+
+@ARTICLE{tapiador2014,
+  author =       {Tapiador, D. and O'Mullane, W. and Browni,
+                  A. G. A. and Luri Carrascoso, X. and Huedo, E. and
+                  Osuna, P.},
+  title =        {A Framework for Building Hypercubes Using MapReduce},
+  year =         2014,
+  journal =      {Computer Physics Communications},
+  volume =       185,
+  number =       5,
+  doi =          {http://dx.doi.org/10.1016/j.cpc.2014.02.010}
+}
+
+@InProceedings{terLinden05,
+  author =       {M.~ter~Linden and H.~de~Wolf and R.~Grim },
+  title =        { GridAssist, a User Friendly Grid-based Workflow
+                  Management Tool},
+  year =         2005,
+  booktitle =    {2005 International Conference on Parallel Processing
+                  Workshops (ICPPW'05)},
+  volume =       {icppw},
+  pages =        {5-10},
+  publisher =    {IEEE Computer Society}
+}
+
+@misc{www:linpack,
+  note =         { Linpack standard numerical benchmark, {\tt
+                  http://www.top500.org/lists/linpack.php} }
 }
 
 @LiveLink{LL:SATSCMP,
@@ -1306,49 +1484,23 @@ pages = {774-14}
 	livelinknumber={},
 	livelinkshortnumber={{IVOAMOC}}
 }
-@TechReport{Lindegren1993,
-		  author =      {Lennart Lindegren and Michael Perryman et al  },
-		  title =       { GAIA : Global Astrometric Interferometer for Astrophysics },
-		institution = { Lund },
-		year =        1993,
-		month =       {October},
-		url = {http://www.astro.lu.se/%7Elennart/Astrometry/gaia_proposal.PDF},
-		note =        {}
 
+@misc{www:top500,
+  note =         { {TOP500} {S}upercomputer {S}ites, {\tt
+                  http://www.top500.org} }
 }
 
-@proceedings{doi:10.1117/12.2233619,
-	author = {Vagg, Daniel and O'Callaghan, Derek and Ó hÓgáin, Fionn and McBreen, Sheila and Hanlon, Lorraine and Lynn, David and O'Mullane, William},
-	title = {
-GAVIP: a platform for Gaia data analysis
-	},
-	journal = {Proc. SPIE},
-	volume = {9913},
-	number = {},
-	pages = {99131V-99131V-19},
-	abstract = {
-		Gaia is a major European Space Agency (ESA) astrophysics mission designed to map and analyse 109 stars, ultimately generating more than 1 PetaByte of data-products. As Gaia data becomes publicly available and reaches a wider audience, there is an increasing need to facilitate the further use of Gaia products without needing to download large datasets. The Gaia Added Value Interface Platform (GAVIP) is designed to address this challenge by providing an innovative platform within which scientists can submit and deploy code, packaged as "Added Value Interfaces" (AVIs), which will be executed close to the data. Deployed AVIs and associated outputs may also be made available to other GAVIP platform users, thus providing a mechanism for scientific experiment reproducibility. This paper describes the capabilities and features of GAVIP.
-	},
-	year = {2016},
-	doi = {10.1117/12.2233619},
-	URL = { http://dx.doi.org/10.1117/12.2233619},
-	eprint = {}
+@article{zucker:1994,
+  author =       { S.~Zucher and T.~Mazech },
+  title =        { ApJ },
+  year =         1994,
+  note =         {420 806}
 }
 
-@proceedings{doi:10.1117/12.2233380,
-	author = {Kantor, Jeffrey and Long, Kevin and Becla, Jacek and Economou, Frossie and Gelman, Margaret and Juric, Mario and Lambert, Ron and Krughoff, Simon and Swinbank, John D. and Wu, Xiuqin},
-	title = {
-		Agile software development in an earned value world: a survival guide
-	},
-	journal = {Proc. SPIE},
-	volume = {9911},
-	number = {},
-	pages = {99110N-99110N-18},
-	abstract = {
-		Agile methodologies are current best practice in software development. They are favored for, among other reasons, preventing premature optimization by taking a somewhat short-term focus, and allowing frequent replans/reprioritizations of upcoming development work based on recent results and current backlog. At the same time, funding agencies prescribe earned value management accounting for large projects which, these days, inevitably include substantial software components. Earned Value approaches emphasize a more comprehensive and typically longer-range plan, and tend to characterize frequent replans and reprioritizations as indicative of problems. Here we describe the planning, execution and reporting framework used by the LSST Data Management team, that navigates these opposite tensions.
-	},
-	year = {2016},
-	doi = {10.1117/12.2233380},
-	URL = { http://dx.doi.org/10.1117/12.2233380},
-	eprint = {}
+@article{zucker:2004,
+  author =       { S.~Zucher and T.~Mazech and N.C.~Santos and S.~Udry
+                  and M.~Mayor},
+  title =        { {A\&A} },
+  year =         2004,
+  note =         {420 806}
 }

--- a/texmf/bibtex/bib/refs_ads.bib
+++ b/texmf/bibtex/bib/refs_ads.bib
@@ -1,3097 +1,3795 @@
-@ARTICLE{2013GWN.....6....4A,
-   author = {{Amaro-Seoane}, P. and {Aoudia}, S. and {Babak}, S. and {Bin{\'e}truy}, P. and
-	{Berti}, E. and {Boh{\'e}}, A. and {Caprini}, C. and {Colpi}, M. and
-	{Cornish}, N.~J. and {Danzmann}, K. and {Dufaux}, J.-F. and
-	{Gair}, J. and {Hinder}, I. and {Jennrich}, O. and {Jetzer}, P. and
-	{Klein}, A. and {Lang}, R.~N. and {Lobo}, A. and {Littenberg}, T. and
-	{McWilliams}, S.~T. and {Nelemans}, G. and {Petiteau}, A. and
-	{Porter}, E.~K. and {Schutz}, B.~F. and {Sesana}, A. and {Stebbins}, R. and
-	{Sumner}, T. and {Vallisneri}, M. and {Vitale}, S. and {Volonteri}, M. and
-	{Ward}, H. and {Wardell}, B.},
-    title = "{eLISA: Astrophysics and cosmology in the millihertz regime}",
-  journal = {GW Notes, Vol.~6, p.~4-110},
-archivePrefix = "arXiv",
-   eprint = {1201.3621},
- primaryClass = "astro-ph.CO",
- keywords = {Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Galaxy Astrophysics, General Relativity and Quantum Cosmology, black holes, gravitational waves},
-     year = 2013,
-    month = may,
-   volume = 6,
-    pages = {4-110},
-   adsurl = {http://adsabs.harvard.edu/abs/2013GWN.....6....4A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{1727RSPT...35..637B,
+  author =       {{Bradley}, J.},
+  title =        "{a Letter from the Reverend Mr. James Bradley
+                  Savilian Professor of Astronomy at Oxford, and
+                  F.R.S. to Dr.Edmond Halley
+                  Astronom. Reg. {\amp}c. Giving an Account of a New
+                  Discovered Motion of the Fix'd Stars.}",
+  journal =      {Royal Society of London Philosophical Transactions
+                  Series I},
+  year =         1727,
+  volume =       35,
+  pages =        {637-661},
+  adsurl =       {http://adsabs.harvard.edu/abs/1727RSPT...35..637B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2009SPIE.7439E..14V,
-   author = {{Vosteen}, L.~L.~A. and {Draaisma}, F. and {van Werkhoven}, W.~P. and
-	{van Riel}, L.~J.~M. and {Mol}, M.~H. and {den Ouden}, G.},
-    title = "{Wavefront sensor for the ESA-GAIA mission}",
-booktitle = {Astronomical and Space Optical Systems},
-     year = 2009,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 7439,
-    month = aug,
-      eid = {743914},
-    pages = {743914},
-      doi = {10.1117/12.825240},
-   adsurl = {http://adsabs.harvard.edu/abs/2009SPIE.7439E..14V},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{1978moas.coll..197L,
+  author =       {{Lindegren}, L.},
+  title =        "{Photoelectric astrometry - A comparison of methods
+                  for precise image location}",
+  keywords =     {ASTROMETRY, ELECTROPHOTOMETERS, POSITION (LOCATION),
+                  ESTIMATES, PHOTOELECTRIC EFFECT, WEIGHTING
+                  FUNCTIONS},
+  booktitle =    {IAU Colloq. 48: Modern Astrometry},
+  year =         1978,
+  editor =       {{Prochazka}, F.~V. and {Tucker}, R.~H.},
+  pages =        {197-217},
+  adsurl =       {http://adsabs.harvard.edu/abs/1978moas.coll..197L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2014EAS....67...15P,
-   author = {{Prusti}, T.},
-    title = "{Gaia Mission Status}",
-booktitle = {EAS Publications Series},
-     year = 2014,
-   series = {EAS Publications Series},
-   volume = 67,
-    month = jul,
-    pages = {15-21},
-      doi = {10.1051/eas/1567003},
-   adsurl = {http://adsabs.harvard.edu/abs/2014EAS....67...15P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{1982A&A...114..278B,
+  author =       {{Bretagnon}, P.},
+  title =        "{Theory for the motion of all the planets - The
+                  VSOP82 solution}",
+  journal =      {\aap},
+  year =         1982,
+  month =        oct,
+  volume =       114,
+  pages =        {278-288},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1982A%26A...114..278B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1983A&A...120..197S,
+  author =       {{Simon}, J.~L.},
+  title =        "{Theory for the motion of the four giant planets -
+                  The TOP 82 solution}",
+  journal =      {\aap},
+  year =         1983,
+  month =        apr,
+  volume =       120,
+  pages =        {197-202},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1983A%26A...120..197S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1985ApJ...298...80C,
+  author =       {{Casertano}, S. and {Hut}, P.},
+  title =        "{Core radius and density measurements in N-body
+                  experiments Connections with theoretical and
+                  observational definitions}",
+  journal =      {\apj},
+  keywords =     {Astronomical Models, Density Distribution, Galactic
+                  Clusters, Many Body Problem, Star Clusters,
+                  Gravitational Effects, Monte Carlo Method},
+  year =         1985,
+  month =        nov,
+  volume =       298,
+  pages =        {80-94},
+  doi =          {10.1086/163589},
+  adsurl =       {http://adsabs.harvard.edu/abs/1985ApJ...298...80C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1985Icar...61..355Z,
+  author =       {{Zellner}, B. and {Tholen}, D.~J. and {Tedesco},
+                  E.~F.},
+  title =        "{The eight-color asteroid survey - Results for 589
+                  minor planets}",
+  journal =      {Icarus},
+  year =         1985,
+  month =        mar,
+  volume =       61,
+  pages =        {355-416},
+  doi =          {10.1016/0019-1035(85)90133-2},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1985Icar...61..355Z&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1985Icar...62..244G,
+  author =       {{Gr\"{u}n}, E. and {Zook}, H.~A. and {Fechtig},
+                  H. and {Giese}, R.},
+  title =        "{Collisional Balance of the Meteoritic Complex}",
+  journal =      {Icarus},
+  year =         1985,
+  month =        may,
+  volume =       62,
+  pages =        {244-272},
+  doi =          {10.1016/0019-1035(85)90121-6},
+  adsurl =
+                  {http://adsabs.harvard.edu/abs/1985Icar...62..244G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1986ApJ...304...62O,
+  author =       {{Otto}, S. and {Politzer}, H.~D. and {Preskill},
+                  J. and {Wise}, M.~B.  },
+  title =        "{The significance of voids}",
+  journal =      {\apj},
+  keywords =     {Cosmology, Galactic Clusters, Galaxies, Spatial
+                  Distribution, Statistical Analysis, Void Ratio,
+                  Density Distribution, Probability Distribution
+                  Functions, Significance, Statistical Correlation,
+                  Statistical Distributions},
+  year =         1986,
+  month =        may,
+  volume =       304,
+  pages =        {62-74},
+  doi =          {10.1086/164144},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/1986ApJ...304...62O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1988A&A...202..309B,
+  author =       {{Bretagnon}, P. and {Francou}, G.},
+  title =        "{Planetary theories in rectangular and spherical
+                  variables - VSOP 87 solutions}",
+  journal =      {\aap},
+  year =         1988,
+  month =        aug,
+  volume =       202,
+  pages =        {309-315},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1988A%26A...202..309B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 @ARTICLE{1989ApJ...345..245C,
-   author = {{Cardelli}, J.~A. and {Clayton}, G.~C. and {Mathis}, J.~S.},
-    title = "{The relationship between infrared, optical, and ultraviolet extinction}",
-  journal = {\apj},
- keywords = {Infrared Spectra, Interstellar Extinction, Ultraviolet Spectra, Visible Spectrum, Computational Astrophysics, Interstellar Matter, Iue},
-     year = 1989,
-    month = oct,
-   volume = 345,
-    pages = {245-256},
-      doi = {10.1086/167900},
-   adsurl = {http://adsabs.harvard.edu/abs/1989ApJ...345..245C},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Cardelli}, J.~A. and {Clayton}, G.~C. and {Mathis},
+                  J.~S.},
+  title =        "{The relationship between infrared, optical, and
+                  ultraviolet extinction}",
+  journal =      {\apj},
+  keywords =     {Infrared Spectra, Interstellar Extinction,
+                  Ultraviolet Spectra, Visible Spectrum, Computational
+                  Astrophysics, Interstellar Matter, Iue},
+  year =         1989,
+  month =        oct,
+  volume =       345,
+  pages =        {245-256},
+  doi =          {10.1086/167900},
+  adsurl =       {http://adsabs.harvard.edu/abs/1989ApJ...345..245C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2014SPIE.9154E..0MJ,
-   author = {{Jorden}, P.~R. and {Jordan}, D. and {Jerram}, P.~A. and {Pratlong}, J. and
-	{Swindells}, I.},
-    title = "{e2v new CCD and CMOS technology developments for astronomical sensors}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2014,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 9154,
-    month = jul,
-      eid = {91540M},
-    pages = {91540M},
-      doi = {10.1117/12.2069423},
-   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9154E..0MJ},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2008SPIE.7021E..0HB,
-   author = {{Beletic}, J.~W. and {Blank}, R. and {Gulbransen}, D. and {Lee}, D. and
-	{Loose}, M. and {Piquette}, E.~C. and {Sprafke}, T. and {Tennant}, W.~E. and
-	{Zandian}, M. and {Zino}, J.},
-    title = "{Teledyne Imaging Sensors: infrared imaging technologies for astronomy and civil space}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2008,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 7021,
-    month = jul,
-      eid = {70210H},
-    pages = {70210H},
-      doi = {10.1117/12.790382},
-   adsurl = {http://adsabs.harvard.edu/abs/2008SPIE.7021E..0HB},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2006SPIE.6206E..01C,
-   author = {{Chorier}, P. and {Tribolet}, P. and {Dest{\'e}fanis}, G.},
-    title = "{From visible to infrared: a new detector approach}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2006,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 6206,
-    month = may,
-      eid = {620601},
-    pages = {620601},
-      doi = {10.1117/12.669128},
-   adsurl = {http://adsabs.harvard.edu/abs/2006SPIE.6206E..01C},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2014SPIE.9143E..0XM,
-   author = {{Mora}, A. and {Biermann}, M. and {Brown}, A.~G.~A. and {Busonero}, D. and
-	{Carminati}, L. and {Carrasco}, J.~M. and {Chassat}, F. and
-	{Erdmann}, M. and {Gielesen}, W.~L.~M. and {Jordi}, C. and {Katz}, D. and
-	{Kohley}, R. and {Lindegren}, L. and {Loeffler}, W. and {Marchal}, O. and
-	{Panuzzo}, P. and {Seabroke}, G. and {Sahlmann}, J. and {Serpell}, E. and
-	{Serraller}, I. and {van Leeuwen}, F. and {van Reeven}, W. and
-	{van den Dool}, T.~C. and {Vosteen}, L.~L.~A.},
-    title = "{Gaia on-board metrology: basic angle and best focus}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2014,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 9143,
-archivePrefix = "arXiv",
-   eprint = {1407.3729},
- primaryClass = "astro-ph.IM",
-    month = aug,
-      eid = {91430X},
-    pages = {0},
-      doi = {10.1117/12.2054602},
-   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9143E..0XM},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@PHDTHESIS{2012PhDT.......175S,
-   author = {{Sahlmann}, J.},
-    title = "{Observing exoplanet populations with high-precision astrometry}",
- keywords = {extrasolar planets, astrometry, radial velocities, interferometry, brown dwarfs, stars: binaries, stars: low-mass},
-   school = {Observatoire de Gen{\`e}ve, Universit{\'e} de Gen{\`e}ve <EMAIL>Johannes.Sahlmann@unige.ch</EMAIL>},
-     year = 2012,
-    month = jun,
-   adsurl = {http://adsabs.harvard.edu/abs/2012PhDT.......175S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2015arXiv150906868H,
-	   author = {{Hees}, A. and {Hestroffer}, D. and {Le Poncin-Lafitte}, C. and
-		   	{David}, P.},
-	       title = "{Tests of gravitation with Gaia observations of Solar System Objects}",
-	         journal = {ArXiv e-prints},
-		 archivePrefix = "arXiv",
-		    eprint = {1509.06868},
-		     primaryClass = "gr-qc",
-		      keywords = {General Relativity and Quantum Cosmology, Astrophysics - Earth and Planetary Astrophysics},
-		           year = 2015,
-			       month = sep,
-			          adsurl = {http://adsabs.harvard.edu/abs/2015arXiv150906868H},
-				    adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2012arXiv1210.5007W,
-	   author = {{Wyrzykowski}, L. and {Hodgkin}, S. and {Blogorodnova}, N. and
-		   	{Koposov}, S. and {Burgon}, R.},
-	       title = "{Photometric Science Alerts from Gaia}",
-	         journal = {ArXiv e-prints},
-		 archivePrefix = "arXiv",
-		    eprint = {1210.5007},
-		     primaryClass = "astro-ph.IM",
-		      keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-		           year = 2012,
-			       month = oct,
-			          adsurl = {http://ads.nao.ac.jp/abs/2012arXiv1210.5007W},
-				    adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@INPROCEEDINGS{2001ASPC..225..201O,
-	   author = {{O'Mullane}, W. and {Luri}, X.},
-	       title = "{GAIA and Virtual Observatories}",
-	       booktitle = {Virtual Observatories of the Future},
-	            year = 2001,
-		       series = {Astronomical Society of the Pacific Conference Series},
-		          volume = 225,
-			     editor = {{Brunner}, R.~J. and {Djorgovski}, S.~G. and {Szalay}, A.~S.
-				     	},
-			         pages = {201},
-				    adsurl = {http://adsabs.harvard.edu/abs/2001ASPC..225..201O},
-				      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{1990ApJ...361..667T,
+  author =       {{Taff}, L.~G. and {Bucciarelli}, B. and {Lattanzi},
+                  M.~G.},
+  title =        "{Catalog-to-catalog reductions}",
+  journal =      {\apj},
+  keywords =     {Astrometry, Astronomical Catalogs, Computerized
+                  Simulation, Monte Carlo Method},
+  year =         1990,
+  month =        oct,
+  volume =       361,
+  pages =        {667-672},
+  doi =          {10.1086/169230},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/1990ApJ...361..667T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{1994A&A...287..338N,
-   author = {{Nordstroem}, B. and {Latham}, D.~W. and {Morse}, J.~A. and ƒ
-	{Milone}, A.~A.~E. and {Kurucz}, R.~L. and {Andersen}, J. and
-	{Stefanik}, R.~P.},
-    title = "{Cross-correlation radial-velocity techniques for rotating F stars}",
-  journal = {\aap},
- keywords = {CROSS CORRELATION, DATA REDUCTION, F STARS, LINE SPECTRA, RADIAL VELOCITY, STELLAR MODELS, STELLAR ROTATION, ERROR ANALYSIS, PROBABILITY DENSITY FUNCTIONS, REFLECTING TELESCOPES, SPECTROGRAPHS, STELLAR ATMOSPHERES},
-     year = 1994,
-    month = jul,
-   volume = 287,
-    pages = {338-347},
-   adsurl = {http://adsabs.harvard.edu/abs/1994A%26A...287..338N},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Nordstroem}, B. and {Latham}, D.~W. and {Morse},
+                  J.~A. and ƒ {Milone}, A.~A.~E. and {Kurucz},
+                  R.~L. and {Andersen}, J. and {Stefanik}, R.~P.},
+  title =        "{Cross-correlation radial-velocity techniques for
+                  rotating F stars}",
+  journal =      {\aap},
+  keywords =     {CROSS CORRELATION, DATA REDUCTION, F STARS, LINE
+                  SPECTRA, RADIAL VELOCITY, STELLAR MODELS, STELLAR
+                  ROTATION, ERROR ANALYSIS, PROBABILITY DENSITY
+                  FUNCTIONS, REFLECTING TELESCOPES, SPECTROGRAPHS,
+                  STELLAR ATMOSPHERES},
+  year =         1994,
+  month =        jul,
+  volume =       287,
+  pages =        {338-347},
+  adsurl =       {http://adsabs.harvard.edu/abs/1994A%26A...287..338N},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{1996A&A...305..146G,
-   author = {{Gunn}, A.~G. and {Hall}, J.~C. and {Lockwood}, G.~W. and {Doyle}, J.~G.
-	},
-    title = "{Cross-correlation radial velocity measurements of chromospherically active binaries.}",
-  journal = {\aap},
- keywords = {STARS: BINARIES: CLOSE, STARS: BINARIES: SPECTROSCOPIC, STARS: ACTIVITY, TECHNIQUES: RADIAL VELOCITIES},
-     year = 1996,
-    month = jan,
-   volume = 305,
-    pages = {146-+},
-   adsurl = {http://adsabs.harvard.edu/abs/1996A%26A...305..146G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{1994ApJ...433..831B,
+  author =       {{Bucciarelli}, B. and {Lattanzi}, M.~G. and {Taff},
+                  L.~G.},
+  title =        "{The analysis of star catalogs. 1: an
+                  intercomparison among the FK3, the FK4, and the
+                  FK5}",
+  journal =      {\apj},
+  keywords =     {Astrometry, Astronomical Catalogs, Comparison, Error
+                  Analysis, Reference Stars, Statistical Analysis,
+                  Statistical Correlation},
+  year =         1994,
+  month =        oct,
+  volume =       433,
+  pages =        {831-844},
+  doi =          {10.1086/174692},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/1994ApJ...433..831B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{1995A&A...304...34K,
+  author =       {{Kovalevsky}, J. and {Lindegren}, L. and
+                  {Froeschle}, M. and {van Leeuwen}, F. and
+                  {Perryman}, M.~A.~C. and {Falin}, J.~L. and
+                  {Mignard}, F. and {Penston}, M.~J. and {Petersen},
+                  C.~S. and {Bernacca}, P.~L. and {Bucciarelli},
+                  B. and {Donati}, F. and {Hering}, R. and {Hog},
+                  E. and {Lattanzi}, M.~G. and {van der Marel}, H. and
+                  {Schrijver}, H. and {Walter}, H.~G.},
+  title =        "{Construction of the intermediate HIPPARCOS
+                  astrometric catalogue}",
+  journal =      {\aap},
+  year =         1995,
+  month =        dec,
+  volume =       304,
+  pages =        {34-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1995A%26A...304...34K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
 
-@ARTICLE{2007AJ....134.1843A,
-   author = {{Allende Prieto}, C.},
-    title = "{Velocities from Cross-Correlation: A Guide for Self-Improvement}",
-  journal = {\aj},
-archivePrefix = "arXiv",
-   eprint = {0707.2764},
- keywords = {methods: statistical, stars: kinematics, techniques: radial velocities},
-     year = 2007,
-    month = nov,
-   volume = 134,
-    pages = {1843-1848},
-      doi = {10.1086/522051},
-   adsurl = {http://adsabs.harvard.edu/abs/2007AJ....134.1843A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{1995A&A...304...52A,
+  author =       {{Arenou}, F. and {Lindegren}, L. and {Froeschle},
+                  M. and {Gomez}, A.~E. and {Turon}, C. and
+                  {Perryman}, M.~A.~C. and {Wielen}, R.},
+  title =        "{Zero-point and external errors of HIPPARCOS
+                  parallaxes}",
+  journal =      {\aap},
+  year =         1995,
+  month =        dec,
+  volume =       304,
+  pages =        52,
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/1995A%26A...304...52A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 
 % Rickman:2001
-@ARTICLE{2001IAUTr..24B....R,
-   author = {{Rickman}, H.},
-    title = "{Transactions of the International Astronomical Union Proceedings of the Twenty-Fourth General Assembly.}",
-  journal = {Transactions of the International Astronomical Union Proceedings of the Twenty-Fourth General Assembly.~Editedy by Hans Rickman.~ ISBN:  1-58381-087-0.~San Francisco: Astronomical Society of the Pacific, 2001.},
-     year = 2001,
-   volume = 24,
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001IAUTr..24B....R&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+
+@ARTICLE{1995A&A...304...61L,
+  author =       {{Lindegren}, L.},
+  title =        "{Estimating the external accuracy of HIPPARCOS
+                  parallaxes by deconvolution.}",
+  journal =      {\aap},
+  keywords =     {ASTROMETRY, METHODS: DATA ANALYSIS, METHODS:
+                  NUMERICAL, STARS: DISTANCES},
+  year =         1995,
+  month =        dec,
+  volume =       304,
+  pages =        61,
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/1995A%26A...304...61L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % Soffel:et:al:2003
 
-@ARTICLE{2003AJ....126.2687S,
-   author = {{Soffel}, M. and {Klioner}, S.~A. and {Petit}, G. and {Wolf}, P. and
-	{Kopeikin}, S.~M. and {Bretagnon}, P. and {Brumberg}, V.~A. and1998A&A...340..309M1998A&A...340..309M
-	{Capitaine}, N. and {Damour}, T. and {Fukushima}, T. and {Guinot}, B. and
-	{Huang}, T.-Y. and {Lindegren}, L. and {Ma}, C. and {Nordtvedt}, K. and
-	{Ries}, J.~C. and {Seidelmann}, P.~K. and {Vokrouhlick{\'y}}, D. and
-	{Will}, C.~M. and {Xu}, C.},
-    title = "{The IAU 2000 Resolutions for Astrometry, Celestial Mechanics, and Metrology in the Relativistic Framework: Explanatory Supplement}",
-  journal = {\aj},
-   eprint = {astro-ph/0303376},
-     year = 2003,
-    month = dec,
-   volume = 126,
-    pages = {2687-2706},
-      doi = {10.1086/378162},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003AJ....126.2687S&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{1995ASPC...77..429R,
+  author =       {{Rose}, J. and {Akella}, R. and {Binegar}, S. and
+                  {Choo}, T.~H. and {Heller-Boyer}, C. and {Hester},
+                  T. and {Hyde}, P. and {Perrine}, R. and {Rose},
+                  M.~A. and {Steuerman}, K.},
+  title =        "{The OPUS Pipeline: A Partially Object-Oriented
+                  Pipeline System}",
+  booktitle =    {Astronomical Data Analysis Software and Systems IV},
+  year =         1995,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       77,
+  editor =       {{Shaw}, R.~A. and {Payne}, H.~E. and {Hayes},
+                  J.~J.~E.},
+  pages =        {429-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/1995ASPC...77..429R},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % Klioner:Soffel:2000
 
-@ARTICLE{2000PhRvD..62b4019K,
-   author = {{Klioner}, S.~A. and {Soffel}, M.~H.},
-    title = "{Relativistic celestial mechanics with PPN parameters}",
-  journal = {\prd},
-   eprint = {gr-qc/9906123},
-     year = 2000,
-    month = jul,
-   volume = 62,
-   number = 2,
-    pages = {024019-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2000PhRvD..62b4019K&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1996A&A...305..146G,
+  author =       {{Gunn}, A.~G. and {Hall}, J.~C. and {Lockwood},
+                  G.~W. and {Doyle}, J.~G.  },
+  title =        "{Cross-correlation radial velocity measurements of
+                  chromospherically active binaries.}",
+  journal =      {\aap},
+  keywords =     {STARS: BINARIES: CLOSE, STARS: BINARIES:
+                  SPECTROSCOPIC, STARS: ACTIVITY, TECHNIQUES: RADIAL
+                  VELOCITIES},
+  year =         1996,
+  month =        jan,
+  volume =       305,
+  pages =        {146-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/1996A%26A...305..146G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % kopeikin2004
 
-@ARTICLE{2004PhR...400..209K,
-   author = {{Kopeikin}, S. and {Vlasov}, I.},
-    title = "{Parametrized post-Newtonian theory of reference frames, multipolar expansions and equations of motion in the N-body problem}",
-  journal = {\physrep},
-   eprint = {gr-qc/0403068},
-     year = 2004,
-    month = nov,
-   volume = 400,
-    pages = {209-318},
-      doi = {10.1016/j.physrep.2004.08.004},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004PhR...400..209K&db_key=PHY},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1997A&A...320..428H,
+  author =       {{Haywood}, M. and {Robin}, A.~C. and {Creze}, M.},
+  title =        "{The evolution of the Milky Way disc. I. Vertical
+                  structure and local constraints.}",
+  journal =      {\aap},
+  year =         1997,
+  month =        apr,
+  volume =       320,
+  pages =        {428-439},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997A%26A...320..428H&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % Klioner:2004
 
-@ARTICLE{2004PhRvD..69l4001K,
-   author = {{Klioner}, S.~A.},
-    title = "{Physically adequate proper reference system of a test observer and relativistic description of the GAIA attitude}",
-  journal = {Phys. Rev. D},
-   eprint = {astro-ph/0311540},
-     year = 2004,
-    month = jun,
-   volume = 69,
-   number = 12,
-    pages = {124001-+},
-      doi = {10.1103/PhysRevD.69.124001},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004PhRvD..69l4001K&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1997A&A...327.1253M,
+  author =       {{Moreno}, F. and {Molina}, A. and {Ortiz}, J.~L.},
+  title =        "{The 1993 south equatorial belt revival and other
+                  features in the Jovian atmosphere: an observational
+                  perspective}",
+  journal =      {\aap},
+  keywords =     {PLANETS AND SATELLITES: INDIVIDUAL: JUPITER},
+  year =         1997,
+  month =        nov,
+  volume =       327,
+  pages =        {1253-1261},
+  adsurl =       {http://adsabs.harvard.edu/abs/1997A%26A...327.1253M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % Klioner:2003
 
-@ARTICLE{2003A&A...410.1063K,
-   author = {{Klioner}, S.~A. and {Peip}, M.},
-    title = "{Numerical simulations of the light propagation  in the gravitational field of moving bodies}",
-  journal = {\aap},
-   eprint = {astro-ph/0305204},
-     year = 2003,
-    month = nov,
-   volume = 410,
-    pages = {1063-1074},
-      doi = {10.1051/0004-6361:20031283},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...410.1063K&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{1997ESASP.402..767D,
+  author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
+                  {Vecchiato}, A. and {Bernacca}, P.~L.},
+  title =        "{A Relativistic Model for the GAIA Observations}",
+  booktitle =    {Hipparcos - Venice '97},
+  year =         1997,
+  series =       {ESA Special Publication},
+  volume =       402,
+  editor =       "{R.~M.~Bonnet, E.~H{\o}g, P.~L.~Bernacca,
+                  L.~Emiliani, A.~Blaauw, C.~Turon, J.~Kovalevsky,
+                  L.~Lindegren, H.~Hassan, M.~Bouffard, B.~Strim,
+                  D.~Heger, M.~A.~C.~Perryman, \& L.~Woltjer}",
+  month =        aug,
+  pages =        {767-770},
+  adsurl =       {http://adsabs.harvard.edu/abs/1997ESASP.402..767D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 
 % Klioner:Peip:2003
 
-@ARTICLE{2003AJ....125.1580K,
-   author = {{Klioner}, S.~A.},
-    title = "{A Practical Relativistic Model for Microarcsecond Astrometry in Space}",
-  journal = {\aj},
-     year = 2003,
-    month = mar,
-   volume = 125,
-    pages = {1580-1597},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003AJ....125.1580K&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@PROCEEDINGS{1997ESASP1200.....P,
+  title =        "{The HIPPARCOS and TYCHO catalogues. Astrometric and
+                  photometric star catalogues derived from the ESA
+                  HIPPARCOS Space Astrometry Mission}",
+  keywords =     {SPACE ASTROMETRY, STAR CATALOGS, POSITIONS,
+                  ARTIFICIAL SATELLITES},
+  booktitle =    {ESA Special Publication},
+  year =         1997,
+  series =       {ESA Special Publication},
+  volume =       1200,
+  editor =       {{Perryman}, M.~A.~C. and {ESA}},
+  adsurl =       {http://adsabs.harvard.edu/abs/1997ESASP1200.....P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 
 % deFelice:2004
 
-@ARTICLE{2004ApJ...607..580D,
-   author = {{de Felice}, F. and {Crosta}, M.~T. and {Vecchiato}, A. and
-	{Lattanzi}, M.~G. and {Bucciarelli}, B.},
-    title = "{A General Relativistic Model of Light Propagation in the Gravitational Field of the Solar System: The Static Case}",
-  journal = {\apj},
-   eprint = {astro-ph/0401637},
-     year = 2004,
-    month = may,
-   volume = 607,
-    pages = {580-595},
-      doi = {10.1086/383244},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJ...607..580D&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1997SSRv...81..201V,
+  author =       {{van Leeuwen}, F.},
+  title =        "{The HIPPARCOS Mission}",
+  journal =      {Space Science Reviews},
+  year =         1997,
+  month =        aug,
+  volume =       81,
+  pages =        {201-409},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997SSRv...81..201V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 
 % defelice1
 
-@ARTICLE{2003A&A...399..337V,
-   author = {{Vecchiato}, A. and {Lattanzi}, M.~G. and {Bucciarelli}, B. and
-	{Crosta}, M. and {de Felice}, F. and {Gai}, M.},
-    title = "{Testing general relativity by micro-arcsecond global astrometry}",
-  journal = {\aap},
-   eprint = {astro-ph/0301323},
-     year = 2003,
-    month = feb,
-   volume = 399,
-    pages = {337-342},
-      doi = {10.1051/0004-6361:20021785},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...399..337V&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{1997hipp.conf..467E,
+  author =       {{Eyer}, L. and {Grenon}, M.},
+  title =        "{Photometric {V}ariability in the {HR} {D}iagram}",
+  booktitle =    {ESA SP-402: Hipparcos - Venice '97},
+  year =         1997,
+  pages =        {467-472},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1997hipp.conf..467E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % vecchia2
 
-@ARTICLE{2001A&A...373..336D,
-   author = {{de Felice}, F. and {Bucciarelli}, B. and {Lattanzi}, M.~G. and
-	{Vecchiato}, A.},
-    title = "{General relativistic satellite astrometry. II. Modeling parallax and proper motion}",
-  journal = {\aap},
-     year = 2001,
-    month = jul,
-   volume = 373,
-    pages = {336-344},
-      doi = {10.1051/0004-6361:20010499},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...373..336D&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{1997hipp.conf..621G,
+  author =       {{Gomez}, A.~E. and {Grenier}, S. and {Udry}, S. and
+                  {Haywood}, M. and {Meillon}, L. and {Sabas}, V. and
+                  {Sellier}, A. and {Morin}, D.  },
+  title =        "{Kinematics of Disk Stars in the Solar
+                  Neighbourhood}",
+  booktitle =    {ESA SP-402: Hipparcos - Venice '97},
+  year =         1997,
+  pages =        {621-624},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997hipp.conf..621G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % bini1
 
-@ARTICLE{2003CQGra..20.4695B,
-   author = {{Bini}, D. and {Crosta}, M.~T. and {de Felice}, F.},
-    title = "{Orbiting frames and satellite attitudes in relativistic astrometry}",
-  journal = {Classical and Quantum Gravity},
-     year = 2003,
-    month = nov,
-   volume = 20,
-    pages = {4695-4706},
-      doi = {10.1088/0264-9381/20/21/009},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003CQGra..20.4695B&db_key=PHY},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1998A&A...332.1133D,
+  author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
+                  {Vecchiato}, A. and {Bernacca}, P.~L.},
+  title =        "{General relativistic satellite astrometry. I. A
+                  non-perturbative approach to data reduction}",
+  journal =      {\aap},
+  keywords =     {RELATIVITY, METHODS: DATA ANALYSIS, SPACE VEHICLES,
+                  ASTROMETRY},
+  year =         1998,
+  month =        apr,
+  volume =       332,
+  pages =        {1133-1141},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998A%26A...332.1133D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % defelice2
 
-@ARTICLE{2006CQGra..23.5467D,
-   author = {{de Felice}, F. and {Preti}, G.},
-    title = "{Ray tracing in relativistic astrometry: stellar positions, stellar motion and error budget}",
-  journal = {Classical and Quantum Gravity},
-     year = 2006,
-    month = sep,
-   volume = 23,
-    pages = {5467-5476},
-      doi = {10.1088/0264-9381/23/18/001},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006CQGra..23.5467D&db_key=PHY},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1998A&A...340..309M,
+  author =       {{Makarov}, V.~V.},
+  title =        "{Absolute measurements of trigonometric parallaxes
+                  with astrometric satellites}",
+  journal =      {\aap},
+  year =         1998,
+  month =        dec,
+  volume =       340,
+  pages =        {309-314},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998A%26A...340..309M},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % Lattanzi-2005:a
 
-@INPROCEEDINGS{2005tdug.conf..251L,
-   author = {{Lattanzi}, M.~G. and {Casertano}, S. and {Jancart}, S. and
-	{Morbidelli}, R. and {Pourbaix}, D. and {Pannunzio}, R. and
-	{Sozzetti}, A. and {Spagna}, A.},
-    title = "{Detection and Characterization of Extra-Solar Planets with Gaia}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {251-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..251L&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1998A&AS..130...65L,
+  author =       {{Lejeune}, T. and {Cuisinier}, F. and {Buser}, R.},
+  title =        "{A standard stellar library for evolutionary
+                  synthesis. II. The M dwarf extension}",
+  journal =      {\aaps},
+  eprint =       {astro-ph/9710350},
+  year =         1998,
+  month =        may,
+  volume =       130,
+  pages =        {65-75},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998A%26AS..130...65L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % gardiol3
 
-@INPROCEEDINGS{2004SPIE.5497..461G,
-   author = {{Gardiol}, D. and {Loreggia}, D. and {Mannu}, S. and {Mottini}, S. and
-	{Perachino}, L. and {Gai}, M. and {Lattanzi}, M.~G.},
-    title = "{End-to-end optomechanical simulation for high-precision global astrometry}",
-booktitle = {Modeling and Systems Engineering for Astronomy.  Edited by Craig, Simon C.; Cullum, Martin J.    Proceedings of the SPIE, Volume 5497, pp. 461-470 (2004).},
-     year = 2004,
-   editor = {{Craig}, S.~C. and {Cullum}, M.~J.},
-    month = sep,
-    pages = {461-470},
-      doi = {10.1117/12.550356},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004SPIE.5497..461G&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1998ARA&A..36...99K,
+  author =       {{Kovalevsky}, J.},
+  title =        "{First Results from HIPPARCOS}",
+  journal =      {\araa},
+  year =         1998,
+  volume =       36,
+  pages =        {99-130},
+  doi =          {10.1146/annurev.astro.36.1.99},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA%26A..36...99K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % Sozzetti-2001:a
 
-@ARTICLE{2001A&A...373L..21S,
-   author = {{Sozzetti}, A. and {Casertano}, S. and {Lattanzi}, M.~G. and
-	{Spagna}, A.},
-    title = "{Detection and measurement of planetary systems with GAIA}",
-  journal = {\aap},
-   eprint = {astro-ph/0104391},
-     year = 2001,
-    month = jul,
-   volume = 373,
-    pages = {L21-L24},
-      doi = {10.1051/0004-6361:20010788},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...373L..21S&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1998MNRAS.298..387D,
+  author =       {{Dehnen}, W. and {Binney}, J.~J.},
+  title =        "{Local stellar kinematics from HIPPARCOS data}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/9710077},
+  keywords =     {STARS: KINEMATICS, GALAXY: FUNDAMENTAL PARAMETERS,
+                  GALAXY: KINEMATICS AND DYNAMICS, SOLAR
+                  NEIGHBOURHOOD, GALAXY: STRUCTURE},
+  year =         1998,
+  month =        aug,
+  volume =       298,
+  pages =        {387-394},
+  doi =          {10.1046/j.1365-8711.1998.01600.x},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998MNRAS.298..387D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % paper:gaiascience
 
-@ARTICLE{2001A&A...369..339P,
-   author = {{Perryman}, M.~A.~C. and {de Boer}, K.~S. and {Gilmore}, G. and
-	{H{\o}g}, E. and {Lattanzi}, M.~G. and {Lindegren}, L. and {Luri}, X. and
-	{Mignard}, F. and {Pace}, O. and {de Zeeuw}, P.~T.},
-    title = "{GAIA: Composition, formation and evolution of the Galaxy}",
-  journal = {\aap},
-   eprint = {astro-ph/0101235},
-     year = 2001,
-    month = apr,
-   volume = 369,
-    pages = {339-363},
-      doi = {10.1051/0004-6361:20010085},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...369..339P&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1998PASP..110..863P,
+  author =       {{Pickles}, A.~J.},
+  title =        "{A Stellar Spectral Flux Library: 1150-25000 {\AA}}",
+  journal =      {\pasp},
+  keywords =     {ATLASES, STARS: GENERAL, GALAXIES: STELLAR CONTENT},
+  year =         1998,
+  month =        jul,
+  volume =       110,
+  pages =        {863-878},
+  doi =          {10.1086/316197},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998PASP..110..863P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % Lattanzi-2000:a
 
-@ARTICLE{2000MNRAS.317..211L,
-   author = {{Lattanzi}, M.~G. and {Spagna}, A. and {Sozzetti}, A. and {Casertano}, S.
-	},
-    title = "{Space-borne global astrometric surveys: the hunt for extrasolar planets}",
-  journal = {\mnras},
-   eprint = {astro-ph/0005024},
-     year = 2000,
-    month = sep,
-   volume = 317,
-    pages = {211-224},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2000MNRAS.317..211L&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1999A&AS..137..521M,
+  author =       {{Munari}, U. and {Tomasella}, L.},
+  title =        "{High resolution spectroscopy over lambda lambda
+                  8500-8750 {\AA} for GAIA. I. Mapping the MKK
+                  classification system}",
+  journal =      {\aaps},
+  year =         1999,
+  month =        jun,
+  volume =       137,
+  pages =        {521-528},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1999A%26AS..137..521M&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % kov1
 
-@ARTICLE{1995A&A...304...34K,
-   author = {{Kovalevsky}, J. and {Lindegren}, L. and {Froeschle}, M. and
-	{van Leeuwen}, F. and {Perryman}, M.~A.~C. and {Falin}, J.~L. and
-	{Mignard}, F. and {Penston}, M.~J. and {Petersen}, C.~S. and
-	{Bernacca}, P.~L. and {Bucciarelli}, B. and {Donati}, F. and
-	{Hering}, R. and {Hog}, E. and {Lattanzi}, M.~G. and {van der Marel}, H. and
-	{Schrijver}, H. and {Walter}, H.~G.},
-    title = "{Construction of the intermediate HIPPARCOS astrometric catalogue}",
-  journal = {\aap},
-     year = 1995,
-    month = dec,
-   volume = 304,
-    pages = {34-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1995A%26A...304...34K&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1999BaltA...8...57O,
+  author =       {{O'Mullane}, W. and {Lindegren}, L.},
+  title =        "{An Object-Oriented Framework for GAIA Data
+                  Processing}",
+  journal =      {Baltic Astronomy},
+  year =         1999,
+  volume =       8,
+  pages =        {57-72},
+  adsurl =       {http://adsabs.harvard.edu/abs/1999BaltA...8...57O},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % Pourbaix-2002:b
 
-@ARTICLE{2002A&A...385..686P,
-   author = {{Pourbaix}, D.},
-    title = "{Precision and accuracy of the orbital parameters derived from 2D {\amp} 1D space observations of visual or astrometric binaries}",
-  journal = {\aap},
-   eprint = {astro-ph/0201132},
-     year = 2002,
-    month = apr,
-   volume = 385,
-    pages = {686-692},
-      doi = {10.1051/0004-6361:20020149},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002A%26A...385..686P&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{1999MNRAS.310..645W,
+  author =       {{Wilkinson}, M.~I. and {Evans}, N.~W.},
+  title =        "{The present and future mass of the Milky Way halo}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/9906197},
+  year =         1999,
+  month =        dec,
+  volume =       310,
+  pages =        {645-662},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1999MNRAS.310..645W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 
 % Smolcic-2004:a
 
-@ARTICLE{2004ApJ...615L.141S,
-   author = {{Smol{\v c}i{\'c}}, V. and {Ivezi{\'c}}, {\v Z}. and {Knapp}, G.~R. and
-	{Lupton}, R.~H. and {Pavlovski}, K. and {Iliji{\'c}}, S. and
-	{Schlegel}, D. and {Smith}, J.~A. and {McGehee}, P.~M. and {Silvestri}, N.~M. and
-	{Hawley}, S.~L. and {Rockosi}, C. and {Gunn}, J.~E. and {Strauss}, M.~A. and
-	{Fan}, X. and {Eisenstein}, D. and {Harris}, H.},
-    title = "{A Second Stellar Color Locus: a Bridge from White Dwarfs to M stars}",
-  journal = {\apjl},
-   eprint = {astro-ph/0403218},
-     year = 2004,
-    month = nov,
-   volume = 615,
-    pages = {L141-L144},
-      doi = {10.1086/426475},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJ...615L.141S&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2000A&A...354..522M,
+  author =       {{Mignard}, F.},
+  title =        "{Local galactic kinematics from Hipparcos proper
+                  motions}",
+  journal =      {\aap},
+  keywords =     {ASTROMETRY, CELESTIAL MECHANICS, STELLAR DYNAMICS,
+                  GALAXY: KINEMATICS AND DYNAMICS, GALAXY: SOLAR
+                  NEIGHBOURHOOD},
+  year =         2000,
+  month =        feb,
+  volume =       354,
+  pages =        {522-536},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A%26A...354..522M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % Bretagnon1988
 
-@ARTICLE{1988A&A...202..309B,
-   author = {{Bretagnon}, P. and {Francou}, G.},
-    title = "{Planetary theories in rectangular and spherical variables - VSOP 87 solutions}",
-  journal = {\aap},
-     year = 1988,
-    month = aug,
-   volume = 202,
-    pages = {309-315},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1988A%26A...202..309B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2000A&A...355L..27H,
+  author =       {{H{\o}g}, E. and {Fabricius}, C. and {Makarov},
+                  V.~V. and {Urban}, S. and {Corbin}, T. and {Wycoff},
+                  G. and {Bastian}, U. and {Schwekendiek}, P. and
+                  {Wicenec}, A.},
+  title =        "{The Tycho-2 catalogue of the 2.5 million brightest
+                  stars}",
+  journal =      {\aap},
+  keywords =     {ASTROMETRY, STARS: FUNDAMENTAL PARAMETERS, CATALOGS},
+  year =         2000,
+  month =        mar,
+  volume =       355,
+  pages =        {L27-L30},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A%26A...355L..27H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % Bretagnon1982
 
-@ARTICLE{1982A&A...114..278B,
-   author = {{Bretagnon}, P.},
-    title = "{Theory for the motion of all the planets - The VSOP82 solution}",
-  journal = {\aap},
-     year = 1982,
-    month = oct,
-   volume = 114,
-    pages = {278-288},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1982A%26A...114..278B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2000A&AS..143...33B,
+  author =       {{Bonnarel}, F. and {Fernique}, P. and
+                  {Bienaym{\'e}}, O. and {Egret}, D. and {Genova},
+                  F. and {Louys}, M. and {Ochsenbein}, F. and
+                  {Wenger}, M. and {Bartlett}, J.~G.},
+  title =        "{The ALADIN interactive sky atlas. A reference tool
+                  for identification of astronomical sources}",
+  journal =      {\aaps},
+  keywords =     {ASTRONOMICAL DATA BASES: MISCELLANEOUS, CATALOGS,
+                  ATLASES, SURVEYS},
+  year =         2000,
+  month =        apr,
+  volume =       143,
+  pages =        {33-40},
+  doi =          {10.1051/aas:2000331},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A%26AS..143...33B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 
 % Simon1983
 
-@ARTICLE{1983A&A...120..197S,
-   author = {{Simon}, J.~L.},
-    title = "{Theory for the motion of the four giant planets - The TOP 82 solution}",
-  journal = {\aap},
-     year = 1983,
-    month = apr,
-   volume = 120,
-    pages = {197-202},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1983A%26A...120..197S&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2000ASPC..203...71E,
+  author =       {{Eyer}, L. and {Cuypers}, J.},
+  title =        "{Predictions on the Number of Variable Stars for the
+                  GAIA Space Mission and for Surveys such as the
+                  Ground-Based International Liquid Mirror Telescope}",
+  booktitle =    {ASP Conf. Ser. 203: IAU Colloq. 176: The Impact of
+                  Large-Scale Surveys on Pulsating Star Research},
+  year =         2000,
+  editor =       {{Szabados}, L. and {Kurtz}, D.},
+  pages =        {71-72},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2000ASPC..203...71E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % astro:besanconmodel
 
-@ARTICLE{2003A&A...409..523R,
-   author = {{Robin}, A.~C. and {Reyl{\'e}}, C. and {Derri{\`e}re}, S. and
-	{Picaud}, S.},
-    title = "{A synthetic view on structure and evolution of the Milky Way}",
-  journal = {\aap},
-   eprint = {astro-ph/0401052},
-     year = 2003,
-    month = oct,
-   volume = 409,
-    pages = {523-540},
-      doi = {10.1051/0004-6361:20031117},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...409..523R&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2000ASPC..216..419O,
+  author =       {{O'Mullane}, W. and {Hazell}, A. and {Bennett},
+                  K. and {Bartelmann}, M. and {Vuerli}, C.},
+  title =        "{ESA Survey Missions and Global Processing}",
+  booktitle =    {Astronomical Data Analysis Software and Systems IX},
+  year =         2000,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       216,
+  editor =       {{Manset}, N. and {Veillet}, C. and {Crabtree}, D.},
+  pages =        {419-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000ASPC..216..419O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % astro:extinctionmodel
 
-@ARTICLE{2001ApJ...556..181D,
-   author = {{Drimmel}, R. and {Spergel}, D.~N.},
-    title = "{Three-dimensional Structure of the Milky Way Disk: The Distribution of Stars and Dust beyond 0.35 R_{solar}}",
-  journal = {\apj},
-     year = 2001,
-    month = jul,
-   volume = 556,
-    pages = {181-202},
-      doi = {10.1086/321556},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001ApJ...556..181D&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2000ASSL..252..201G,
+  author =       {{Groom}, D.~E. and {Eberhard}, P.~H. and {Holland},
+                  S.~E. and {Levi}, M.~E. and {Palaio}, N.~P. and
+                  {Perlmutter}, S. and {Stover}, R.~J. and {Wei}, M.},
+  title =        "{Point-spread function in depleted and partially
+                  depleted CCDs}",
+  booktitle =    {Astrophysics and Space Science Library},
+  year =         2000,
+  series =       {Astrophysics and Space Science Library},
+  volume =       252,
+  editor =       "{P.~Amico \& J.~W.~Beletic}",
+  pages =        {201-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000ASSL..252..201G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % Haywood1997
 
-@ARTICLE{1997A&A...320..428H,
-   author = {{Haywood}, M. and {Robin}, A.~C. and {Creze}, M.},
-    title = "{The evolution of the Milky Way disc. I. Vertical structure and local constraints.}",
-  journal = {\aap},
-     year = 1997,
-    month = apr,
-   volume = 320,
-    pages = {428-439},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997A%26A...320..428H&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2000MNRAS.317..211L,
+  author =       {{Lattanzi}, M.~G. and {Spagna}, A. and {Sozzetti},
+                  A. and {Casertano}, S.  },
+  title =        "{Space-borne global astrometric surveys: the hunt
+                  for extrasolar planets}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0005024},
+  year =         2000,
+  month =        sep,
+  volume =       317,
+  pages =        {211-224},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2000MNRAS.317..211L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % gomez1997
 
-@INPROCEEDINGS{1997hipp.conf..621G,
-   author = {{Gomez}, A.~E. and {Grenier}, S. and {Udry}, S. and {Haywood}, M. and
-	{Meillon}, L. and {Sabas}, V. and {Sellier}, A. and {Morin}, D.
-	},
-    title = "{Kinematics of Disk Stars in the Solar Neighbourhood}",
-booktitle = {ESA SP-402: Hipparcos - Venice '97},
-     year = 1997,
-    pages = {621-624},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997hipp.conf..621G&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2000MNRAS.319..657H,
+  author =       {{Helmi}, A. and {de Zeeuw}, P.~T.},
+  title =        "{Mapping the substructure in the Galactic halo with
+                  the next generation of astrometric satellites}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0007166},
+  year =         2000,
+  month =        dec,
+  volume =       319,
+  pages =        {657-665},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2000MNRAS.319..657H&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % cu6:skew_technique
 
-@ARTICLE{2003MNRAS.342..151V,
-   author = {{Vande Putte}, D. and {Smith}, R.~C. and {Hawkins}, N.~A. and
-	{Martin}, J.~S.},
-    title = "{A spectroscopic search for faint secondaries in cataclysmic variables}",
-  journal = {\mnras},
-   eprint = {astro-ph/0302507},
-     year = 2003,
-    month = jun,
-   volume = 342,
-    pages = {151-162},
-      doi = {10.1046/j.1365-8711.2003.06524.x},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003MNRAS.342..151V&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2000PhRvD..62b4019K,
+  author =       {{Klioner}, S.~A. and {Soffel}, M.~H.},
+  title =        "{Relativistic celestial mechanics with PPN
+                  parameters}",
+  journal =      {\prd},
+  eprint =       {gr-qc/9906123},
+  year =         2000,
+  month =        jul,
+  volume =       62,
+  number =       2,
+  pages =        {024019-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2000PhRvD..62b4019K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % koval98
 
-@ARTICLE{1998ARA&A..36...99K,
-   author = {{Kovalevsky}, J.},
-    title = "{First Results from HIPPARCOS}",
-  journal = {\araa},
-     year = 1998,
-   volume = 36,
-    pages = {99-130},
-      doi = {10.1146/annurev.astro.36.1.99},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA%26A..36...99K&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2000SPIE.4013..453G,
+  author =       {{Gilmore}, G.~F. and {de Boer}, K.~S. and {Favata},
+                  F. and {Hoeg}, E. and {Lattanzi}, M.~G. and
+                  {Lindegren}, L. and {Luri}, X. and {Mignard}, F. and
+                  {Perryman}, M.~A. and {de Zeeuw}, P.~T.},
+  title =        "{GAIA: origin and evolution of the Milky Way}",
+  booktitle =    {Proc. SPIE Vol. 4013, p. 453-472, UV, Optical, and
+                  IR Space Telescopes and Instruments, James
+                  B. Breckinridge; Peter Jakobsen; Eds.},
+  year =         2000,
+  series =       {Presented at the Society of Photo-Optical
+                  Instrumentation Engineers (SPIE) Conference},
+  volume =       4013,
+  editor =       {{Breckinridge}, J.~B. and {Jakobsen}, P.},
+  month =        jul,
+  pages =        {453-472},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000SPIE.4013..453G},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % paper:hipquality
 
-@ARTICLE{2005A&A...439..805V,
-   author = {{van Leeuwen}, F.},
-    title = "{Rights and wrongs of the Hipparcos data. A critical quality assessment of the Hipparcos catalogue}",
-  journal = {\aap},
-   eprint = {astro-ph/0505431},
-     year = 2005,
-    month = aug,
-   volume = 439,
-    pages = {805-822},
-      doi = {10.1051/0004-6361:20053192},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...439..805V&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2001A&A...369..339P,
+  author =       {{Perryman}, M.~A.~C. and {de Boer}, K.~S. and
+                  {Gilmore}, G. and {H{\o}g}, E. and {Lattanzi},
+                  M.~G. and {Lindegren}, L. and {Luri}, X. and
+                  {Mignard}, F. and {Pace}, O. and {de Zeeuw}, P.~T.},
+  title =        "{GAIA: Composition, formation and evolution of the
+                  Galaxy}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0101235},
+  year =         2001,
+  month =        apr,
+  volume =       369,
+  pages =        {339-363},
+  doi =          {10.1051/0004-6361:20010085},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...369..339P&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % paper:hipreproc
 
-@ARTICLE{2005A&A...439..791V,
-   author = {{van Leeuwen}, F. and {Fantino}, E.},
-    title = "{A new reduction of the raw Hipparcos data}",
-  journal = {\aap},
-   eprint = {astro-ph/0505432},
-     year = 2005,
-    month = aug,
-   volume = 439,
-    pages = {791-803},
-      doi = {10.1051/0004-6361:20053193},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...439..791V&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2001A&A...373..336D,
+  author =       {{de Felice}, F. and {Bucciarelli}, B. and
+                  {Lattanzi}, M.~G. and {Vecchiato}, A.},
+  title =        "{General relativistic satellite
+                  astrometry. II. Modeling parallax and proper
+                  motion}",
+  journal =      {\aap},
+  year =         2001,
+  month =        jul,
+  volume =       373,
+  pages =        {336-344},
+  doi =          {10.1051/0004-6361:20010499},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...373..336D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % fvl97
 
-@ARTICLE{1997SSRv...81..201V,
-   author = {{van Leeuwen}, F.},
-    title = "{The HIPPARCOS Mission}",
-  journal = {Space Science Reviews},
-     year = 1997,
-    month = aug,
-   volume = 81,
-    pages = {201-409},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997SSRv...81..201V&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2001A&A...373L..21S,
+  author =       {{Sozzetti}, A. and {Casertano}, S. and {Lattanzi},
+                  M.~G. and {Spagna}, A.},
+  title =        "{Detection and measurement of planetary systems with
+                  GAIA}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0104391},
+  year =         2001,
+  month =        jul,
+  volume =       373,
+  pages =        {L21-L24},
+  doi =          {10.1051/0004-6361:20010788},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...373L..21S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % paper:RBBdL06
 
-@ARTICLE{2006MNRAS.370..141R,
-   author = {{Recio-Blanco}, A. and {Bijaoui}, A. and {de Laverny}, P.},
-    title = "{Automated derivation of stellar atmospheric parameters and chemical abundances: the MATISSE algorithm}",
-  journal = {\mnras},
-   eprint = {astro-ph/0604385},
-     year = 2006,
-    month = jul,
-   volume = 370,
-    pages = {141-150},
-      doi = {10.1111/j.1365-2966.2006.10455.x},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.370..141R&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2001ASPC..225..201O,
+  author =       {{O'Mullane}, W. and {Luri}, X.},
+  title =        "{GAIA and Virtual Observatories}",
+  booktitle =    {Virtual Observatories of the Future},
+  year =         2001,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       225,
+  editor =       {{Brunner}, R.~J. and {Djorgovski}, S.~G. and
+                  {Szalay}, A.~S.  },
+  pages =        201,
+  adsurl =       {http://adsabs.harvard.edu/abs/2001ASPC..225..201O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % helmi2000
 
-@ARTICLE{2000MNRAS.319..657H,
-   author = {{Helmi}, A. and {de Zeeuw}, P.~T.},
-    title = "{Mapping the substructure in the Galactic halo with the next generation of astrometric satellites}",
-  journal = {\mnras},
-   eprint = {astro-ph/0007166},
-     year = 2000,
-    month = dec,
-   volume = 319,
-    pages = {657-665},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2000MNRAS.319..657H&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2001ApJ...556..181D,
+  author =       {{Drimmel}, R. and {Spergel}, D.~N.},
+  title =        "{Three-dimensional Structure of the Milky Way Disk:
+                  The Distribution of Stars and Dust beyond 0.35
+                  R_{solar}}",
+  journal =      {\apj},
+  year =         2001,
+  month =        jul,
+  volume =       556,
+  pages =        {181-202},
+  doi =          {10.1086/321556},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001ApJ...556..181D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 
 % pickles1998
 
-@ARTICLE{1998PASP..110..863P,
-author = {{Pickles}, A.~J.},
-title = "{A Stellar Spectral Flux Library: 1150-25000 {\AA}}",
-journal = {\pasp},
-keywords = {ATLASES, STARS: GENERAL, GALAXIES: STELLAR CONTENT},
-year = 1998,
-month = jul,
-volume = 110,
-pages = {863-878},
-doi = {10.1086/316197},
-adsurl = {http://adsabs.harvard.edu/abs/1998PASP..110..863P},
-adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2001IAUTr..24B....R,
+  author =       {{Rickman}, H.},
+  title =        "{Transactions of the International Astronomical
+                  Union Proceedings of the Twenty-Fourth General
+                  Assembly.}",
+  journal =      {Transactions of the International Astronomical Union
+                  Proceedings of the Twenty-Fourth General
+                  Assembly.~Editedy by Hans Rickman.~ ISBN:
+                  1-58381-087-0.~San Francisco: Astronomical Society
+                  of the Pacific, 2001.},
+  year =         2001,
+  volume =       24,
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001IAUTr..24B....R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % soderhjelm2004
 
-@INPROCEEDINGS{2005tdug.conf...97S,
-   author = {{S}\"{o}derhjelm, S.},
-    title = "{Census of Binaries the Big Picture}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.},
-    month = jan,
-    pages = {97-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib\_query?bibcode=2005tdug.conf...97S&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2001astro.ph..7457K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{A Practical Relativistic Model of Microarcsecond
+                  Astrometry in Space}",
+  journal =      {ArXiv Astrophysics e-prints},
+  eprint =       {astro-ph/0107457},
+  year =         2001,
+  month =        jul,
+  adsurl =       {http://adsabs.harvard.edu/abs/2001astro.ph..7457K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % spite2004
-@INPROCEEDINGS{2005tdug.conf..645S,
-   author = {{Spite}, M.},
-    title = "{Gaia, the Oldest Stars and the Early Universe}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {645-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..645S&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+
+@BOOK{2001sccd.book.....J,
+  author =       {{Janesick}, J.~R.},
+  title =        "{Scientific charge-coupled devices}",
+  keywords =     {CHARGE COUPLED DEVICES, OPTICAL INSTRUMENTS},
+  booktitle =    {Scientific charge-coupled devices, Bellingham, WA:
+                  SPIE Optical Engineering Press, 2001, xvi, 906
+                  p.~SPIE Press monograph, PM 83.~ISBN 0819436984},
+  year =         2001,
+  editor =       "{Janesick, J.~R.}",
+  adsurl =       {http://adsabs.harvard.edu/abs/2001sccd.book.....J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % wilkinson1999
 
-@ARTICLE{1999MNRAS.310..645W,
-   author = {{Wilkinson}, M.~I. and {Evans}, N.~W.},
-    title = "{The present and future mass of the Milky Way halo}",
-  journal = {\mnras},
-   eprint = {astro-ph/9906197},
-     year = 1999,
-    month = dec,
-   volume = 310,
-    pages = {645-662},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1999MNRAS.310..645W&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2002A&A...385..686P,
+  author =       {{Pourbaix}, D.},
+  title =        "{Precision and accuracy of the orbital parameters
+                  derived from 2D {\amp} 1D space observations of
+                  visual or astrometric binaries}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0201132},
+  year =         2002,
+  month =        apr,
+  volume =       385,
+  pages =        {686-692},
+  doi =          {10.1051/0004-6361:20020149},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002A%26A...385..686P&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % wilkinson2004a
 
-@INPROCEEDINGS{2005tdug.conf..651W,
-   author = {{Wilkinson}, M.~I.},
-    title = "{Dark Matter in the Local Group}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {651-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..651W&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2002ASPC..259..160E,
+  author =       {{Eyer}, L. and {Blake}, C.},
+  title =        "{Automated Classification of Variable Stars for ASAS
+                  Data}",
+  booktitle =    {ASP Conf. Ser. 259: IAU Colloq. 185: Radial and
+                  Nonradial Pulsationsn as Probes of Stellar Physics},
+  year =         2002,
+  editor =       {{Aerts}, C. and {Bedding}, T.~R. and
+                  {Christensen-Dalsgaard}, J.  },
+  pages =        {160-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2002ASPC..259..160E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % wilkinson2004b
 
-@ARTICLE{2005MNRAS.359.1306W,
-   author = {{Wilkinson}, M.~I. and {Vallenari}, A. and {Turon}, C. and {Munari}, U. and
-	{Katz}, D. and {Bono}, G. and {Cropper}, M. and {Helmi}, A. and
-	{Robichon}, N. and {Th{\'e}venin}, F. and {Vidrih}, S. and {Zwitter}, T. and
-	{Arenou}, F. and {Baylac}, M.-O. and {Bertelli}, G. and {Bijaoui}, A. and
-	{Boschi}, F. and {Castelli}, F. and {Crifo}, F. and {David}, M. and
-	{Gomboc}, A. and {G{\'o}mez}, A. and {Haywood}, M. and {Jauregi}, U. and
-	{de Laverny}, P. and {Lebreton}, Y. and {Marrese}, P. and {Marsh}, T. and
-	{Mignot}, S. and {Morin}, D. and {Pasetto}, S. and {Perryman}, M. and
-	{Pr{\v s}a}, A. and {Recio-Blanco}, A. and {Royer}, F. and {Sellier}, A. and
-	{Siviero}, A. and {Sordo}, R. and {Soubiran}, C. and {Tomasella}, L. and
-	{Viala}, Y.},
-    title = "{Spectroscopic survey of the Galaxy with Gaia- II. The expected science yield from the Radial Velocity Spectrometer}",
-  journal = {\mnras},
-   eprint = {astro-ph/0506083},
-     year = 2005,
-    month = jun,
-   volume = 359,
-    pages = {1306-1335},
-      doi = {10.1111/j.1365-2966.2005.09012.x},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.359.1306W&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2002AcA....52..241E,
+  author =       {{Eyer}, L.},
+  title =        "{Search for QSO Candidates in OGLE-II Data}",
+  journal =      {Acta Astronomica},
+  eprint =       {astro-ph/0206074},
+  year =         2002,
+  month =        sep,
+  volume =       52,
+  pages =        {241-262},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002AcA....52..241E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % crosta06
 
-@ARTICLE{2006CQGra..23.4853C,
-   author = {{Crosta}, M.~T. and {Mignard}, F.},
-    title = "{Microarcsecond light bending by Jupiter}",
-  journal = {Classical and Quantum Gravity},
-   eprint = {astro-ph/0512359},
-     year = 2006,
-    month = aug,
-   volume = 23,
-    pages = {4853-4871},
-      doi = {10.1088/0264-9381/23/15/006},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006CQGra..23.4853C&db_key=PHY},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2002Ap&SS.280...21B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{Determination of Stellar Parameters with GAIA}",
+  journal =      {Astrophysics and Space Science},
+  eprint =       {astro-ph/0201014},
+  year =         2002,
+  volume =       280,
+  pages =        {21-29},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Ap%26SS.280...21B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % paper:tdi
 
-@ARTICLE{2005A&A...438..745B,
-   author = {{Bastian}, U. and {Biermann}, M.},
-    title = "{Astrometric meaning and interpretation of high-precision time delay integration CCD data}",
-  journal = {\aap},
-     year = 2005,
-    month = aug,
-   volume = 438,
-    pages = {745-755},
-      doi = {10.1051/0004-6361:20042372},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...438..745B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2002EAS.....2..107M,
+  author =       {{Mignard}, F.},
+  title =        "{Fundamental Physics with GAIA}",
+  booktitle =    {EAS Publications Series},
+  year =         2002,
+  series =       {Engineering and Science},
+  volume =       2,
+  editor =       {{Bienayme}, O. and {Turon}, C.},
+  pages =        {107-121},
+  adsurl =       {http://adsabs.harvard.edu/abs/2002EAS.....2..107M},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@PHDTHESIS{crosta03,
-   author = {{Crosta}, M.~T.},
-    title = "{Methods of Relativistic Astrometry for the analysis of
-astrometric data in the Solar System gravitational field}",
-     year = 2003
+@ARTICLE{2002Icar..158..106B,
+  author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
+  title =        "{Phase II of the Small Main-Belt Asteroid
+                  Spectroscopic SurveyThe Observations}",
+  journal =      {Icarus},
+  year =         2002,
+  month =        jul,
+  volume =       158,
+  pages =        {106-145},
+  doi =          {10.1006/icar.2002.6857},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Icar..158..106B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % defelice3
 
-@ARTICLE{2006ApJ...653.1552D,
-   author = {{de Felice}, F. and {Vecchiato}, A. and {Crosta}, M.~T. and
-	{Lattanzi}, M.~G. and {Bucciarelli}, B.},
-    title = "{A general relativistic model for the light propagation in the gravitational field of the  Solar System: the dynamical case}",
-  journal = {\apj},
-     year = 2006,
-    month = {},
-   volume = 653,
-    pages = {1552},
-      doi = {10.1051/0004-6361:20042372},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006ApJ...653.1552D&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2002Icar..158..146B,
+  author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
+  title =        "{Phase II of the Small Main-Belt Asteroid
+                  Spectroscopic SurveyA Feature-Based Taxonomy}",
+  journal =      {Icarus},
+  year =         2002,
+  month =        jul,
+  volume =       158,
+  pages =        {146-177},
+  doi =          {10.1006/icar.2002.6856},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Icar..158..146B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % busonero1
 
-@ARTICLE{2006A&A...449..827B,
-   author = {{Busonero}, D. and {Gai}, M. and {Gardiol}, D. and {Lattanzi}, M.~G. and
-	{Loreggia}, D.},
-    title = "{Chromaticity in all-reflective telescopes for astrometry}",
-  journal = {\aap},
-   eprint = {astro-ph/0511572},
-     year = 2006,
-    month = apr,
-   volume = 449,
-    pages = {827-836},
-      doi = {10.1051/0004-6361:20054180},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006A%26A...449..827B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2002SPIE.4836..333S,
+  author =       {{Szalay}, A.~S. and {Gray}, J. and {VandenBerg}, J.},
+  title =        "{Petabyte Scale Data Mining: Dream or Reality?}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2002,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       4836,
+  eprint =       {arXiv:cs/0208013},
+  editor =       "{J.~A.~Tyson \& S.~Wolff}",
+  month =        dec,
+  pages =        {333-338},
+  doi =          {10.1117/12.461427},
+  adsurl =       {http://adsabs.harvard.edu/abs/2002SPIE.4836..333S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % gai2
 
-@INPROCEEDINGS{2005tdug.conf..433G,
-   author = {{Gai}, M. and {Busonero}, D. and {Gardiol}, D. and {Loreggia}, D.
-	},
-    title = "{The Gaia Focal Plane to Sky Mapping: A Sample of Calibration Issues}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {433-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..433G&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2002cs........2013S,
+  author =       {{Szalay}, A.~S. and {Gray}, J. and {Thakar},
+                  A.~R. and {Kunszt}, P.~Z. and {Malik}, T. and
+                  {Raddick}, J. and {Stoughton}, C. and {vandenBerg},
+                  J.  },
+  title =        "{The SDSS SkyServer: Public Access to the Sloan
+                  Digital Sky Server Data}",
+  journal =      {eprint arXiv:cs/0202013},
+  eprint =       {arXiv:cs/0202013},
+  keywords =     {Computer Science - Digital Libraries, Computer
+                  Science - Databases, H.3.7, H.3.5, H.2, H.3, H.4,
+                  H.5},
+  year =         2002,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2002cs........2013S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % paper:jfc06QSO
 
-@ARTICLE{2006MNRAS.367..879C,
-   author = {{Claeskens}, J.-F. and {Smette}, A. and {Vandenbulcke}, L. and
-	{Surdej}, J.},
-    title = "{Identification and redshift determination of quasi-stellar objects with medium-band photometry: application to Gaia}",
-  journal = {\mnras},
-     year = 2006,
-    month = apr,
-   volume = 367,
-    pages = {879-904},
-      doi = {10.1111/j.1365-2966.2006.10024.x},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.367..879C&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003A&A...399..337V,
+  author =       {{Vecchiato}, A. and {Lattanzi}, M.~G. and
+                  {Bucciarelli}, B. and {Crosta}, M. and {de Felice},
+                  F. and {Gai}, M.},
+  title =        "{Testing general relativity by micro-arcsecond
+                  global astrometry}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0301323},
+  year =         2003,
+  month =        feb,
+  volume =       399,
+  pages =        {337-342},
+  doi =          {10.1051/0004-6361:20021785},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...399..337V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % paper:gtr04QSO
 
-@ARTICLE{2004ApJS..155..257R,
-   author = {{Richards}, G.~T. and {Nichol}, R.~C. and {Gray}, A.~G. and
-	{Brunner}, R.~J. and {Lupton}, R.~H. and {Vanden Berk}, D.~E. and
-	{Chong}, S.~S. and {Weinstein}, M.~A. and {Schneider}, D.~P. and
-	{Anderson}, S.~F. and {Munn}, J.~A. and {Harris}, H.~C. and
-	{Strauss}, M.~A. and {Fan}, X. and {Gunn}, J.~E. and {Ivezi{\'c}}, {\v Z}. and
-	{York}, D.~G. and {Brinkmann}, J. and {Moore}, A.~W.},
-    title = "{Efficient Photometric Selection of Quasars from the Sloan Digital Sky Survey: 100,000 z {\lt} 3 Quasars from Data Release One}",
-  journal = {\apjs},
-   eprint = {astro-ph/0408505},
-     year = 2004,
-    month = dec,
-   volume = 155,
-    pages = {257-269},
-      doi = {10.1086/425356},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJS..155..257R&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003A&A...409..523R,
+  author =       {{Robin}, A.~C. and {Reyl{\'e}}, C. and
+                  {Derri{\`e}re}, S. and {Picaud}, S.},
+  title =        "{A synthetic view on structure and evolution of the
+                  Milky Way}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0401052},
+  year =         2003,
+  month =        oct,
+  volume =       409,
+  pages =        {523-540},
+  doi =          {10.1051/0004-6361:20031117},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...409..523R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % paper:le02QSO
 
-@ARTICLE{2002AcA....52..241E,
-   author = {{Eyer}, L.},
-    title = "{Search for QSO Candidates in OGLE-II Data}",
-  journal = {Acta Astronomica},
-   eprint = {astro-ph/0206074},
-     year = 2002,
-    month = sep,
-   volume = 52,
-    pages = {241-262},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002AcA....52..241E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003A&A...410.1063K,
+  author =       {{Klioner}, S.~A. and {Peip}, M.},
+  title =        "{Numerical simulations of the light propagation in
+                  the gravitational field of moving bodies}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0305204},
+  year =         2003,
+  month =        nov,
+  volume =       410,
+  pages =        {1063-1074},
+  doi =          {10.1051/0004-6361:20031283},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...410.1063K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % munari1999
 
-@ARTICLE{1999A&AS..137..521M,
-   author = {{Munari}, U. and {Tomasella}, L.},
-    title = "{High resolution spectroscopy over lambda lambda 8500-8750 {\AA} for GAIA. I. Mapping the MKK classification system}",
-  journal = {\aaps},
-     year = 1999,
-    month = jun,
-   volume = 137,
-    pages = {521-528},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1999A%26AS..137..521M&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003A&A...412..105M,
+  author =       {{Moniez}, M.},
+  title =        "{Does transparent hidden matter generate optical
+                  scintillation?}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0302460},
+  keywords =     {cosmology: dark matter, Galaxy: disk, Galaxy: halo,
+                  ISM: clouds, ISM: molecules},
+  year =         2003,
+  month =        dec,
+  volume =       412,
+  pages =        {105-120},
+  doi =          {10.1051/0004-6361:20031478},
+  adsurl =       {http://adsabs.harvard.edu/abs/2003A%26A...412..105M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % paper:sozzrev
 
-@ARTICLE{2005PASP..117.1021S,
-   author = {{Sozzetti}, A.},
-    title = "{Astrometric Methods and Instrumentation to Identify and Characterize Extrasolar Planets: A Review}",
-  journal = {\pasp},
-   eprint = {astro-ph/0507115},
-     year = 2005,
-    month = oct,
-   volume = 117,
-    pages = {1021-1048},
-      doi = {10.1086/444487},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005PASP..117.1021S&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003AJ....125.1580K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{A Practical Relativistic Model for Microarcsecond
+                  Astrometry in Space}",
+  journal =      {\aj},
+  year =         2003,
+  month =        mar,
+  volume =       125,
+  pages =        {1580-1597},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003AJ....125.1580K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % paper:c1bc1m
 
-@ARTICLE{2006MNRAS.367..290J,
-   author = {{Jordi}, C. and {H{\o}g}, E. and {Brown}, A.~G.~A. and {Lindegren}, L. and
-	{Bailer-Jones}, C.~A.~L. and {Carrasco}, J.~M. and {Knude}, J. and
-	{Strai{\v z}ys}, V. and {de Bruijne}, J.~H.~J. and {Claeskens}, J.-F. and
-	{Drimmel}, R. and {Figueras}, F. and {Grenon}, M. and {Kolka}, I. and
-	{Perryman}, M.~A.~C. and {Tautvai{\v s}ien{\.e}}, G. and {Vansevi{\v c}ius}, V. and
-	{Willemsen}, P.~G. and {Brid{\v z}ius}, A. and {Evans}, D.~W. and
-	{Fabricius}, C. and {Fiorucci}, M. and {Heiter}, U. and {Kaempf}, T.~A. and
-	{Kazlauskas}, A. and {Ku{\v c}inskas}, A. and {Malyuto}, V. and
-	{Munari}, U. and {Reyl{\'e}}, C. and {Torra}, J. and {Vallenari}, A. and
-	{Zdanavi{\v c}ius}, K. and {Korakitis}, R. and {Malkov}, O. and
-	{Smette}, A.},
-    title = "{The design and performance of the Gaia photometric system}",
-  journal = {\mnras},
-   eprint = {astro-ph/0512038},
-     year = 2006,
-    month = mar,
-   volume = 367,
-    pages = {290-314},
-      doi = {10.1111/j.1365-2966.2005.09944.x},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.367..290J&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003AJ....126.2687S,
+  author =       {{Soffel}, M. and {Klioner}, S.~A. and {Petit},
+                  G. and {Wolf}, P. and {Kopeikin}, S.~M. and
+                  {Bretagnon}, P. and {Brumberg},
+                  V.~A. and1998A&A...340..309M1998A&A...340..309M
+                  {Capitaine}, N. and {Damour}, T. and {Fukushima},
+                  T. and {Guinot}, B. and {Huang}, T.-Y. and
+                  {Lindegren}, L. and {Ma}, C. and {Nordtvedt}, K. and
+                  {Ries}, J.~C. and {Seidelmann}, P.~K. and
+                  {Vokrouhlick{\'y}}, D. and {Will}, C.~M. and {Xu},
+                  C.},
+  title =        "{The IAU 2000 Resolutions for Astrometry, Celestial
+                  Mechanics, and Metrology in the Relativistic
+                  Framework: Explanatory Supplement}",
+  journal =      {\aj},
+  eprint =       {astro-ph/0303376},
+  year =         2003,
+  month =        dec,
+  volume =       126,
+  pages =        {2687-2706},
+  doi =          {10.1086/378162},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003AJ....126.2687S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % brettetal2004
 
-@ARTICLE{2004MNRAS.353..369B,
-   author = {{Brett}, D.~R. and {West}, R.~G. and {Wheatley}, P.~J.},
-    title = "{The automated classification of astronomical light curves using {K}ohonen self-organizing maps}",
-  journal = {\mnras},
-   eprint = {astro-ph/0408118},
-     year = 2004,
-    month = sep,
-   volume = 353,
-    pages = {369-376},
-      doi = {10.1111/j.1365-2966.2004.08093.x},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2004MNRAS.353..369B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2003ASPC..295..261M,
+  author =       {{Miller}, III, W.~W. and {Sontag}, C. and {Rose},
+                  J.~F.},
+  title =        "{OPUS: A CORBA Pipeline for Java, Python, and Perl
+                  Applications}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XII},
+  year =         2003,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       295,
+  editor =       {{Payne}, H.~E. and {Jedrzejewski}, R.~I. and {Hook},
+                  R.~N.},
+  pages =        {261-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2003ASPC..295..261M},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % evansbelokurov2005
 
-@INPROCEEDINGS{2005tdug.conf..385W,
-   author = {{Evans}, N.~W. and {Belokurov}, V.},
-    title = "{A {P}rototype for {S}cience {A}lerts}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {385-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..385W&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2003ASPC..298..199B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{On the classification and parametrization of GAIA
+                  data using pattern recognition methods}",
+  booktitle =    {GAIA Spectroscopy: Science and Technology},
+  year =         2003,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       298,
+  editor =       {{Munari}, U.},
+  pages =        {199-+},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/2003ASPC..298..199B},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % eyergrenon1997
 
-@INPROCEEDINGS{1997hipp.conf..467E,
-   author = {{Eyer}, L. and {Grenon}, M.},
-    title = "{Photometric {V}ariability in the {HR} {D}iagram}",
-booktitle = {ESA SP-402: Hipparcos - Venice '97},
-     year = 1997,
-    pages = {467-472},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1997hipp.conf..467E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003CQGra..20.4695B,
+  author =       {{Bini}, D. and {Crosta}, M.~T. and {de Felice}, F.},
+  title =        "{Orbiting frames and satellite attitudes in
+                  relativistic astrometry}",
+  journal =      {Classical and Quantum Gravity},
+  year =         2003,
+  month =        nov,
+  volume =       20,
+  pages =        {4695-4706},
+  doi =          {10.1088/0264-9381/20/21/009},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003CQGra..20.4695B&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % eyercuypers2000
 
-@INPROCEEDINGS{2000ASPC..203...71E,
-   author = {{Eyer}, L. and {Cuypers}, J.},
-    title = "{Predictions on the Number of Variable Stars for the GAIA Space Mission and for Surveys such as the Ground-Based International Liquid Mirror Telescope}",
-booktitle = {ASP Conf. Ser. 203: IAU Colloq. 176: The Impact of Large-Scale Surveys on Pulsating Star Research},
-     year = 2000,
-   editor = {{Szabados}, L. and {Kurtz}, D.},
-    pages = {71-72},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2000ASPC..203...71E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2003MNRAS.342..151V,
+  author =       {{Vande Putte}, D. and {Smith}, R.~C. and {Hawkins},
+                  N.~A. and {Martin}, J.~S.},
+  title =        "{A spectroscopic search for faint secondaries in
+                  cataclysmic variables}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0302507},
+  year =         2003,
+  month =        jun,
+  volume =       342,
+  pages =        {151-162},
+  doi =          {10.1046/j.1365-8711.2003.06524.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003MNRAS.342..151V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % eyerblake2002
 
-@INPROCEEDINGS{2002ASPC..259..160E,
-   author = {{Eyer}, L. and {Blake}, C.},
-    title = "{Automated Classification of Variable Stars for ASAS Data}",
-booktitle = {ASP Conf. Ser. 259: IAU Colloq. 185: Radial and Nonradial Pulsationsn as Probes of Stellar Physics},
-     year = 2002,
-   editor = {{Aerts}, C. and {Bedding}, T.~R. and {Christensen-Dalsgaard}, J.
-	},
-    pages = {160-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2002ASPC..259..160E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2004A&A...419..385B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{Evolutionary design of photometric systems and its
+                  application to Gaia}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0402591},
+  year =         2004,
+  month =        may,
+  volume =       419,
+  pages =        {385-403},
+  doi =          {10.1051/0004-6361:20035779},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004A%26A...419..385B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % eyer2005
 
-@INPROCEEDINGS{2005tdug.conf..513E,
-   author = {{Eyer}, L.},
-    title = "{Variability Analysis: Detection and Classification}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {513-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..513E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2004ASPC..314..293Y,
+  author =       {{Yasuda}, N. and {Mizumoto}, Y. and {Ohishi}, M. and
+                  {O'Mullane}, W. and {Budav{\'a}ri}, T. and
+                  {Haridas}, V. and {Li}, N. and {Malik}, T. and
+                  {Szalay}, A.~S. and {Hill}, M. and {Linde}, T. and
+                  {Mann}, B. and {Page}, C.~G.},
+  title =        "{Astronomical Data Query Language: Simple Query
+                  Protocol for the Virtual Observatory}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  (ADASS) XIII},
+  year =         2004,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       314,
+  editor =       "{F.~Ochsenbein, M.~G.~Allen, \& D.~Egret}",
+  month =        jul,
+  pages =        293,
+  adsurl =       {http://adsabs.harvard.edu/abs/2004ASPC..314..293Y},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % eyerblake2005
 
-@ARTICLE{2005MNRAS.358...30E,
-   author = {{Eyer}, L. and {Blake}, C.},
-    title = "{Automated classification of variable stars for All-Sky Automated Survey 1-2 data}",
-  journal = {\mnras},
-   eprint = {astro-ph/0406333},
-     year = 2005,
-    month = mar,
-   volume = 358,
-    pages = {30-38},
-      doi = {10.1111/j.1365-2966.2005.08651.x},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.358...30E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2004ASPC..314..376W,
+  author =       {{Wieprecht}, E. and {Brumfit}, J. and {Bakker},
+                  J. and {de Candussio}, N. and {Guest}, S. and
+                  {Huygen}, R. and {de Jonge}, A. and {Matthieu},
+                  J.~J. and {Osterhage}, S. and {Ott}, S. and
+                  {Siddiqui}, H. and {Vandenbussche}, B. and {de
+                  Meester}, W. and {Wetzstein}, M. and {Wiezorrek},
+                  E. and {Zaal}, P.},
+  title =        "{The HERSCHEL/PACS Common Software System as Data
+                  Reduction System}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  (ADASS) XIII},
+  year =         2004,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       314,
+  editor =       {{Ochsenbein}, F. and {Allen}, M.~G. and {Egret}, D.},
+  month =        jul,
+  pages =        {376-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004ASPC..314..376W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % eyermignard2005
 
-@ARTICLE{2005MNRAS.361.1136E,
-   author = {{Eyer}, L. and {Mignard}, F.},
-    title = "{Rate of correct detection of periodic signal with the Gaia satellite}",
-  journal = {\mnras},
-     year = 2005,
-    month = aug,
-   volume = 361,
-    pages = {1136-1144},
-      doi = {10.1111/j.1365-2966.2005.09266.x},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.361.1136E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2004ASPC..314..585P,
+  author =       {{Plante}, R. and {Greene}, G. and {Hanisch}, R. and
+                  {McGlynn}, T. and {O'Mullane}, W. and {Williamson},
+                  R.},
+  title =        "{Resource Registries for the Virtual Observatory}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  (ADASS) XIII},
+  year =         2004,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       314,
+  editor =       "{F.~Ochsenbein, M.~G.~Allen, \& D.~Egret}",
+  month =        jul,
+  pages =        585,
+  adsurl =       {http://adsabs.harvard.edu/abs/2004ASPC..314..585P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 
 % eyer2006a
 
-@ARTICLE{2006MmSAI..77..549E,
-   author = {{Eyer}, L.},
-    title = "{The Gaia mission . Pulsating stars with Gaia}",
-  journal = {Memorie della Societa Astronomica Italiana},
-   eprint = {astro-ph/0511460},
-     year = 2006,
-   volume = 77,
-    pages = {549-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006MmSAI..77..549E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2004ApJ...607..580D,
+  author =       {{de Felice}, F. and {Crosta}, M.~T. and {Vecchiato},
+                  A. and {Lattanzi}, M.~G. and {Bucciarelli}, B.},
+  title =        "{A General Relativistic Model of Light Propagation
+                  in the Gravitational Field of the Solar System: The
+                  Static Case}",
+  journal =      {\apj},
+  eprint =       {astro-ph/0401637},
+  year =         2004,
+  month =        may,
+  volume =       607,
+  pages =        {580-595},
+  doi =          {10.1086/383244},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJ...607..580D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % eyer2006b
 
-@INPROCEEDINGS{2006ASPC..349...15E,
-   author = {{Eyer}, L.},
-    title = "{Astronomical Databases, Space Photometry and Time Series Analysis: Open Questions}",
-booktitle = {Astronomical Society of the Pacific Conference Series},
-     year = 2006,
-   editor = {{Sterken}, C. and {Aerts}, C.},
-    month = apr,
-    pages = {15-+},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006ASPC..349...15E&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2004ApJ...615L.141S,
+  author =       {{Smol{\v c}i{\'c}}, V. and {Ivezi{\'c}}, {\v Z}. and
+                  {Knapp}, G.~R. and {Lupton}, R.~H. and {Pavlovski},
+                  K. and {Iliji{\'c}}, S. and {Schlegel}, D. and
+                  {Smith}, J.~A. and {McGehee}, P.~M. and {Silvestri},
+                  N.~M. and {Hawley}, S.~L. and {Rockosi}, C. and
+                  {Gunn}, J.~E. and {Strauss}, M.~A. and {Fan}, X. and
+                  {Eisenstein}, D. and {Harris}, H.},
+  title =        "{A Second Stellar Color Locus: a Bridge from White
+                  Dwarfs to M stars}",
+  journal =      {\apjl},
+  eprint =       {astro-ph/0403218},
+  year =         2004,
+  month =        nov,
+  volume =       615,
+  pages =        {L141-L144},
+  doi =          {10.1086/426475},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJ...615L.141S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % protopapasetal2006
 
-@ARTICLE{2006MNRAS.369..677P,
-   author = {{Protopapas}, P. and {Giammarco}, J.~M. and {Faccioli}, L. and
-	{Struble}, M.~F. and {Dave}, R. and {Alcock}, C.},
-    title = "{Finding outlier light curves in catalogues of periodic variable stars}",
-  journal = {\mnras},
-   eprint = {astro-ph/0505495},
-     year = 2006,
-    month = jun,
-   volume = 369,
-    pages = {677-696},
-      doi = {10.1111/j.1365-2966.2006.10327.x},
-   adsurl = {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006MNRAS.369..677P&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2004ApJS..155..257R,
+  author =       {{Richards}, G.~T. and {Nichol}, R.~C. and {Gray},
+                  A.~G. and {Brunner}, R.~J. and {Lupton}, R.~H. and
+                  {Vanden Berk}, D.~E. and {Chong}, S.~S. and
+                  {Weinstein}, M.~A. and {Schneider}, D.~P. and
+                  {Anderson}, S.~F. and {Munn}, J.~A. and {Harris},
+                  H.~C. and {Strauss}, M.~A. and {Fan}, X. and {Gunn},
+                  J.~E. and {Ivezi{\'c}}, {\v Z}. and {York},
+                  D.~G. and {Brinkmann}, J. and {Moore}, A.~W.},
+  title =        "{Efficient Photometric Selection of Quasars from the
+                  Sloan Digital Sky Survey: 100,000 z {\lt} 3 Quasars
+                  from Data Release One}",
+  journal =      {\apjs},
+  eprint =       {astro-ph/0408505},
+  year =         2004,
+  month =        dec,
+  volume =       155,
+  pages =        {257-269},
+  doi =          {10.1086/425356},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJS..155..257R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % moniez2003
 
-@ARTICLE{2003A&A...412..105M,
-   author = {{Moniez}, M.},
-    title = "{Does transparent hidden matter generate optical scintillation?}",
-  journal = {\aap},
-   eprint = {astro-ph/0302460},
- keywords = {cosmology: dark matter, Galaxy: disk, Galaxy: halo, ISM: clouds, ISM: molecules},
-     year = 2003,
-    month = dec,
-   volume = 412,
-    pages = {105-120},
-      doi = {10.1051/0004-6361:20031478},
-   adsurl = {http://adsabs.harvard.edu/abs/2003A%26A...412..105M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2004MNRAS.353..369B,
+  author =       {{Brett}, D.~R. and {West}, R.~G. and {Wheatley},
+                  P.~J.},
+  title =        "{The automated classification of astronomical light
+                  curves using {K}ohonen self-organizing maps}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0408118},
+  year =         2004,
+  month =        sep,
+  volume =       353,
+  pages =        {369-376},
+  doi =          {10.1111/j.1365-2966.2004.08093.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2004MNRAS.353..369B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % cu8:cbjparis
 
-@INPROCEEDINGS{2005tdug.conf..393B,
-   author = {{Bailer-Jones}, C.~A.~L.},
-    title = "{Object Classification and the Determination of Stellar Parameters}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {393-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..393B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2004PhR...400..209K,
+  author =       {{Kopeikin}, S. and {Vlasov}, I.},
+  title =        "{Parametrized post-Newtonian theory of reference
+                  frames, multipolar expansions and equations of
+                  motion in the N-body problem}",
+  journal =      {\physrep},
+  eprint =       {gr-qc/0403068},
+  year =         2004,
+  month =        nov,
+  volume =       400,
+  pages =        {209-318},
+  doi =          {10.1016/j.physrep.2004.08.004},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004PhR...400..209K&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % cu8:cbjhfd
 
-@ARTICLE{2004A&A...419..385B,
-   author = {{Bailer-Jones}, C.~A.~L.},
-    title = "{Evolutionary design of photometric systems and its application to Gaia}",
-  journal = {\aap},
-   eprint = {astro-ph/0402591},
-     year = 2004,
-    month = may,
-   volume = 419,
-    pages = {385-403},
-      doi = {10.1051/0004-6361:20035779},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004A%26A...419..385B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2004PhRvD..69l4001K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{Physically adequate proper reference system of a
+                  test observer and relativistic description of the
+                  GAIA attitude}",
+  journal =      {Phys. Rev. D},
+  eprint =       {astro-ph/0311540},
+  year =         2004,
+  month =        jun,
+  volume =       69,
+  number =       12,
+  pages =        {124001-+},
+  doi =          {10.1103/PhysRevD.69.124001},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004PhRvD..69l4001K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % cu8:cbjvilnius
 
-@ARTICLE{2002Ap&SS.280...21B,
-   author = {{Bailer-Jones}, C.~A.~L.},
-    title = "{Determination of Stellar Parameters with GAIA}",
-  journal = {Astrophysics and Space Science},
-   eprint = {astro-ph/0201014},
-     year = 2002,
-   volume = 280,
-    pages = {21-29},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Ap%26SS.280...21B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2004SPIE.5494..529B,
+  author =       {{Baccaro}, S. and {Cecilia}, A. and {Di Sarcina},
+                  I. and {Piegari}, A.~M.  },
+  title =        "{Optical coating behavior under y irradiation for
+                  space applications}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2004,
+  series =       {Presented at the Society of Photo-Optical
+                  Instrumentation Engineers (SPIE) Conference},
+  volume =       5494,
+  editor =       "{E.~Atad-Ettedgui \& P.~Dierickx}",
+  month =        sep,
+  pages =        {529-535},
+  doi =          {10.1117/12.553602},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004SPIE.5494..529B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % cu8:baselmethod
 
-@ARTICLE{1998A&AS..130...65L,
-   author = {{Lejeune}, T. and {Cuisinier}, F. and {Buser}, R.},
-    title = "{A standard stellar library for evolutionary synthesis. II. The M dwarf extension}",
-  journal = {\aaps},
-   eprint = {astro-ph/9710350},
-     year = 1998,
-    month = may,
-   volume = 130,
-    pages = {65-75},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998A%26AS..130...65L&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2004SPIE.5495...23J,
+  author =       {{Jessen}, N.~C. and {N{\o}rgaard-Nielsen}, H.~U. and
+                  {Stevenson}, T. and {Sykes}, J. and {Schroll},
+                  J. and {Hastings}, P.},
+  title =        "{The CFRP primary structure of the MIRI instrument
+                  onboard the James Webb Space Telescope}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2004,
+  series =       {Presented at the Society of Photo-Optical
+                  Instrumentation Engineers (SPIE) Conference},
+  volume =       5495,
+  editor =       "{J.~Antebi \& D.~Lemke}",
+  month =        sep,
+  pages =        {23-30},
+  doi =          {10.1117/12.550023},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004SPIE.5495...23J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % mpclass:bus2002b
 
-@ARTICLE{2002Icar..158..146B,
-   author = {{Bus}, S.~J. and {Binzel}, R.~P.},
-    title = "{Phase II of the Small Main-Belt Asteroid Spectroscopic SurveyA Feature-Based Taxonomy}",
-  journal = {Icarus},
-     year = 2002,
-    month = jul,
-   volume = 158,
-    pages = {146-177},
-      doi = {10.1006/icar.2002.6856},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Icar..158..146B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2004SPIE.5497..461G,
+  author =       {{Gardiol}, D. and {Loreggia}, D. and {Mannu}, S. and
+                  {Mottini}, S. and {Perachino}, L. and {Gai}, M. and
+                  {Lattanzi}, M.~G.},
+  title =        "{End-to-end optomechanical simulation for
+                  high-precision global astrometry}",
+  booktitle =    {Modeling and Systems Engineering for Astronomy.
+                  Edited by Craig, Simon C.; Cullum, Martin J.
+                  Proceedings of the SPIE, Volume 5497, pp. 461-470
+                  (2004).},
+  year =         2004,
+  editor =       {{Craig}, S.~C. and {Cullum}, M.~J.},
+  month =        sep,
+  pages =        {461-470},
+  doi =          {10.1117/12.550356},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004SPIE.5497..461G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % mpclass:bus2002a
 
-@ARTICLE{2002Icar..158..106B,
-   author = {{Bus}, S.~J. and {Binzel}, R.~P.},
-    title = "{Phase II of the Small Main-Belt Asteroid Spectroscopic SurveyThe Observations}",
-  journal = {Icarus},
-     year = 2002,
-    month = jul,
-   volume = 158,
-    pages = {106-145},
-      doi = {10.1006/icar.2002.6857},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Icar..158..106B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2005A&A...438..745B,
+  author =       {{Bastian}, U. and {Biermann}, M.},
+  title =        "{Astrometric meaning and interpretation of
+                  high-precision time delay integration CCD data}",
+  journal =      {\aap},
+  year =         2005,
+  month =        aug,
+  volume =       438,
+  pages =        {745-755},
+  doi =          {10.1051/0004-6361:20042372},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...438..745B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % mpclass:Zellner
 
-@ARTICLE{1985Icar...61..355Z,
-   author = {{Zellner}, B. and {Tholen}, D.~J. and {Tedesco}, E.~F.},
-    title = "{The eight-color asteroid survey - Results for 589 minor planets}",
-  journal = {Icarus},
-     year = 1985,
-    month = mar,
-   volume = 61,
-    pages = {355-416},
-      doi = {10.1016/0019-1035(85)90133-2},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1985Icar...61..355Z&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2005A&A...439..791V,
+  author =       {{van Leeuwen}, F. and {Fantino}, E.},
+  title =        "{A new reduction of the raw Hipparcos data}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0505432},
+  year =         2005,
+  month =        aug,
+  volume =       439,
+  pages =        {791-803},
+  doi =          {10.1051/0004-6361:20053193},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...439..791V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % cu3:Bruen
 
-@ARTICLE{1985Icar...62..244G,
-   author = {{Gr\"{u}n}, E. and {Zook}, H.~A. and {Fechtig}, H. and {Giese}, R.},
-    title = "{Collisional Balance of the Meteoritic Complex}",
-  journal = {Icarus},
-     year = 1985,
-    month = may,
-   volume = 62,
-    pages = {244-272},
-      doi = {10.1016/0019-1035(85)90121-6},
-   adsurl = {http://adsabs.harvard.edu/abs/1985Icar...62..244G&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2005A&A...439..805V,
+  author =       {{van Leeuwen}, F.},
+  title =        "{Rights and wrongs of the Hipparcos data. A critical
+                  quality assessment of the Hipparcos catalogue}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0505431},
+  year =         2005,
+  month =        aug,
+  volume =       439,
+  pages =        {805-822},
+  doi =          {10.1051/0004-6361:20053192},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...439..805V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 % conf:gaiascience
 
-@INPROCEEDINGS{2005tdug.conf....5M,
-   author = {{Mignard}, F.},
-    title = "{Overall Science Goals of the Gaia Mission}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {5-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf....5M&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@ARTICLE{2005ApJ...622..759G,
+  author =       {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday},
+                  A.~J. and {Wandelt}, B.~D. and {Hansen}, F.~K. and
+                  {Reinecke}, M. and {Bartelmann}, M.},
+  title =        "{HEALPix: A Framework for High-Resolution
+                  Discretization and Fast Analysis of Data Distributed
+                  on the Sphere}",
+  journal =      {\apj},
+  eprint =       {arXiv:astro-ph/0409513},
+  keywords =     {Cosmology: Cosmic Microwave Background, Cosmology:
+                  Observations, Methods: Statistical},
+  year =         2005,
+  month =        apr,
+  volume =       622,
+  pages =        {759-771},
+  doi =          {10.1086/427976}
 }
 
 %conf:gaiaeurospaceproject
 
-@INPROCEEDINGS{2002EAS.....2..107M,
-   author = {{Mignard}, F.},
-    title = "{Fundamental Physics with GAIA}",
-booktitle = {EAS Publications Series},
-     year = 2002,
-   series = {Engineering and Science},
-   volume = 2,
-   editor = {{Bienayme}, O. and {Turon}, C.},
-    pages = {107-121},
-   adsurl = {http://adsabs.harvard.edu/abs/2002EAS.....2..107M},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@PROCEEDINGS{2005ESASP.576.....T,
+  title =        "{The Three-Dimensional Universe with Gaia}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576.....T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % conf:inpopephem
 
-@INPROCEEDINGS{2005tdug.conf..293F,
-   author = {{Fienga}, A. and {Laskar}, J. and {Simon}, J.~L. and {Manche}, H. and
-	{Gastineau}, M.},
-    title = "{IMCCE Planetary Ephemerides: Present and Future}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {293-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..293F&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005ESASP.576...29L,
+  author =       {{Lindegren}, L.},
+  title =        "{The Astrometric Instrument of Gaia: Principles}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C. },
+  month =        jan,
+  pages =        {29-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576...29L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 % cu5:photometry-paris
 
-@INPROCEEDINGS{2005tdug.conf..377B,
-   author = {{Brown}, A.~G.~A.},
-    title = "{Gaia Photometric Data Analysis}",
-booktitle = {ESA SP-576: The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {377-+},
-   adsurl = {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..377B&db_key=AST},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2000SPIE.4013..453G,
-   author = {{Gilmore}, G.~F. and {de Boer}, K.~S. and {Favata}, F. and {Hoeg}, E. and
-	{Lattanzi}, M.~G. and {Lindegren}, L. and {Luri}, X. and {Mignard}, F. and
-	{Perryman}, M.~A. and {de Zeeuw}, P.~T.},
-    title = "{GAIA: origin and evolution of the Milky Way}",
-booktitle = {Proc. SPIE Vol. 4013, p. 453-472, UV, Optical, and IR Space Telescopes and Instruments, James B. Breckinridge; Peter Jakobsen; Eds.},
-     year = 2000,
-   series = {Presented at the Society of Photo-Optical Instrumentation Engineers (SPIE) Conference},
-   volume = 4013,
-   editor = {{Breckinridge}, J.~B. and {Jakobsen}, P.},
-    month = jul,
-    pages = {453-472},
-   adsurl = {http://adsabs.harvard.edu/abs/2000SPIE.4013..453G},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2006astro.ph.11885O,
-   author = {{O'Mullane}, W. and {Lammers}, U. and {Bailer-Jones}, C. and
-	{Bastian}, U. and {Brown}, A. and {Drimmel}, R. and {Eyer}, L. and
-	{Huc}, C. and {Jansen}, F. and {Katz}, D. and {Lindegren}, L. and
-	{Pourbaix}, D. and {Luri}, X. and {Mignard}, F. and {Torra}, J. and
-	{van Leeuwen}, F.},
-    title = "{Gaia Data Processing Architecture}",
-  journal = {ArXiv Astrophysics e-prints},
-   eprint = {astro-ph/0611885},
-     year = 2006,
-    month = nov,
-   adsurl = {http://adsabs.harvard.edu/abs/2006astro.ph.11885O},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1999BaltA...8...57O,
-   author = {{O'Mullane}, W. and {Lindegren}, L.},
-    title = "{An Object-Oriented Framework for GAIA Data Processing}",
-  journal = {Baltic Astronomy},
-     year = 1999,
-   volume = 8,
-    pages = {57-72},
-   adsurl = {http://adsabs.harvard.edu/abs/1999BaltA...8...57O},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2005cs........2018N,
-   author = {{Nieto-Santisteban}, M.~A. and {Szalay}, A.~S. and {Thakar}, A.~R. and
-	{O'Mullane}, W.~J. and {Gray}, J. and {Annis}, J.},
-    title = "{When Database Systems Meet the Grid}",
-  journal = {ArXiv Computer Science e-prints},
-   eprint = {cs/0502018},
-     year = 2005,
-    month = feb,
-   adsurl = {http://adsabs.harvard.edu/abs/2005cs........2018N},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2003ASPC..295..261M,
-   author = {{Miller}, III, W.~W. and {Sontag}, C. and {Rose}, J.~F.},
-    title = "{OPUS: A CORBA Pipeline for Java, Python, and Perl Applications}",
-booktitle = {Astronomical Data Analysis Software and Systems XII},
-     year = 2003,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 295,
-   editor = {{Payne}, H.~E. and {Jedrzejewski}, R.~I. and {Hook}, R.~N.},
-    pages = {261-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2003ASPC..295..261M},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{1995ASPC...77..429R,
-   author = {{Rose}, J. and {Akella}, R. and {Binegar}, S. and {Choo}, T.~H. and
-	{Heller-Boyer}, C. and {Hester}, T. and {Hyde}, P. and {Perrine}, R. and
-	{Rose}, M.~A. and {Steuerman}, K.},
-    title = "{The OPUS Pipeline: A Partially Object-Oriented Pipeline System}",
-booktitle = {Astronomical Data Analysis Software and Systems IV},
-     year = 1995,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 77,
-   editor = {{Shaw}, R.~A. and {Payne}, H.~E. and {Hayes}, J.~J.~E.},
-    pages = {429-+},
-   adsurl = {http://adsabs.harvard.edu/abs/1995ASPC...77..429R},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-
-@INPROCEEDINGS{2003ASPC..298..199B,
-   author = {{Bailer-Jones}, C.~A.~L.},
-    title = "{On the classification and parametrization of GAIA data using pattern recognition methods}",
-booktitle = {GAIA Spectroscopy: Science and Technology},
-     year = 2003,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 298,
-   editor = {{Munari}, U.},
-    pages = {199-+},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/2003ASPC..298..199B},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2007A&A...467.1373R,
-   author = {{Re Fiorentin}, P. and {Bailer-Jones}, C.~A.~L. and {Lee}, Y.~S. and
-	{Beers}, T.~C. and {Sivarani}, T. and {Wilhelm}, R. and {Allende Prieto}, C. and
-	{Norris}, J.~E.},
-    title = "{Estimation of stellar atmospheric parameters from SDSS/SEGUE spectra}",
-  journal = {Astronomy and Astrophysics},
-   eprint = {arXiv:astro-ph/0703309},
-     year = 2007,
-    month = jun,
-   volume = 467,
-    pages = {1373-1387},
-      doi = {10.1051/0004-6361:20077334},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/2007A%26A...467.1373R},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1998A&A...340..309M,
-   author = {{Makarov}, V.~V.},
-    title = "{Absolute measurements of trigonometric parallaxes with astrometric satellites}",
-  journal = {\aap},
-     year = 1998,
-    month = dec,
-   volume = 340,
-    pages = {309-314},
-   adsurl = {http://adsabs.harvard.edu/abs/1998A%26A...340..309M},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2005MmSAI..76..531V,
-   author = {{Vlemmings}, W.~H.~T. and {Chatterjee}, S. and {Brisken}, W.~F. and
-	{Lazio}, T.~J.~W. and {Cordes}, J.~M. and {Thorsett}, S.~E. and
-	{Goss}, W.~M. and {Fomalont}, E.~B. and {Kramer}, M. and {Lyne}, A.~G. and
-	{Seagroves}, S. and {Benson}, J.~M. and {McKinnon}, M.~M. and
-	{Backer}, D.~C. and {Dewey}, R.},
-    title = "{Pulsar Astrometry at the Microarcsecond Level .}",
-  journal = {Memorie della Societa Astronomica Italiana},
-   eprint = {arXiv:astro-ph/0509025},
-     year = 2005,
-   volume = 76,
-    pages = {531-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2005MmSAI..76..531V},
-  adsnote = {Provided by the Smithsonian/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2001astro.ph..7457K,
-   author = {{Klioner}, S.~A.},
-    title = "{A Practical Relativistic Model of Microarcsecond Astrometry in Space}",
-  journal = {ArXiv Astrophysics e-prints},
-   eprint = {astro-ph/0107457},
-     year = 2001,
-    month = jul,
-   adsurl = {http://adsabs.harvard.edu/abs/2001astro.ph..7457K},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2007arXiv0712.0249O,
-   author = {{O'Mullane}, W. and {Hoar}, J. and {Lammers}, U.},
-    title = "{ECSS in the eXtreme}",
-  journal = {ArXiv e-prints},
-   eprint = {0712.0249},
-     year = 2007,
-    month = dec,
-   volume = 712,
-   adsurl = {http://adsabs.harvard.edu/abs/2007arXiv0712.0249O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2005ESASP.576...29L,
-   author = {{Lindegren}, L.},
-    title = "{The Astrometric Instrument of Gaia: Principles}",
-booktitle = {The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   series = {ESA Special Publication},
-   volume = 576,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C. },
-    month = jan,
-    pages = {29-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2005ESASP.576...29L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005ESASP.576...67D,
+  author =       {{de Bruijne}, J.~H.~J. and {Lammers}, U. and
+                  {Perryman}, M.~A.~C.  },
+  title =        "{The Gaia Parameter Database}",
+  keywords =     {Gaia, Reference Values, Database},
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       "{C.~Turon, K.~S.~O'Flaherty, \& M.~A.~C.~Perryman}",
+  month =        jan,
+  pages =        {67-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576...67D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2005ESASP.576..207K,
-   author = {{Klioner}, S.~A.},
-    title = "{Relativistic Formulation and Reference Frame}",
-booktitle = {The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   series = {ESA Special Publication},
-   volume = 576,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {207-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2005ESASP.576..207K},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Klioner}, S.~A.},
+  title =        "{Relativistic Formulation and Reference Frame}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {207-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576..207K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005ESASP.576..281C,
+  author =       {{Crosta}, M.~T. and {Mignard}, F.},
+  title =        "{GAREX: a Relativity Experiment with Gaia}",
+  keywords =     {Gaia, Science, General Relativity (GR), Solar
+                  System},
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {281-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576..281C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2005ESASP.576..305K,
-   author = {{Klioner}, S.~A. and {Soffel}, M.~H.},
-    title = "{Refining the Relativistic Model for Gaia: Cosmological Effects in the BCRS}",
-booktitle = {The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   series = {ESA Special Publication},
-   volume = 576,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {305-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2005ESASP.576..305K},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Klioner}, S.~A. and {Soffel}, M.~H.},
+  title =        "{Refining the Relativistic Model for Gaia:
+                  Cosmological Effects in the BCRS}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {305-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576..305K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@PROCEEDINGS{2005ESASP.576.....T,
-    title = "{The Three-Dimensional Universe with Gaia}",
-booktitle = {The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   series = {ESA Special Publication},
-   volume = 576,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-   adsurl = {http://adsabs.harvard.edu/abs/2005ESASP.576.....T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2005MNRAS.358...30E,
+  author =       {{Eyer}, L. and {Blake}, C.},
+  title =        "{Automated classification of variable stars for
+                  All-Sky Automated Survey 1-2 data}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0406333},
+  year =         2005,
+  month =        mar,
+  volume =       358,
+  pages =        {30-38},
+  doi =          {10.1111/j.1365-2966.2005.08651.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.358...30E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-@ARTICLE{2006IAUJD..13E..32K,
-   author = {{Kobayashi}, Y. and {Gouda}, G. and {Tsujimoto}, T. and {Yano}, T. and
-	{Suganuma}, M. and {Yamauchi}, M. and {Takato}, N. and {Miyazaki}, S. and
-	{Yamada}, Y. and {Sako}, N. and {Nakasuka}, S.},
-    title = "{A very small astrometry satellite mission: Nano-JASMINE}",
-  journal = {Exploiting Large Surveys for Galactic Astronomy, 26th meeting of the IAU, Joint Discussion 13, 22-23 August 2006, Prague, Czech Republic, JD13, \#32},
-     year = 2006,
-    month = aug,
-   volume = 13,
-   adsurl = {http://adsabs.harvard.edu/abs/2006IAUJD..13E..32K},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2005MNRAS.359.1306W,
+  author =       {{Wilkinson}, M.~I. and {Vallenari}, A. and {Turon},
+                  C. and {Munari}, U. and {Katz}, D. and {Bono},
+                  G. and {Cropper}, M. and {Helmi}, A. and {Robichon},
+                  N. and {Th{\'e}venin}, F. and {Vidrih}, S. and
+                  {Zwitter}, T. and {Arenou}, F. and {Baylac},
+                  M.-O. and {Bertelli}, G. and {Bijaoui}, A. and
+                  {Boschi}, F. and {Castelli}, F. and {Crifo}, F. and
+                  {David}, M. and {Gomboc}, A. and {G{\'o}mez}, A. and
+                  {Haywood}, M. and {Jauregi}, U. and {de Laverny},
+                  P. and {Lebreton}, Y. and {Marrese}, P. and {Marsh},
+                  T. and {Mignot}, S. and {Morin}, D. and {Pasetto},
+                  S. and {Perryman}, M. and {Pr{\v s}a}, A. and
+                  {Recio-Blanco}, A. and {Royer}, F. and {Sellier},
+                  A. and {Siviero}, A. and {Sordo}, R. and {Soubiran},
+                  C. and {Tomasella}, L. and {Viala}, Y.},
+  title =        "{Spectroscopic survey of the Galaxy with Gaia-
+                  II. The expected science yield from the Radial
+                  Velocity Spectrometer}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0506083},
+  year =         2005,
+  month =        jun,
+  volume =       359,
+  pages =        {1306-1335},
+  doi =          {10.1111/j.1365-2966.2005.09012.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.359.1306W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2000ASPC..216..419O,
-   author = {{O'Mullane}, W. and {Hazell}, A. and {Bennett}, K. and {Bartelmann}, M. and
-	{Vuerli}, C.},
-    title = "{ESA Survey Missions and Global Processing}",
-booktitle = {Astronomical Data Analysis Software and Systems IX},
-     year = 2000,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 216,
-   editor = {{Manset}, N. and {Veillet}, C. and {Crabtree}, D.},
-    pages = {419-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2000ASPC..216..419O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-@INPROCEEDINGS{2004ASPC..314..376W,
-   author = {{Wieprecht}, E. and {Brumfit}, J. and {Bakker}, J. and {de Candussio}, N. and
-	{Guest}, S. and {Huygen}, R. and {de Jonge}, A. and {Matthieu}, J.~J. and
-	{Osterhage}, S. and {Ott}, S. and {Siddiqui}, H. and {Vandenbussche}, B. and
-	{de Meester}, W. and {Wetzstein}, M. and {Wiezorrek}, E. and
-	{Zaal}, P.},
-    title = "{The HERSCHEL/PACS Common Software System as Data Reduction System}",
-booktitle = {Astronomical Data Analysis Software and Systems (ADASS) XIII},
-     year = 2004,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 314,
-   editor = {{Ochsenbein}, F. and {Allen}, M.~G. and {Egret}, D.},
-    month = jul,
-    pages = {376-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2004ASPC..314..376W},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2005MNRAS.361.1136E,
+  author =       {{Eyer}, L. and {Mignard}, F.},
+  title =        "{Rate of correct detection of periodic signal with
+                  the Gaia satellite}",
+  journal =      {\mnras},
+  year =         2005,
+  month =        aug,
+  volume =       361,
+  pages =        {1136-1144},
+  doi =          {10.1111/j.1365-2966.2005.09266.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.361.1136E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-@INPROCEEDINGS{2008AIPC.1082..331H,
-   author = {{Hogg}, D.~W. and {Lang}, D.},
-    title = "{Astronomical imaging: The theory of everything}",
- keywords = {astronomical atlases, statistical analysis, astronomical telescopes},
-booktitle = {American Institute of Physics Conference Series},
-     year = 2008,
-   series = {American Institute of Physics Conference Series},
-   volume = 1082,
-    month = dec,
-    pages = {331-338},
-      doi = {10.1063/1.3059072},
-   adsurl = {http://adsabs.harvard.edu/abs/2008AIPC.1082..331H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2005MmSAI..76..531V,
+  author =       {{Vlemmings}, W.~H.~T. and {Chatterjee}, S. and
+                  {Brisken}, W.~F. and {Lazio}, T.~J.~W. and {Cordes},
+                  J.~M. and {Thorsett}, S.~E. and {Goss}, W.~M. and
+                  {Fomalont}, E.~B. and {Kramer}, M. and {Lyne},
+                  A.~G. and {Seagroves}, S. and {Benson}, J.~M. and
+                  {McKinnon}, M.~M. and {Backer}, D.~C. and {Dewey},
+                  R.},
+  title =        "{Pulsar Astrometry at the Microarcsecond Level .}",
+  journal =      {Memorie della Societa Astronomica Italiana},
+  eprint =       {arXiv:astro-ph/0509025},
+  year =         2005,
+  volume =       76,
+  pages =        {531-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005MmSAI..76..531V},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-@INPROCEEDINGS{2005ESASP.576..281C,
-   author = {{Crosta}, M.~T. and {Mignard}, F.},
-    title = "{GAREX: a Relativity Experiment with Gaia}",
- keywords = {Gaia, Science, General Relativity (GR), Solar System},
-booktitle = {The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   series = {ESA Special Publication},
-   volume = 576,
-   editor = {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman}, M.~A.~C.
-	},
-    month = jan,
-    pages = {281-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2005ESASP.576..281C},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2005PASP..117.1021S,
+  author =       {{Sozzetti}, A.},
+  title =        "{Astrometric Methods and Instrumentation to Identify
+                  and Characterize Extrasolar Planets: A Review}",
+  journal =      {\pasp},
+  eprint =       {astro-ph/0507115},
+  year =         2005,
+  month =        oct,
+  volume =       117,
+  pages =        {1021-1048},
+  doi =          {10.1086/444487},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005PASP..117.1021S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2000ASSL..252..201G,
-   author = {{Groom}, D.~E. and {Eberhard}, P.~H. and {Holland}, S.~E. and
-	{Levi}, M.~E. and {Palaio}, N.~P. and {Perlmutter}, S. and {Stover}, R.~J. and
-	{Wei}, M.},
-    title = "{Point-spread function in depleted and partially depleted CCDs}",
-booktitle = {Astrophysics and Space Science Library},
-     year = 2000,
-   series = {Astrophysics and Space Science Library},
-   volume = 252,
-   editor = "{P.~Amico \& J.~W.~Beletic}",
-    pages = {201-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2000ASSL..252..201G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2005cs........2018N,
+  author =       {{Nieto-Santisteban}, M.~A. and {Szalay}, A.~S. and
+                  {Thakar}, A.~R. and {O'Mullane}, W.~J. and {Gray},
+                  J. and {Annis}, J.},
+  title =        "{When Database Systems Meet the Grid}",
+  journal =      {ArXiv Computer Science e-prints},
+  eprint =       {cs/0502018},
+  year =         2005,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005cs........2018N},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@BOOK{2001sccd.book.....J,
-   author = {{Janesick}, J.~R.},
-    title = "{Scientific charge-coupled devices}",
- keywords = {CHARGE COUPLED DEVICES, OPTICAL INSTRUMENTS},
-booktitle = {Scientific charge-coupled devices, Bellingham, WA: SPIE Optical Engineering Press, 2001, xvi, 906 p.~SPIE Press monograph, PM 83.~ISBN 0819436984},
-     year = 2001,
-   editor = "{Janesick, J.~R.}",
-   adsurl = {http://adsabs.harvard.edu/abs/2001sccd.book.....J},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf....5M,
+  author =       {{Mignard}, F.},
+  title =        "{Overall Science Goals of the Gaia Mission}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {5-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf....5M&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2004SPIE.5494..529B,
-   author = {{Baccaro}, S. and {Cecilia}, A. and {Di Sarcina}, I. and {Piegari}, A.~M.
-	},
-    title = "{Optical coating behavior under y irradiation for space applications}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2004,
-   series = {Presented at the Society of Photo-Optical Instrumentation Engineers (SPIE) Conference},
-   volume = 5494,
-   editor = "{E.~Atad-Ettedgui \& P.~Dierickx}",
-    month = sep,
-    pages = {529-535},
-      doi = {10.1117/12.553602},
-   adsurl = {http://adsabs.harvard.edu/abs/2004SPIE.5494..529B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf...97S,
+  author =       {{S}\"{o}derhjelm, S.},
+  title =        "{Census of Binaries the Big Picture}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.},
+  month =        jan,
+  pages =        {97-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib\_query?bibcode=2005tdug.conf...97S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2004SPIE.5495...23J,
-   author = {{Jessen}, N.~C. and {N{\o}rgaard-Nielsen}, H.~U. and {Stevenson}, T. and
-	{Sykes}, J. and {Schroll}, J. and {Hastings}, P.},
-    title = "{The CFRP primary structure of the MIRI instrument onboard the James Webb Space Telescope}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2004,
-   series = {Presented at the Society of Photo-Optical Instrumentation Engineers (SPIE) Conference},
-   volume = 5495,
-   editor = "{J.~Antebi \& D.~Lemke}",
-    month = sep,
-    pages = {23-30},
-      doi = {10.1117/12.550023},
-   adsurl = {http://adsabs.harvard.edu/abs/2004SPIE.5495...23J},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..251L,
+  author =       {{Lattanzi}, M.~G. and {Casertano}, S. and {Jancart},
+                  S. and {Morbidelli}, R. and {Pourbaix}, D. and
+                  {Pannunzio}, R. and {Sozzetti}, A. and {Spagna}, A.},
+  title =        "{Detection and Characterization of Extra-Solar
+                  Planets with Gaia}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {251-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..251L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{2005ApJ...622..759G,
-   author = {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday}, A.~J. and
-    {Wandelt}, B.~D. and {Hansen}, F.~K. and {Reinecke}, M. and
-    {Bartelmann}, M.},
-    title = "{HEALPix: A Framework for High-Resolution Discretization and Fast Analysis of Data Distributed on the Sphere}",
-  journal = {\apj},
-   eprint = {arXiv:astro-ph/0409513},
- keywords = {Cosmology: Cosmic Microwave Background, Cosmology: Observations, Methods: Statistical},
-     year = 2005,
-    month = apr,
-   volume = 622,
-    pages = {759-771},
-      doi = {10.1086/427976}
+@INPROCEEDINGS{2005tdug.conf..293F,
+  author =       {{Fienga}, A. and {Laskar}, J. and {Simon}, J.~L. and
+                  {Manche}, H. and {Gastineau}, M.},
+  title =        "{IMCCE Planetary Ephemerides: Present and Future}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {293-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..293F&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{1997A&A...327.1253M,
-   author = {{Moreno}, F. and {Molina}, A. and {Ortiz}, J.~L.},
-    title = "{The 1993 south equatorial belt revival and other features in the Jovian atmosphere: an observational perspective}",
-  journal = {\aap},
- keywords = {PLANETS AND SATELLITES: INDIVIDUAL: JUPITER},
-     year = 1997,
-    month = nov,
-   volume = 327,
-    pages = {1253-1261},
-   adsurl = {http://adsabs.harvard.edu/abs/1997A%26A...327.1253M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..377B,
+  author =       {{Brown}, A.~G.~A.},
+  title =        "{Gaia Photometric Data Analysis}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {377-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..377B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2005ESASP.576...67D,
-   author = {{de Bruijne}, J.~H.~J. and {Lammers}, U. and {Perryman}, M.~A.~C.
-	},
-    title = "{The Gaia Parameter Database}",
- keywords = {Gaia, Reference Values, Database},
-booktitle = {The Three-Dimensional Universe with Gaia},
-     year = 2005,
-   series = {ESA Special Publication},
-   volume = 576,
-   editor = "{C.~Turon, K.~S.~O'Flaherty, \& M.~A.~C.~Perryman}",
-    month = jan,
-    pages = {67-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2005ESASP.576...67D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..385W,
+  author =       {{Evans}, N.~W. and {Belokurov}, V.},
+  title =        "{A {P}rototype for {S}cience {A}lerts}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {385-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..385W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{2008ExA....22..143P,
-   author = {{Perryman}, M. and {de Bruijne}, J. and {Lammers}, U.},
-    title = "{A parameter database for large scientific projects: application to the Gaia space astrometry mission}",
-  journal = {Experimental Astronomy},
-     year = 2008,
-    month = oct,
-   volume = 22,
-    pages = {143-150},
-      doi = {10.1007/s10686-008-9116-7},
-   adsurl = {http://adsabs.harvard.edu/abs/2008ExA....22..143P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..393B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{Object Classification and the Determination of
+                  Stellar Parameters}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {393-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..393B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-@INPROCEEDINGS{2010SPIE.7740E..51G,
-   author = {{Gaudet}, S. and {Hill}, N. and {Armstrong}, P. and {Ball}, N. and
-	{Burke}, J. and {Chapel}, B. and {Chapin}, E. and {Damian}, A. and
-	{Dowler}, P. and {Gable}, I. and {Goliath}, S. and {Ghiurea}, I. and
-	{Fabbro}, S. and {Gwyn}, S. and {Jenkins}, D. and {Kavelaars}, J. and
-	{Major}, B. and {Ouellette}, J. and {Paterson}, M. and {Peddle}, M. and
-	{Penfold-Brown}, D. and {Pritchet}, C. and {Schade}, D. and
-	{Sobie}, R. and {Woods}, D. and {Yeung}, A. and {Zhang}, Y.},
-    title = "{CANFAR: the Canadian Advanced Network for Astronomical Research}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2010,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 7740,
-    month = jul,
-      doi = {10.1117/12.858026},
-   adsurl = {http://adsabs.harvard.edu/abs/2010SPIE.7740E..51G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..433G,
+  author =       {{Gai}, M. and {Busonero}, D. and {Gardiol}, D. and
+                  {Loreggia}, D.  },
+  title =        "{The Gaia Focal Plane to Sky Mapping: A Sample of
+                  Calibration Issues}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {433-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..433G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-@ARTICLE{2011arXiv1102.5123H,
-   author = {{Hassan}, A. and {Fluke}, C.~J.},
-    title = "{Scientific Visualization in Astronomy: Towards the Petascale Astronomy Era}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1102.5123},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Graphics},
-     year = 2011,
-    month = feb,
-   adsurl = {http://adsabs.harvard.edu/abs/2011arXiv1102.5123H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..513E,
+  author =       {{Eyer}, L.},
+  title =        "{Variability Analysis: Detection and
+                  Classification}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {513-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..513E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-@ARTICLE{2011arXiv1108.0355O,
-   author = {{O'Mullane}, W. and {Luri}, X. and {Parsons}, P. and {Lammers}, U. and
-	{Hoar}, J. and {Hernandez}, J.},
-    title = "{Using Java for distributed computing in the Gaia satellite data processing}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1108.0355},
- primaryClass = "cs.CE",
- keywords = {Computer Science - Computational Engineering, Finance, and Science, Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Mathematical Software},
-     year = 2011,
-    month = aug,
-   adsurl = {http://adsabs.harvard.edu/abs/2011arXiv1108.0355O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..645S,
+  author =       {{Spite}, M.},
+  title =        "{Gaia, the Oldest Stars and the Early Universe}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {645-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..645S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{2010A&A...518A..10V,
-   author = {{Veron-Cetty}, M.P. and {Veron}, P.},
-    title = "{A catalogue of quasars and active nuclei: 13th edition}",
-  journal = {Astronomy and Astrophysics},
- keywords = {quasars: general, galaxies: Seyfert, BL Lacertae objects: general},
-     year = 2010,
-    month = jul,
-   volume = 518,
-      doi = {10.1051/0004-6361/201014188},
-   adsurl = {http://adsabs.harvard.edu/abs/2010A&A...518A..10V},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2005tdug.conf..651W,
+  author =       {{Wilkinson}, M.~I.},
+  title =        "{Dark Matter in the Local Group}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {651-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..651W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006A&A...449..827B,
+  author =       {{Busonero}, D. and {Gai}, M. and {Gardiol}, D. and
+                  {Lattanzi}, M.~G. and {Loreggia}, D.},
+  title =        "{Chromaticity in all-reflective telescopes for
+                  astrometry}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0511572},
+  year =         2006,
+  month =        apr,
+  volume =       449,
+  pages =        {827-836},
+  doi =          {10.1051/0004-6361:20054180},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006A%26A...449..827B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
 @ARTICLE{2006AJ....131.1163S,
-   author = {Skrutskie, M. F. and Cutri, R. M. and Stiening, R. and Weinberg, M. D. and Schneider, S. and Carpenter, J. M. and Beichman, C. and Capps, R. and Chester, T. and Elias, J. and Huchra, J. and Liebert, J. and Lonsdale, C. and Monet, D. G. and Price, S. and Seitzer, P. and Jarrett, T. and Kirkpatrick, J. D. and Gizis, J. E. and Howard, E. and Evans, T. and Fowler, J. and Fullmer, L. and Hurt, R. and Light, R. and Kopan, E. L. and Marsh, K. A. and McCallon, H. L. and Tam, R. and Van Dyk, S. and Wheelock, S.},
-    title = "{The Two Micron All Sky Survey (2MASS)}",
-  journal = {The Astronomical Journal},
- keywords = {catalogs; infrared: general; surveys},
-     year = 2006,
-    month = feb,
-   volume = 131,
-   number = 2,
-      doi = {10.1086/498708},
-   adsurl = {http://adsabs.harvard.edu/abs/2006AJ....131.1163S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {Skrutskie, M. F. and Cutri, R. M. and Stiening,
+                  R. and Weinberg, M. D. and Schneider, S. and
+                  Carpenter, J. M. and Beichman, C. and Capps, R. and
+                  Chester, T. and Elias, J. and Huchra, J. and
+                  Liebert, J. and Lonsdale, C. and Monet, D. G. and
+                  Price, S. and Seitzer, P. and Jarrett, T. and
+                  Kirkpatrick, J. D. and Gizis, J. E. and Howard,
+                  E. and Evans, T. and Fowler, J. and Fullmer, L. and
+                  Hurt, R. and Light, R. and Kopan, E. L. and Marsh,
+                  K. A. and McCallon, H. L. and Tam, R. and Van Dyk,
+                  S. and Wheelock, S.},
+  title =        "{The Two Micron All Sky Survey (2MASS)}",
+  journal =      {The Astronomical Journal},
+  keywords =     {catalogs; infrared: general; surveys},
+  year =         2006,
+  month =        feb,
+  volume =       131,
+  number =       2,
+  doi =          {10.1086/498708},
+  adsurl =       {http://adsabs.harvard.edu/abs/2006AJ....131.1163S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2009ApJS..182..543A,
-   author = {{Abazajian}, K.N. and Adelman-McCarthy, Jennifer K. and Ageros, Marcel A. and Allam, Sahar S. and Allende Prieto, Carlos and An, Deokkeun and Anderson, Kurt S. J. and Anderson, Scott F. and Annis, James and Bahcall, Neta A. and Bailer-Jones, C. A. L. and Barentine, J. C. and Bassett, Bruce A. and Becker, Andrew C. and Beers, Timothy C. and Bell, Eric F. and Belokurov, Vasily and Berlind, Andreas A. and Berman, Eileen F. and Bernardi, Mariangela and Bickerton, Steven J. and Bizyaev, Dmitry and Blakeslee, John P. and Blanton, Michael R. and Bochanski, John J. and Boroski, William N. and Brewington, Howard J. and Brinchmann, Jarle and Brinkmann, J. and Brunner, Robert J. and Budavri, Tams and Carey, Larry N. and Carliles, Samuel and Carr, Michael A. and Castander, Francisco J. and Cinabro, David and Connolly, A. J. and Csabai, Istvn and Cunha, Carlos E. and Czarapata, Paul C. and Davenport, James R. A. and de Haas, Ernst and Dilday, Ben and Doi, Mamoru and Eisenstein, Daniel J. and Evans, Michael L. and Evans, N. W. and Fan, Xiaohui and Friedman, Scott D. and Frieman, Joshua A. and Fukugita, Masataka and Gnsicke, Boris T. and Gates, Evalyn and Gillespie, Bruce and Gilmore, G. and Gonzalez, Belinda and Gonzalez, Carlos F. and Grebel, Eva K. and Gunn, James E. and Gyry, Zsuzsanna and Hall, Patrick B. and Harding, Paul and Harris, Frederick H. and Harvanek, Michael and Hawley, Suzanne L. and Hayes, Jeffrey J. E. and Heckman, Timothy M. and Hendry, John S. and Hennessy, Gregory S. and Hindsley, Robert B. and Hoblitt, J. and Hogan, Craig J. and Hogg, David W. and Holtzman, Jon A. and Hyde, Joseph B. and Ichikawa, Shin-ichi and Ichikawa, Takashi and Im, Myungshin and Ivezic, Zeljko and Jester, Sebastian and Jiang, Linhua and Johnson, Jennifer A. and Jorgensen, Anders M. and Juric, Mario and Kent, Stephen M. and Kessler, R. and Kleinman, S. J. and Knapp, G. R. and Konishi, Kohki and Kron, Richard G. and Krzesinski, Jurek and Kuropatkin, Nikolay and Lampeitl, Hubert and Lebedeva, Svetlana and Lee, Myung Gyoon and Lee, Young Sun and French Leger, R. and Lpine, Sbastien and Li, Nolan and Lima, Marcos and Lin, Huan and Long, Daniel C. and Loomis, Craig P. and Loveday, Jon and Lupton, Robert H. and Magnier, Eugene and Malanushenko, Olena and Malanushenko, Viktor and Mandelbaum, Rachel and Margon, Bruce and Marriner, John P. and Martnez-Delgado, David and Matsubara, Takahiko and McGehee, Peregrine M. and McKay, Timothy A. and Meiksin, Avery and Morrison, Heather L. and Mullally, Fergal and Munn, Jeffrey A. and Murphy, Tara and Nash, Thomas and Nebot, Ada and Neilsen, Eric H., Jr. and Newberg, Heidi Jo and Newman, Peter R. and Nichol, Robert C. and Nicinski, Tom and Nieto-Santisteban, Maria and Nitta, Atsuko and Okamura, Sadanori and Oravetz, Daniel J. and Ostriker, Jeremiah P. and Owen, Russell and Padmanabhan, Nikhil and Pan, Kaike and Park, Changbom and Pauls, George and Peoples, John, Jr. and Percival, Will J. and Pier, Jeffrey R. and Pope, Adrian C. and Pourbaix, Dimitri and Price, Paul A. and Purger, Norbert and Quinn, Thomas and Raddick, M. Jordan and Re Fiorentin, Paola and Richards, Gordon T. and Richmond, Michael W. and Riess, Adam G. and Rix, Hans-Walter and Rockosi, Constance M. and Sako, Masao and Schlegel, David J. and Schneider, Donald P. and Scholz, Ralf-Dieter and Schreiber, Matthias R. and Schwope, Axel D. and Seljak, Uro and Sesar, Branimir and Sheldon, Erin and Shimasaku, Kazu and Sibley, Valena C. and Simmons, A. E. and Sivarani, Thirupathi and Allyn Smith, J. and Smith, Martin C. and Smolcic, Vernesa and Snedden, Stephanie A. and Stebbins, Albert and Steinmetz, Matthias and Stoughton, Chris and Strauss, Michael A. and SubbaRao, Mark and Suto, Yasushi and Szalay, Alexander S. and Szapudi, Istvn and Szkody, Paula and Tanaka, Masayuki and Tegmark, Max and Teodoro, Luis F. A. and Thakar, Aniruddha R. and Tremonti, Christy A. and Tucker, Douglas L. and Uomoto, Alan and Vanden Berk, Daniel E. and Vandenberg, Jan and Vidrih, S. and Vogeley, Michael S. and Voges, Wolfgang and Vogt, Nicole P. and Wadadekar, Yogesh and Watters, Shannon and Weinberg, David H. and West, Andrew A. and White, Simon D. M. and Wilhite, Brian C. and Wonders, Alainna C. and Yanny, Brian and Yocum, D. R. and York, Donald G. and Zehavi, Idit and Zibetti, Stefano and Zucker, Daniel B.},
-    title = "{THE SEVENTH DATA RELEASE OF THE SLOAN DIGITAL SKY SURVEY}",
-  journal = {The Astrophysical Journal Supplement Series},
- keywords = {atlases; catalogs; surveys},
-     year = 2009,
-    month = jun,
-   volume = 182,
-   number = 2,
-      doi = {10.1088/0067-0049/182/2/543},
-   adsurl = {http://adsabs.harvard.edu/abs/2009ApJS..182..543A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2006ASPC..349...15E,
+  author =       {{Eyer}, L.},
+  title =        "{Astronomical Databases, Space Photometry and Time
+                  Series Analysis: Open Questions}",
+  booktitle =    {Astronomical Society of the Pacific Conference
+                  Series},
+  year =         2006,
+  editor =       {{Sterken}, C. and {Aerts}, C.},
+  month =        apr,
+  pages =        {15-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006ASPC..349...15E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{2008AJ....136..735L,
-   author = {{Lasker}, B.M. and {Lattanzi}, M.G. and {McLean}, B.J. and {Bucciarelli}, B. and {Drimmel}, R. and {Garcia}, Jorge and {Greene}, Gretchen and {Guglielmetti}, Fabrizia and {Hanley}, Christopher and {Hawkins}, George and {Laidler}, Victoria G. and {Loomis}, Charles and {Meakes}, Michael and {Mignani}, Roberto and {Morbidelli}, Roberto and {Morrison}, Jane and {Pannunzio}, Renato and {Rosenberg}, Amy and {Sarasso}, Maria and {Smart}, Richard L. and {Spagna}, Alessandro and {Sturch}, Conrad R. and {Volpicelli}, Antonio and {White}, Richard L. and {Wolfe}, David and {Zacchei}, Andrea},
-    title = "{THE SECOND-GENERATION GUIDE STAR CATALOG: DESCRIPTION AND PROPERTIES}",
-  journal = {The Astronomical Journal},
- keywords = {astrometry; astronomical data bases: miscellaneous; catalogs; surveys; techniques: image processing; techniques: photometric},
-     year = 2008,
-    month = aug,
-   volume = 136,
-   number = 2,
-      doi = {10.1088/0004-6256/136/2/735},
-   adsurl = {http://adsabs.harvard.edu/abs/2008AJ....136..735L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006ApJ...653.1552D,
+  author =       {{de Felice}, F. and {Vecchiato}, A. and {Crosta},
+                  M.~T. and {Lattanzi}, M.~G. and {Bucciarelli}, B.},
+  title =        "{A general relativistic model for the light
+                  propagation in the gravitational field of the Solar
+                  System: the dynamical case}",
+  journal =      {\apj},
+  year =         2006,
+  volume =       653,
+  pages =        1552,
+  doi =          {10.1051/0004-6361:20042372},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006ApJ...653.1552D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2011AAS...21734408S,
-   author = {{Schmitz}, M. and {Baker}, K. and {Chan}, B. and {Corwin}, H., Jr. and {Ebert}, R. and {Frayer}, C. and {Helou}, G. and {LaGue}, C. and {Lo}, T. and {Madore}, B. and {Mazzarella}, J. and {Pevunova}, O. and {Steer}, I. and {Terek}, S.},
-    title = "{The NASA/IPAC Extragalactic Database (NED): Enhanced Content and New Functionality}",
-booktitle = {Bulletin of the American Astronomical Society},
-     year = 2011,
-   series = {Bulletin of the American Astronomical Society},
-   volume = 43,
-    month = jan,
-   adsurl = {http://adsabs.harvard.edu/abs/2011AAS...21734408S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006CQGra..23.4853C,
+  author =       {{Crosta}, M.~T. and {Mignard}, F.},
+  title =        "{Microarcsecond light bending by Jupiter}",
+  journal =      {Classical and Quantum Gravity},
+  eprint =       {astro-ph/0512359},
+  year =         2006,
+  month =        aug,
+  volume =       23,
+  pages =        {4853-4871},
+  doi =          {10.1088/0264-9381/23/15/006},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006CQGra..23.4853C&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2010AAS...21641512W,
-   author = {Wood-Vasey, W. Michael and Rest, A. and Smartt, S. and Huber, M. and Narayan, G. and Price, P. and Valenti, S. and Smith, K. and Botticella, M. and Foley, R. J. and Rodney, S. and Young, D. and Gezari, S. and Chornock, R. and Challis, P. and Tonry, J. and Chornock, R. and Stubbs, C. and Welling, J. and Riess, A. and Berger, E. and Soderberg, A. M. and Sand, D. J. and Kirshner, R. P. and Builders, PS1},
-    title = "{The Pan-STARRS 1 Survey Transient Identification System}",
-booktitle = {Bulletin of the American Astronomical Society},
-     year = 2010,
-   series = {Bulletin of the American Astronomical Society},
-   volume = 42,
-    month = may,
-   adsurl = {http://adsabs.harvard.edu/abs/2010AAS...21641512W},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006CQGra..23.5467D,
+  author =       {{de Felice}, F. and {Preti}, G.},
+  title =        "{Ray tracing in relativistic astrometry: stellar
+                  positions, stellar motion and error budget}",
+  journal =      {Classical and Quantum Gravity},
+  year =         2006,
+  month =        sep,
+  volume =       23,
+  pages =        {5467-5476},
+  doi =          {10.1088/0264-9381/23/18/001},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006CQGra..23.5467D&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{2011ExA....31..215O,
-   author = {{O'Mullane}, W. and {Lammers}, U. and {Lindegren}, L. and {Hernandez}, J. and
-	{Hobbs}, D.},
-    title = "{Implementing the Gaia Astrometric Global Iterative Solution (AGIS) in Java}",
-  journal = {Experimental Astronomy},
-archivePrefix = "arXiv",
-   eprint = {1108.2206},
- primaryClass = "astro-ph.IM",
- keywords = {Astrometry, Satellite, Algorithms, Implementation, Data management},
-     year = 2011,
-    month = oct,
-   volume = 31,
-    pages = {215-241},
-      doi = {10.1007/s10686-011-9248-z},
-   adsurl = {http://adsabs.harvard.edu/abs/2011ExA....31..215O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006IAUJD..13E..32K,
+  author =       {{Kobayashi}, Y. and {Gouda}, G. and {Tsujimoto},
+                  T. and {Yano}, T. and {Suganuma}, M. and {Yamauchi},
+                  M. and {Takato}, N. and {Miyazaki}, S. and {Yamada},
+                  Y. and {Sako}, N. and {Nakasuka}, S.},
+  title =        "{A very small astrometry satellite mission:
+                  Nano-JASMINE}",
+  journal =      {Exploiting Large Surveys for Galactic Astronomy,
+                  26th meeting of the IAU, Joint Discussion 13, 22-23
+                  August 2006, Prague, Czech Republic, JD13, \#32},
+  year =         2006,
+  month =        aug,
+  volume =       13,
+  adsurl =       {http://adsabs.harvard.edu/abs/2006IAUJD..13E..32K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2011ExA....31..243O,
-   author = {{O'Mullane}, W. and {Luri}, X. and {Parsons}, P. and {Lammers}, U. and
-	{Hoar}, J. and {Hernandez}, J.},
-    title = "{Using Java for distributed computing in the Gaia satellite data processing}",
-  journal = {Experimental Astronomy},
-archivePrefix = "arXiv",
-   eprint = {1108.0355},
- primaryClass = "cs.CE",
- keywords = {Distributed computing, Java, Astrometry, Cloud computing, Mathematics},
-     year = 2011,
-    month = oct,
-   volume = 31,
-    pages = {243-258},
-      doi = {10.1007/s10686-011-9241-6},
-   adsurl = {http://adsabs.harvard.edu/abs/2011ExA....31..243O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006MNRAS.367..290J,
+  author =       {{Jordi}, C. and {H{\o}g}, E. and {Brown},
+                  A.~G.~A. and {Lindegren}, L. and {Bailer-Jones},
+                  C.~A.~L. and {Carrasco}, J.~M. and {Knude}, J. and
+                  {Strai{\v z}ys}, V. and {de Bruijne}, J.~H.~J. and
+                  {Claeskens}, J.-F. and {Drimmel}, R. and {Figueras},
+                  F. and {Grenon}, M. and {Kolka}, I. and {Perryman},
+                  M.~A.~C. and {Tautvai{\v s}ien{\.e}}, G. and
+                  {Vansevi{\v c}ius}, V. and {Willemsen}, P.~G. and
+                  {Brid{\v z}ius}, A. and {Evans}, D.~W. and
+                  {Fabricius}, C. and {Fiorucci}, M. and {Heiter},
+                  U. and {Kaempf}, T.~A. and {Kazlauskas}, A. and
+                  {Ku{\v c}inskas}, A. and {Malyuto}, V. and {Munari},
+                  U. and {Reyl{\'e}}, C. and {Torra}, J. and
+                  {Vallenari}, A. and {Zdanavi{\v c}ius}, K. and
+                  {Korakitis}, R. and {Malkov}, O. and {Smette}, A.},
+  title =        "{The design and performance of the Gaia photometric
+                  system}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0512038},
+  year =         2006,
+  month =        mar,
+  volume =       367,
+  pages =        {290-314},
+  doi =          {10.1111/j.1365-2966.2005.09944.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.367..290J&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{1997ESASP.402..767D,
-   author = {{de Felice}, F. and {Lattanzi}, M.~G. and {Vecchiato}, A. and
-	{Bernacca}, P.~L.},
-    title = "{A Relativistic Model for the GAIA Observations}",
-booktitle = {Hipparcos - Venice '97},
-     year = 1997,
-   series = {ESA Special Publication},
-   volume = 402,
-   editor = "{R.~M.~Bonnet, E.~H{\o}g, P.~L.~Bernacca, L.~Emiliani, A.~Blaauw,
-	C.~Turon, J.~Kovalevsky, L.~Lindegren, H.~Hassan, M.~Bouffard,
-	B.~Strim, D.~Heger, M.~A.~C.~Perryman, \& L.~Woltjer}",
-    month = aug,
-    pages = {767-770},
-   adsurl = {http://adsabs.harvard.edu/abs/1997ESASP.402..767D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006MNRAS.367..879C,
+  author =       {{Claeskens}, J.-F. and {Smette}, A. and
+                  {Vandenbulcke}, L. and {Surdej}, J.},
+  title =        "{Identification and redshift determination of
+                  quasi-stellar objects with medium-band photometry:
+                  application to Gaia}",
+  journal =      {\mnras},
+  year =         2006,
+  month =        apr,
+  volume =       367,
+  pages =        {879-904},
+  doi =          {10.1111/j.1365-2966.2006.10024.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.367..879C&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{1998A&A...332.1133D,
-   author = {{de Felice}, F. and {Lattanzi}, M.~G. and {Vecchiato}, A. and
-	{Bernacca}, P.~L.},
-    title = "{General relativistic satellite astrometry. I. A non-perturbative approach to data reduction}",
-  journal = {\aap},
- keywords = {RELATIVITY, METHODS: DATA ANALYSIS, SPACE VEHICLES, ASTROMETRY},
-     year = 1998,
-    month = apr,
-   volume = 332,
-    pages = {1133-1141},
-   adsurl = {http://adsabs.harvard.edu/abs/1998A%26A...332.1133D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006MNRAS.369..677P,
+  author =       {{Protopapas}, P. and {Giammarco}, J.~M. and
+                  {Faccioli}, L. and {Struble}, M.~F. and {Dave},
+                  R. and {Alcock}, C.},
+  title =        "{Finding outlier light curves in catalogues of
+                  periodic variable stars}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0505495},
+  year =         2006,
+  month =        jun,
+  volume =       369,
+  pages =        {677-696},
+  doi =          {10.1111/j.1365-2966.2006.10327.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006MNRAS.369..677P&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-
-@ARTICLE{2010A&A...516A..77B,
-   author = {{Bombrun}, A. and {Lindegren}, L. and {Holl}, B. and {Jordan}, S.
-    },
-    title = "{Complexity of the Gaia astrometric least-squares problem and the (non-)feasibility of a direct solution method}",
-  journal = {\aap},
- keywords = {methods: data analysis, methods: numerical, space vehicles: instruments, astrometry, reference systems},
-     year = 2010,
-    month = jun,
-   volume = 516,
-    pages = {A77},
-      doi = {10.1051/0004-6361/200913503},
-   adsurl = {http://adsabs.harvard.edu/abs/2010A%26A...516A..77B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006MNRAS.370..141R,
+  author =       {{Recio-Blanco}, A. and {Bijaoui}, A. and {de
+                  Laverny}, P.},
+  title =        "{Automated derivation of stellar atmospheric
+                  parameters and chemical abundances: the MATISSE
+                  algorithm}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0604385},
+  year =         2006,
+  month =        jul,
+  volume =       370,
+  pages =        {141-150},
+  doi =          {10.1111/j.1365-2966.2006.10455.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.370..141R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-
-@INPROCEEDINGS{2009ASPC..411...55L,
-   author = {{Lammers}, U. and {Lindegren}, L. and {O'Mullane}, W. and {Hobbs}, D.
-	},
-    title = "{To Boldly Go Where No Man has Gone Before: Seeking Gaia's Astrometric Solution with AGIS}",
-booktitle = {Astronomical Data Analysis Software and Systems XVIII},
-     year = 2009,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 411,
-   editor = "{D.~A.~Bohlender, D.~Durand, \& P.~Dowler}",
-    month = sep,
-    pages = {55-+},
-   adsurl = {http://adsabs.harvard.edu/abs/2009ASPC..411...55L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006MmSAI..77..549E,
+  author =       {{Eyer}, L.},
+  title =        "{The Gaia mission . Pulsating stars with Gaia}",
+  journal =      {Memorie della Societa Astronomica Italiana},
+  eprint =       {astro-ph/0511460},
+  year =         2006,
+  volume =       77,
+  pages =        {549-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006MmSAI..77..549E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{1727RSPT...35..637B,
-   author = {{Bradley}, J.},
-    title = "{a Letter from the Reverend Mr. James Bradley Savilian Professor of Astronomy at Oxford, and F.R.S. to Dr.Edmond Halley Astronom. Reg. {\amp}c. Giving an Account of a New Discovered Motion of the Fix'd Stars.}",
-  journal = {Royal Society of London Philosophical Transactions Series I},
-     year = 1727,
-   volume = 35,
-    pages = {637-661},
-   adsurl = {http://adsabs.harvard.edu/abs/1727RSPT...35..637B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2006SPIE.6206E..01C,
+  author =       {{Chorier}, P. and {Tribolet}, P. and
+                  {Dest{\'e}fanis}, G.},
+  title =        "{From visible to infrared: a new detector approach}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2006,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       6206,
+  month =        may,
+  eid =          620601,
+  pages =        620601,
+  doi =          {10.1117/12.669128},
+  adsurl =       {http://adsabs.harvard.edu/abs/2006SPIE.6206E..01C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2002SPIE.4836..333S,
-   author = {{Szalay}, A.~S. and {Gray}, J. and {VandenBerg}, J.},
-    title = "{Petabyte Scale Data Mining: Dream or Reality?}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2002,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 4836,
-   eprint = {arXiv:cs/0208013},
-   editor = "{J.~A.~Tyson \& S.~Wolff}",
-    month = dec,
-    pages = {333-338},
-      doi = {10.1117/12.461427},
-   adsurl = {http://adsabs.harvard.edu/abs/2002SPIE.4836..333S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2006astro.ph.11885O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and
+                  {Bailer-Jones}, C. and {Bastian}, U. and {Brown},
+                  A. and {Drimmel}, R. and {Eyer}, L. and {Huc},
+                  C. and {Jansen}, F. and {Katz}, D. and {Lindegren},
+                  L. and {Pourbaix}, D. and {Luri}, X. and {Mignard},
+                  F. and {Torra}, J. and {van Leeuwen}, F.},
+  title =        "{Gaia Data Processing Architecture}",
+  journal =      {ArXiv Astrophysics e-prints},
+  eprint =       {astro-ph/0611885},
+  year =         2006,
+  month =        nov,
+  adsurl =       {http://adsabs.harvard.edu/abs/2006astro.ph.11885O},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@INPROCEEDINGS{2004ASPC..314..293Y,
-   author = {{Yasuda}, N. and {Mizumoto}, Y. and {Ohishi}, M. and {O'Mullane}, W. and
-	{Budav{\'a}ri}, T. and {Haridas}, V. and {Li}, N. and {Malik}, T. and
-	{Szalay}, A.~S. and {Hill}, M. and {Linde}, T. and {Mann}, B. and
-	{Page}, C.~G.},
-    title = "{Astronomical Data Query Language: Simple Query Protocol for the Virtual Observatory}",
-booktitle = {Astronomical Data Analysis Software and Systems (ADASS) XIII},
-     year = 2004,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 314,
-   editor = "{F.~Ochsenbein, M.~G.~Allen, \& D.~Egret}",
-    month = jul,
-    pages = {293},
-   adsurl = {http://adsabs.harvard.edu/abs/2004ASPC..314..293Y},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2007A&A...467.1373R,
+  author =       {{Re Fiorentin}, P. and {Bailer-Jones}, C.~A.~L. and
+                  {Lee}, Y.~S. and {Beers}, T.~C. and {Sivarani},
+                  T. and {Wilhelm}, R. and {Allende Prieto}, C. and
+                  {Norris}, J.~E.},
+  title =        "{Estimation of stellar atmospheric parameters from
+                  SDSS/SEGUE spectra}",
+  journal =      {Astronomy and Astrophysics},
+  eprint =       {arXiv:astro-ph/0703309},
+  year =         2007,
+  month =        jun,
+  volume =       467,
+  pages =        {1373-1387},
+  doi =          {10.1051/0004-6361:20077334},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2007A%26A...467.1373R},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
 }
 
-@ARTICLE{2011arXiv1110.0497D,
-   author = {{Dowler}, P. and {Rixon}, G. and {Tody}, D.},
-    title = "{IVOA Recommendation: Table Access Protocol Version 1.0}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1110.0497},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-     year = 2011,
-    month = oct,
-   adsurl = {http://adsabs.harvard.edu/abs/2011arXiv1110.0497D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@INPROCEEDINGS{2004ASPC..314..585P,
-   author = {{Plante}, R. and {Greene}, G. and {Hanisch}, R. and {McGlynn}, T. and
-	{O'Mullane}, W. and {Williamson}, R.},
-    title = "{Resource Registries for the Virtual Observatory}",
-booktitle = {Astronomical Data Analysis Software and Systems (ADASS) XIII},
-     year = 2004,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 314,
-   editor = "{F.~Ochsenbein, M.~G.~Allen, \& D.~Egret}",
-    month = jul,
-    pages = {585},
-   adsurl = {http://adsabs.harvard.edu/abs/2004ASPC..314..585P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2011EAS....45..351H,
-   author = {{Hogg}, D.~W. and {Lang}, D.},
-    title = "{Telescopes don't make catalogues!}",
-booktitle = {EAS Publications Series},
-     year = 2011,
-   series = {EAS Publications Series},
-   volume = 45,
-archivePrefix = "arXiv",
-   eprint = {1008.0738},
- primaryClass = "astro-ph.IM",
-    month = feb,
-    pages = {351-358},
-      doi = {10.1051/eas/1045059},
-   adsurl = {http://adsabs.harvard.edu/abs/2011EAS....45..351H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2007AJ....134.1843A,
+  author =       {{Allende Prieto}, C.},
+  title =        "{Velocities from Cross-Correlation: A Guide for
+                  Self-Improvement}",
+  journal =      {\aj},
+  archivePrefix ="arXiv",
+  eprint =       {0707.2764},
+  keywords =     {methods: statistical, stars: kinematics, techniques:
+                  radial velocities},
+  year =         2007,
+  month =        nov,
+  volume =       134,
+  pages =        {1843-1848},
+  doi =          {10.1086/522051},
+  adsurl =       {http://adsabs.harvard.edu/abs/2007AJ....134.1843A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2007ASPC..376..491V,
-   author = {{Valentijn}, E.~A. and {McFarland}, J.~P. and {Snigula}, J. and
-	{Begeman}, K.~G. and {Boxhoorn}, D.~R. and {Rengelink}, R. and
-	{Helmich}, E. and {Heraudeau}, P. and {Kleijn}, G.~V. and {Vermeij}, R. and
-	{Vriend}, W.-J. and {Tempelaar}, M.~J. and {Deul}, E. and {Kuijken}, K. and
-	{Capaccioli}, M. and {Silvotti}, R. and {Bender}, R. and {Neeser}, M. and
-	{Saglia}, R. and {Bertin}, E. and {Mellier}, Y.},
-    title = "{Astro-WISE: Chaining to the Universe}",
-booktitle = {Astronomical Data Analysis Software and Systems XVI},
-     year = 2007,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 376,
-   eprint = {arXiv:astro-ph/0702189},
-   editor = "{R.~A.~Shaw, F.~Hill, \& D.~J.~Bell}",
-    month = oct,
-    pages = {491},
-   adsurl = {http://adsabs.harvard.edu/abs/2007ASPC..376..491V},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Valentijn}, E.~A. and {McFarland}, J.~P. and
+                  {Snigula}, J. and {Begeman}, K.~G. and {Boxhoorn},
+                  D.~R. and {Rengelink}, R. and {Helmich}, E. and
+                  {Heraudeau}, P. and {Kleijn}, G.~V. and {Vermeij},
+                  R. and {Vriend}, W.-J. and {Tempelaar}, M.~J. and
+                  {Deul}, E. and {Kuijken}, K. and {Capaccioli},
+                  M. and {Silvotti}, R. and {Bender}, R. and {Neeser},
+                  M. and {Saglia}, R. and {Bertin}, E. and {Mellier},
+                  Y.},
+  title =        "{Astro-WISE: Chaining to the Universe}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XVI},
+  year =         2007,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       376,
+  eprint =       {arXiv:astro-ph/0702189},
+  editor =       "{R.~A.~Shaw, F.~Hill, \& D.~J.~Bell}",
+  month =        oct,
+  pages =        491,
+  adsurl =       {http://adsabs.harvard.edu/abs/2007ASPC..376..491V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2011arXiv1110.0528T,
-   author = {{Taylor}, M. and {Boch}, T. and {Fitzpatrick}, M. and {Allan}, A. and
-	{Paioro}, L. and {Taylor}, J. and {Tody}, D.},
-    title = "{IVOA Recommendation: SAMP - Simple Application Messaging Protocol Version 1.2}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1110.0528},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-     year = 2011,
-    month = oct,
-   adsurl = {http://adsabs.harvard.edu/abs/2011arXiv1110.0528T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2007arXiv0712.0249O,
+  author =       {{O'Mullane}, W. and {Hoar}, J. and {Lammers}, U.},
+  title =        "{ECSS in the eXtreme}",
+  journal =      {ArXiv e-prints},
+  eprint =       {0712.0249},
+  year =         2007,
+  month =        dec,
+  volume =       712,
+  adsurl =       {http://adsabs.harvard.edu/abs/2007arXiv0712.0249O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2010IAUS..261..320H,
-   author = {{Holl}, B. and {Hobbs}, D. and {Lindegren}, L.},
-    title = "{Spatial correlations in the Gaia astrometric solution}",
- keywords = {Astrometry, reference systems, catalogs, methods: data analysis, methods: statistical, space vehicles},
-booktitle = {IAU Symposium},
-     year = 2010,
-   series = {IAU Symposium},
-   volume = 261,
-   editor = "{S.~A.~Klioner, P.~K.~Seidelmann, \& M.~H.~Soffel}",
-    month = jan,
-    pages = {320-324},
-      doi = {10.1017/S1743921309990573},
-   adsurl = {http://adsabs.harvard.edu/abs/2010IAUS..261..320H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2009ASPC..411..470O,
-   author = {{O'Mullane}, W. and {Hern{\'a}ndez}, J. and {Hoar}, J. and {Lammers}, U.
-	},
-    title = "{Gaia Data Processing Architecture 2009}",
-booktitle = {Astronomical Data Analysis Software and Systems XVIII},
-     year = 2009,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 411,
-   editor = "{D.~A.~Bohlender, D.~Durand, \& P.~Dowler}",
-    month = sep,
-    pages = {470},
-   adsurl = {http://esoads.eso.org/abs/2009ASPC..411..470O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2012A&A...538A..78L,
-   author = {{Lindegren}, L. and {Lammers}, U. and {Hobbs}, D. and {O'Mullane}, W. and
-	{Bastian}, U. and {Hern{\'a}ndez}, J.},
-    title = "{The astrometric core solution for the Gaia mission. Overview of models, algorithms, and software implementation}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1112.4139},
- primaryClass = "astro-ph.IM",
- keywords = {astrometry, methods: data analysis, methods: numerical, space vehicles: instruments},
-     year = 2012,
-    month = feb,
-   volume = 538,
-      eid = {A78},
-    pages = {A78},
-      doi = {10.1051/0004-6361/201117905},
-   adsurl = {http://adsabs.harvard.edu/abs/2012A%26A...538A..78L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2011ASPC..442..351O,
-   author = {{O'Mullane}, W. and {Lammers}, U. and {Hernandez}, J.},
-    title = "{Gaia: Processing to Archive}",
-booktitle = {Astronomical Data Analysis Software and Systems XX},
-     year = 2011,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 442,
-   editor = "{I.~N.~Evans, A.~Accomazzi, D.~J.~Mink, \& A.~H.~Rots}",
-    month = jul,
-    pages = {351},
-   adsurl = {http://adsabs.harvard.edu/abs/2011ASPC..442..351O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2012arXiv1202.0132R,
-   author = {{Robin}, A.~C. and {Luri}, X. and {Reyl{\'e}}, C. and {Isasi}, Y. and
-	{Grux}, E. and {Blanco-Cuaresma}, S. and {Arenou}, F. and {Babusiaux}, C. and
-	{Belcheva}, M. and {Drimmel}, R. and {Jordi}, C. and {Krone-Martins}, A. and
-	{Masana}, E. and {Mauduit}, J.~C. and {Mignard}, F. and {Mowlavi}, N. and
-	{Rocca-Volmerange}, B. and {Sartoretti}, P. and {Slezak}, E. and
-	{Sozzetti}, A.},
-    title = "{Gaia Universe Model Snapshot : A statistical analysis of the expected contents of the Gaia catalogue}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1202.0132},
- primaryClass = "astro-ph.GA",
- keywords = {Astrophysics - Galaxy Astrophysics, Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
-     year = 2012,
-    month = feb,
-   adsurl = {http://adsabs.harvard.edu/abs/2012arXiv1202.0132R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@PROCEEDINGS{1997ESASP1200.....P,
-    title = "{The HIPPARCOS and TYCHO catalogues. Astrometric and photometric star catalogues derived from the ESA HIPPARCOS Space Astrometry Mission}",
- keywords = {SPACE ASTROMETRY, STAR CATALOGS, POSITIONS, ARTIFICIAL SATELLITES},
-booktitle = {ESA Special Publication},
-     year = 1997,
-   series = {ESA Special Publication},
-   volume = 1200,
-   editor = {{Perryman}, M.~A.~C. and {ESA}},
-   adsurl = {http://adsabs.harvard.edu/abs/1997ESASP1200.....P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2007cs........1164S,
+  author =       {{Szalay}, A.~S. and {Gray}, J. and {Fekete}, G. and
+                  {Kunszt}, P.~Z. and {Kukol}, P. and {Thakar}, A.},
+  title =        "{Indexing the Sphere with the Hierarchical
+                  Triangular Mesh}",
+  journal =      {eprint arXiv:cs/0701164},
+  eprint =       {arXiv:cs/0701164},
+  keywords =     {Computer Science - Databases, Computer Science -
+                  Data Structures and Algorithms},
+  year =         2007,
+  month =        jan,
+  adsurl =       {http://adsabs.harvard.edu/abs/2007cs........1164S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2008A&A...478..951K,
-   author = {{Klioner}, S.~A.},
-    title = "{Relativistic scaling of astronomical quantities and the system of astronomical units}",
-  journal = {\aap},
- keywords = {astrometry, reference systems, relativity, time, ephemerides, celestial mechanics},
-     year = 2008,
-    month = feb,
-   volume = 478,
-    pages = {951-958},
-      doi = {10.1051/0004-6361:20077786},
-   adsurl = {http://adsabs.harvard.edu/abs/2008A%26A...478..951K},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2010SPIE.7731E..35D,
-   author = {{de Bruijne}, J. and {Kohley}, R. and {Prusti}, T.},
-    title = "{Gaia: 1,000 million stars with 100 CCD detectors}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2010,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 7731,
-    month = jul,
-      doi = {10.1117/12.862062},
-   adsurl = {http://adsabs.harvard.edu/abs/2010SPIE.7731E..35D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2009SPIE.7439E..29V,
-   author = {{Vosteen}, L.~L.~A. and {Draaisma}, F. and {van Werkhoven}, W.~P. and
-	{van Riel}, L.~J.~M. and {Mol}, M.~H. and {den Ouden}, G.},
-    title = "{Wavefront sensor for the ESA-GAIA mission}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2009,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 7439,
-    month = aug,
-      doi = {10.1117/12.825240},
-   adsurl = {http://adsabs.harvard.edu/abs/2009SPIE.7439E..29V},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{1978moas.coll..197L,
-   author = {{Lindegren}, L.},
-    title = "{Photoelectric astrometry - A comparison of methods for precise image location}",
- keywords = {ASTROMETRY, ELECTROPHOTOMETERS, POSITION (LOCATION), ESTIMATES, PHOTOELECTRIC EFFECT, WEIGHTING FUNCTIONS},
-booktitle = {IAU Colloq. 48: Modern Astrometry},
-     year = 1978,
-   editor = {{Prochazka}, F.~V. and {Tucker}, R.~H.},
-    pages = {197-217},
-   adsurl = {http://adsabs.harvard.edu/abs/1978moas.coll..197L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2010ISSIR...9..279L,
-   author = {{Lindegren}, L.},
-    title = "{High-accuracy positioning: astrometry}",
-  journal = {ISSI Scientific Reports Series},
-     year = 2010,
-   volume = 9,
-    pages = {279-291},
-   adsurl = {http://adsabs.harvard.edu/abs/2010ISSIR...9..279L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2000A&AS..143...33B,
-   author = {{Bonnarel}, F. and {Fernique}, P. and {Bienaym{\'e}}, O. and
-	{Egret}, D. and {Genova}, F. and {Louys}, M. and {Ochsenbein}, F. and
-	{Wenger}, M. and {Bartlett}, J.~G.},
-    title = "{The ALADIN interactive sky atlas. A reference tool for identification of astronomical sources}",
-  journal = {\aaps},
- keywords = {ASTRONOMICAL DATA BASES: MISCELLANEOUS, CATALOGS, ATLASES, SURVEYS},
-     year = 2000,
-    month = apr,
-   volume = 143,
-    pages = {33-40},
-      doi = {10.1051/aas:2000331},
-   adsurl = {http://adsabs.harvard.edu/abs/2000A%26AS..143...33B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2002cs........2013S,
-   author = {{Szalay}, A.~S. and {Gray}, J. and {Thakar}, A.~R. and {Kunszt}, P.~Z. and
-	{Malik}, T. and {Raddick}, J. and {Stoughton}, C. and {vandenBerg}, J.
-	},
-    title = "{The SDSS SkyServer: Public Access to the Sloan Digital Sky Server Data}",
-  journal = {eprint arXiv:cs/0202013},
-   eprint = {arXiv:cs/0202013},
- keywords = {Computer Science - Digital Libraries, Computer Science - Databases, H.3.7, H.3.5, H.2, H.3, H.4, H.5},
-     year = 2002,
-    month = feb,
-   adsurl = {http://adsabs.harvard.edu/abs/2002cs........2013S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2007cs........1164S,
-   author = {{Szalay}, A.~S. and {Gray}, J. and {Fekete}, G. and {Kunszt}, P.~Z. and
-	{Kukol}, P. and {Thakar}, A.},
-    title = "{Indexing the Sphere with the Hierarchical Triangular Mesh}",
-  journal = {eprint arXiv:cs/0701164},
-   eprint = {arXiv:cs/0701164},
- keywords = {Computer Science - Databases, Computer Science - Data Structures and Algorithms},
-     year = 2007,
-    month = jan,
-   adsurl = {http://adsabs.harvard.edu/abs/2007cs........1164S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@INPROCEEDINGS{2011ASPC..442..443C,
-   author = {{Connolly}, A.~J. and {Smith}, I. and {Krughoff}, K.~S. and
-	{Gibson}, R.},
-    title = "{Using the Browser for Science: A Collaborative Toolkit for Astronomy}",
-booktitle = {Astronomical Data Analysis Software and Systems XX},
-     year = 2011,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 442,
-   editor = {{Evans}, I.~N. and {Accomazzi}, A. and {Mink}, D.~J. and {Rots}, A.~H.
-	},
-    month = jul,
-    pages = {443},
-   adsurl = {http://adsabs.harvard.edu/abs/2011ASPC..442..443C},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2010A&A...523A..48J,
-  author = {{Jordi}, C. and {Gebran}, M. and {Carrasco}, J.~M. and {de Bruijne}, J.
-    and {Voss}, H. and {Fabricius}, C. and {Knude}, J. and {Vallenari}, A. and
-    {Kohley}, R. and {Mora}, A.},
-  title = "{Gaia broad band photometry}",
-  journal = {\aap},
-  archivePrefix = "arXiv",
-  eprint = {1008.0815},
-  primaryClass = "astro-ph.IM",
-  keywords = {instrumentation: photometers, techniques: photometric, Galaxy:
-    general, dust, extinction, stars: evolution},
-  year = 2010,
-  month = nov,
-  volume = 523,
-  eid = {A48},
-  pages = {A48},
-  doi = {10.1051/0004-6361/201015441},
-  adsurl =
-  {http://adsabs.harvard.edu/abs/2010A%26A...523A..48J},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2011ExA....31..157H,
-   author = {{Harrison}, D.~L.},
-    title = "{A fast 2D image reconstruction algorithm from 1D data for the Gaia mission}",
-  journal = {Experimental Astronomy},
-archivePrefix = "arXiv",
-   eprint = {1107.0210},
- primaryClass = "astro-ph.IM",
- keywords = {Methods, Data analysis},
-     year = 2011,
-    month = oct,
-   volume = 31,
-    pages = {157-175},
-      doi = {10.1007/s10686-011-9240-7},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/2011ExA....31..157H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2012A&A...547A..59M,
-   author = {{Mignard}, F. and {Klioner}, S.},
-    title = "{Analysis of astrometric catalogues with vector spherical harmonics}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1207.0025},
- primaryClass = "astro-ph.IM",
- keywords = {astrometry, proper motions, reference systems, methods: data analysis},
-     year = 2012,
-    month = nov,
-   volume = 547,
-      eid = {A59},
-    pages = {A59},
-      doi = {10.1051/0004-6361/201219927},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/2012A%26A...547A..59M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2012A&A...543A..14H,
-   author = {{Holl}, B. and {Lindegren}, L.},
-    title = "{Error characterization of the Gaia astrometric solution. I. Mathematical basis of the covariance expansion model}",
-  journal = {\aap},
- keywords = {astrometry, catalogs, methods: data analysis, methods: statistical, space vehicles: instruments},
-     year = 2012,
-    month = jul,
-   volume = 543,
-      eid = {A14},
-    pages = {A14},
-      doi = {10.1051/0004-6361/201218807},
-   adsurl = {http://adsabs.harvard.edu/abs/2012A%26A...543A..14H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2012A&A...543A..15H,
-   author = {{Holl}, B. and {Lindegren}, L. and {Hobbs}, D.},
-    title = "{Error characterization of the Gaia astrometric solution. II. Validating the covariance expansion model}",
-  journal = {\aap},
- keywords = {astrometry, catalogs, methods: data analysis, methods: statistical, space vehicles: instruments},
-     year = 2012,
-    month = jul,
-   volume = 543,
-      eid = {A15},
-    pages = {A15},
-      doi = {10.1051/0004-6361/201218808},
-   adsurl = {http://adsabs.harvard.edu/abs/2012A%26A...543A..15H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@ARTICLE{2008CSE....10...30T,
-   author = {{Thakar}, A.~R. and {Szalay}, A. and {Fekete}, G. and {Gray}, J.
-	},
-    title = "{The Catalog Archive Server Database Management System}",
-  journal = {Computing in Science and Engineering},
-     year = 2008,
-    month = jan,
-   volume = 10,
-    pages = {30-37},
-      doi = {10.1109/MCSE.2008.15},
-   adsurl = {http://adsabs.harvard.edu/abs/2008CSE....10...30T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2008CSE....10....9T,
-   author = {{Thakar}, A.~R.},
-    title = "{The Sloan Digital Sky Survey: Drinking from the Fire Hose}",
-  journal = {Computing in Science and Engineering},
-     year = 2008,
-    month = jan,
-   volume = 10,
-    pages = {9-12},
-      doi = {10.1109/MCSE.2008.17},
-   adsurl = {http://adsabs.harvard.edu/abs/2008CSE....10....9T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-@BOOK{2012adm..book.....S,
-   author = {{Sarro}, L.~M. and {Eyer}, L. and {O'Mullane}, W. and {De Ridder}, J.
-	},
-    title = "{Astrostatistics and Data Mining}",
- keywords = {Physics},
-booktitle = {Astrostatistics and Data Mining},
-     year = 2012,
-      doi = {10.1007/978-1-4614-3323-1},
-   adsurl = {http://adsabs.harvard.edu/abs/2012adm..book.....S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2012SPIE.8449E..0GC,
-   author = {{Comoretto}, G. and {Gallegos}, J. and {Els}, S. and {Gracia}, G. and
-	{Lock}, T. and {Mercier}, E. and {O'Mullane}, W.},
-    title = "{The Information Management Tool (IMT) of Gaia DPAC and its potential as tool for large scale software development projects}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2012,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 8449,
-    month = sep,
-      eid = {84490G},
-      doi = {10.1117/12.926797},
-   adsurl = {http://adsabs.harvard.edu/abs/2012SPIE.8449E..0GC},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2012ExA....34..669R,
-  author = {{Risquez}, D. and {van Leeuwen}, F. and {Brown}, A.~G.~A.},
-  title = "{Dynamical attitude model for Gaia}",
-  journal = {Experimental Astronomy},
-  keywords = {Gaia, Spacecraft attitude, Astrometry, Simulation},
-  year = 2012,
-  month = nov,
-  volume = 34,
-  pages = {669-703},
-  doi = {10.1007/s10686-012-9310-5},
-  adsurl = {http://adsabs.harvard.edu/abs/2012ExA....34..669R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2011MNRAS.414.2215P,
-   author = {{Prod'homme}, T. and {Brown}, A.~G.~A. and {Lindegren}, L. and
-	{Short}, A.~D.~T. and {Brown}, S.~W.},
-    title = "{Electrode level Monte Carlo model of radiation damage effects on astronomical CCDs}",
-  journal = {\mnras},
-archivePrefix = "arXiv",
-   eprint = {1103.3630},
- primaryClass = "astro-ph.IM",
- keywords = {instrumentation: detectors, methods: analytical, methods: data analysis, methods: numerical, space vehicles, astrometry},
-     year = 2011,
-    month = jul,
-   volume = 414,
-    pages = {2215-2228},
-      doi = {10.1111/j.1365-2966.2011.18537.x},
-   adsurl = {http://adsabs.harvard.edu/abs/2011MNRAS.414.2215P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2013MNRAS.430.3155S,
-   author = {{Seabroke}, G.~M. and {Prod'homme}, T. and {Murray}, N.~J. and
-	{Crowley}, C. and {Hopkinson}, G. and {Brown}, A.~G.~A. and
-	{Kohley}, R. and {Holland}, A.},
-    title = "{Digging supplementary buried channels: investigating the notch architecture within the CCD pixels on ESA's Gaia satellite}",
-  journal = {\mnras},
-archivePrefix = "arXiv",
-   eprint = {1302.1873},
- primaryClass = "astro-ph.IM",
- keywords = {instrumentation: detectors, methods: laboratory, methods: numerical, space vehicles: instruments, astrometry, galaxies: general},
-     year = 2013,
-    month = apr,
-   volume = 430,
-    pages = {3155-3170},
-      doi = {10.1093/mnras/stt121},
-   adsurl = {http://adsabs.harvard.edu/abs/2013MNRAS.430.3155S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2013IAUS..289..414M,
-   author = {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D. and {Lammers}, U. and
-	{Yamada}, Y.},
-    title = "{Improving distance estimates to nearby bright stars: Combining astrometric data from Hipparcos, Nano-JASMINE and Gaia}",
- keywords = {astrometry, catalogs, methods: data analysis, methods: statistical, reference systems,},
-booktitle = {IAU Symposium},
-     year = 2013,
-   series = {IAU Symposium},
-   volume = 289,
-   editor = {{de Grijs}, R.},
-    month = feb,
-    pages = {414-417},
-      doi = {10.1017/S1743921312021849},
-   adsurl = {http://adsabs.harvard.edu/abs/2013IAUS..289..414M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2012ASPC..461..585Y,
-   author = {{Yamada}, Y. and {Hara}, T. and {Yoshioka}, S. and {Kobayashi}, Y. and
-	{Gouda}, N. and {Miyashita}, H. and {Hatsutori}, Y. and {Lammers}, U. and
-	{Michalik}, D.},
-    title = "{Nano-JASMINE Data Analysis and Publication}",
-booktitle = {Astronomical Data Analysis Software and Systems XXI},
-     year = 2012,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 461,
-   editor = {{Ballester}, P. and {Egret}, D. and {Lorente}, N.~P.~F.},
-    month = sep,
-    pages = {585},
-   adsurl = {http://adsabs.harvard.edu/abs/2012ASPC..461..585Y},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2012ASPC..461..549M,
-   author = {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D. and {Lammers}, U. and
-	{Yamada}, Y.},
-    title = "{Combining and Comparing Astrometric Data from Different Epochs: A Case Study with Hipparcos and Nano-JASMINE}",
-booktitle = {Astronomical Data Analysis Software and Systems XXI},
-     year = 2012,
-   series = {Astronomical Society of the Pacific Conference Series},
-   volume = 461,
-archivePrefix = "arXiv",
-   eprint = {1201.2849},
- primaryClass = "astro-ph.IM",
-   editor = {{Ballester}, P. and {Egret}, D. and {Lorente}, N.~P.~F.},
-    month = sep,
-    pages = {549},
-   adsurl = {http://adsabs.harvard.edu/abs/2012ASPC..461..549M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2011A&A...530A..76W,
-   author = {{Windmark}, F. and {Lindegren}, L. and {Hobbs}, D.},
-    title = "{Using Galactic Cepheids to verify Gaia parallaxes}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1104.2348},
- primaryClass = "astro-ph.IM",
- keywords = {stars: variables: Cepheids, space vehicles: instruments, parallaxes},
-     year = 2011,
-    month = jun,
-   volume = 530,
-      eid = {A76},
-    pages = {A76},
-      doi = {10.1051/0004-6361/201116929},
-   adsurl = {http://adsabs.harvard.edu/abs/2011A%26A...530A..76W},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1998MNRAS.298..387D,
-   author = {{Dehnen}, W. and {Binney}, J.~J.},
-    title = "{Local stellar kinematics from HIPPARCOS data}",
-  journal = {\mnras},
-   eprint = {astro-ph/9710077},
- keywords = {STARS: KINEMATICS, GALAXY: FUNDAMENTAL PARAMETERS, GALAXY: KINEMATICS AND DYNAMICS, SOLAR NEIGHBOURHOOD, GALAXY: STRUCTURE},
-     year = 1998,
-    month = aug,
-   volume = 298,
-    pages = {387-394},
-      doi = {10.1046/j.1365-8711.1998.01600.x},
-   adsurl = {http://adsabs.harvard.edu/abs/1998MNRAS.298..387D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2000A&A...354..522M,
-   author = {{Mignard}, F.},
-    title = "{Local galactic kinematics from Hipparcos proper motions}",
-  journal = {\aap},
- keywords = {ASTROMETRY, CELESTIAL MECHANICS, STELLAR DYNAMICS, GALAXY: KINEMATICS AND DYNAMICS, GALAXY: SOLAR NEIGHBOURHOOD},
-     year = 2000,
-    month = feb,
-   volume = 354,
-    pages = {522-536},
-   adsurl = {http://adsabs.harvard.edu/abs/2000A%26A...354..522M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Klioner}, S.~A.},
+  title =        "{Relativistic scaling of astronomical quantities and
+                  the system of astronomical units}",
+  journal =      {\aap},
+  keywords =     {astrometry, reference systems, relativity, time,
+                  ephemerides, celestial mechanics},
+  year =         2008,
+  month =        feb,
+  volume =       478,
+  pages =        {951-958},
+  doi =          {10.1051/0004-6361:20077786},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008A%26A...478..951K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2008A&A...488..401R,
-   author = {{R{\"o}ser}, S. and {Schilbach}, E. and {Schwan}, H. and {Kharchenko}, N.~V. and
-	{Piskunov}, A.~E. and {Scholz}, R.-D.},
-    title = "{PPM-Extended (PPMX) - a catalogue of positions and proper motions}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {0806.1009},
- keywords = {catalogs, astrometry},
-     year = 2008,
-    month = sep,
-   volume = 488,
-    pages = {401-408},
-      doi = {10.1051/0004-6361:200809775},
-   adsurl = {http://adsabs.harvard.edu/abs/2008A%26A...488..401R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{R{\"o}ser}, S. and {Schilbach}, E. and {Schwan},
+                  H. and {Kharchenko}, N.~V. and {Piskunov}, A.~E. and
+                  {Scholz}, R.-D.},
+  title =        "{PPM-Extended (PPMX) - a catalogue of positions and
+                  proper motions}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {0806.1009},
+  keywords =     {catalogs, astrometry},
+  year =         2008,
+  month =        sep,
+  volume =       488,
+  pages =        {401-408},
+  doi =          {10.1051/0004-6361:200809775},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008A%26A...488..401R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2012A&A...543A.100R,
-   author = {{Robin}, A.~C. and {Luri}, X. and {Reyl{\'e}}, C. and {Isasi}, Y. and
-	{Grux}, E. and {Blanco-Cuaresma}, S. and {Arenou}, F. and {Babusiaux}, C. and
-	{Belcheva}, M. and {Drimmel}, R. and {Jordi}, C. and {Krone-Martins}, A. and
-	{Masana}, E. and {Mauduit}, J.~C. and {Mignard}, F. and {Mowlavi}, N. and
-	{Rocca-Volmerange}, B. and {Sartoretti}, P. and {Slezak}, E. and
-	{Sozzetti}, A.},
-    title = "{Gaia Universe model snapshot. A statistical analysis of the expected contents of the Gaia catalogue}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1202.0132},
- primaryClass = "astro-ph.GA",
- keywords = {methods: data analysis, Galaxy: stellar content, catalogs, Galaxy: structure, galaxies: statistics, stars: statistics},
-     year = 2012,
-    month = jul,
-   volume = 543,
-      eid = {A100},
-    pages = {A100},
-      doi = {10.1051/0004-6361/201118646},
-   adsurl = {http://adsabs.harvard.edu/abs/2012A%26A...543A.100R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2008AIPC.1082..331H,
+  author =       {{Hogg}, D.~W. and {Lang}, D.},
+  title =        "{Astronomical imaging: The theory of everything}",
+  keywords =     {astronomical atlases, statistical analysis,
+                  astronomical telescopes},
+  booktitle =    {American Institute of Physics Conference Series},
+  year =         2008,
+  series =       {American Institute of Physics Conference Series},
+  volume =       1082,
+  month =        dec,
+  pages =        {331-338},
+  doi =          {10.1063/1.3059072},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008AIPC.1082..331H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008AJ....136..735L,
+  author =       {{Lasker}, B.M. and {Lattanzi}, M.G. and {McLean},
+                  B.J. and {Bucciarelli}, B. and {Drimmel}, R. and
+                  {Garcia}, Jorge and {Greene}, Gretchen and
+                  {Guglielmetti}, Fabrizia and {Hanley}, Christopher
+                  and {Hawkins}, George and {Laidler}, Victoria G. and
+                  {Loomis}, Charles and {Meakes}, Michael and
+                  {Mignani}, Roberto and {Morbidelli}, Roberto and
+                  {Morrison}, Jane and {Pannunzio}, Renato and
+                  {Rosenberg}, Amy and {Sarasso}, Maria and {Smart},
+                  Richard L. and {Spagna}, Alessandro and {Sturch},
+                  Conrad R. and {Volpicelli}, Antonio and {White},
+                  Richard L. and {Wolfe}, David and {Zacchei}, Andrea},
+  title =        "{THE SECOND-GENERATION GUIDE STAR CATALOG:
+                  DESCRIPTION AND PROPERTIES}",
+  journal =      {The Astronomical Journal},
+  keywords =     {astrometry; astronomical data bases: miscellaneous;
+                  catalogs; surveys; techniques: image processing;
+                  techniques: photometric},
+  year =         2008,
+  month =        aug,
+  volume =       136,
+  number =       2,
+  doi =          {10.1088/0004-6256/136/2/735},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008AJ....136..735L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008CSE....10....9T,
+  author =       {{Thakar}, A.~R.},
+  title =        "{The Sloan Digital Sky Survey: Drinking from the
+                  Fire Hose}",
+  journal =      {Computing in Science and Engineering},
+  year =         2008,
+  month =        jan,
+  volume =       10,
+  pages =        {9-12},
+  doi =          {10.1109/MCSE.2008.17},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008CSE....10....9T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008CSE....10...30T,
+  author =       {{Thakar}, A.~R. and {Szalay}, A. and {Fekete},
+                  G. and {Gray}, J.  },
+  title =        "{The Catalog Archive Server Database Management
+                  System}",
+  journal =      {Computing in Science and Engineering},
+  year =         2008,
+  month =        jan,
+  volume =       10,
+  pages =        {30-37},
+  doi =          {10.1109/MCSE.2008.15},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008CSE....10...30T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008ExA....22..143P,
+  author =       {{Perryman}, M. and {de Bruijne}, J. and {Lammers},
+                  U.},
+  title =        "{A parameter database for large scientific projects:
+                  application to the Gaia space astrometry mission}",
+  journal =      {Experimental Astronomy},
+  year =         2008,
+  month =        oct,
+  volume =       22,
+  pages =        {143-150},
+  doi =          {10.1007/s10686-008-9116-7},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008ExA....22..143P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2008SPIE.7021E..0HB,
+  author =       {{Beletic}, J.~W. and {Blank}, R. and {Gulbransen},
+                  D. and {Lee}, D. and {Loose}, M. and {Piquette},
+                  E.~C. and {Sprafke}, T. and {Tennant}, W.~E. and
+                  {Zandian}, M. and {Zino}, J.},
+  title =        "{Teledyne Imaging Sensors: infrared imaging
+                  technologies for astronomy and civil space}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2008,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7021,
+  month =        jul,
+  eid =          {70210H},
+  pages =        {70210H},
+  doi =          {10.1117/12.790382},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008SPIE.7021E..0HB},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009ASPC..411...55L,
+  author =       {{Lammers}, U. and {Lindegren}, L. and {O'Mullane},
+                  W. and {Hobbs}, D.  },
+  title =        "{To Boldly Go Where No Man has Gone Before: Seeking
+                  Gaia's Astrometric Solution with AGIS}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  XVIII},
+  year =         2009,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       411,
+  editor =       "{D.~A.~Bohlender, D.~Durand, \& P.~Dowler}",
+  month =        sep,
+  pages =        {55-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009ASPC..411...55L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009ASPC..411..470O,
+  author =       {{O'Mullane}, W. and {Hern{\'a}ndez}, J. and {Hoar},
+                  J. and {Lammers}, U.  },
+  title =        "{Gaia Data Processing Architecture 2009}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  XVIII},
+  year =         2009,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       411,
+  editor =       "{D.~A.~Bohlender, D.~Durand, \& P.~Dowler}",
+  month =        sep,
+  pages =        470,
+  adsurl =       {http://esoads.eso.org/abs/2009ASPC..411..470O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2009ApJS..182..543A,
+  author =       {{Abazajian}, K.N. and Adelman-McCarthy, Jennifer
+                  K. and Ageros, Marcel A. and Allam, Sahar S. and
+                  Allende Prieto, Carlos and An, Deokkeun and
+                  Anderson, Kurt S. J. and Anderson, Scott F. and
+                  Annis, James and Bahcall, Neta A. and Bailer-Jones,
+                  C. A. L. and Barentine, J. C. and Bassett, Bruce
+                  A. and Becker, Andrew C. and Beers, Timothy C. and
+                  Bell, Eric F. and Belokurov, Vasily and Berlind,
+                  Andreas A. and Berman, Eileen F. and Bernardi,
+                  Mariangela and Bickerton, Steven J. and Bizyaev,
+                  Dmitry and Blakeslee, John P. and Blanton, Michael
+                  R. and Bochanski, John J. and Boroski, William
+                  N. and Brewington, Howard J. and Brinchmann, Jarle
+                  and Brinkmann, J. and Brunner, Robert J. and
+                  Budavri, Tams and Carey, Larry N. and Carliles,
+                  Samuel and Carr, Michael A. and Castander, Francisco
+                  J. and Cinabro, David and Connolly, A. J. and
+                  Csabai, Istvn and Cunha, Carlos E. and Czarapata,
+                  Paul C. and Davenport, James R. A. and de Haas,
+                  Ernst and Dilday, Ben and Doi, Mamoru and
+                  Eisenstein, Daniel J. and Evans, Michael L. and
+                  Evans, N. W. and Fan, Xiaohui and Friedman, Scott
+                  D. and Frieman, Joshua A. and Fukugita, Masataka and
+                  Gnsicke, Boris T. and Gates, Evalyn and Gillespie,
+                  Bruce and Gilmore, G. and Gonzalez, Belinda and
+                  Gonzalez, Carlos F. and Grebel, Eva K. and Gunn,
+                  James E. and Gyry, Zsuzsanna and Hall, Patrick
+                  B. and Harding, Paul and Harris, Frederick H. and
+                  Harvanek, Michael and Hawley, Suzanne L. and Hayes,
+                  Jeffrey J. E. and Heckman, Timothy M. and Hendry,
+                  John S. and Hennessy, Gregory S. and Hindsley,
+                  Robert B. and Hoblitt, J. and Hogan, Craig J. and
+                  Hogg, David W. and Holtzman, Jon A. and Hyde, Joseph
+                  B. and Ichikawa, Shin-ichi and Ichikawa, Takashi and
+                  Im, Myungshin and Ivezic, Zeljko and Jester,
+                  Sebastian and Jiang, Linhua and Johnson, Jennifer
+                  A. and Jorgensen, Anders M. and Juric, Mario and
+                  Kent, Stephen M. and Kessler, R. and Kleinman,
+                  S. J. and Knapp, G. R. and Konishi, Kohki and Kron,
+                  Richard G. and Krzesinski, Jurek and Kuropatkin,
+                  Nikolay and Lampeitl, Hubert and Lebedeva, Svetlana
+                  and Lee, Myung Gyoon and Lee, Young Sun and French
+                  Leger, R. and Lpine, Sbastien and Li, Nolan and
+                  Lima, Marcos and Lin, Huan and Long, Daniel C. and
+                  Loomis, Craig P. and Loveday, Jon and Lupton, Robert
+                  H. and Magnier, Eugene and Malanushenko, Olena and
+                  Malanushenko, Viktor and Mandelbaum, Rachel and
+                  Margon, Bruce and Marriner, John P. and
+                  Martnez-Delgado, David and Matsubara, Takahiko and
+                  McGehee, Peregrine M. and McKay, Timothy A. and
+                  Meiksin, Avery and Morrison, Heather L. and
+                  Mullally, Fergal and Munn, Jeffrey A. and Murphy,
+                  Tara and Nash, Thomas and Nebot, Ada and Neilsen,
+                  Eric H., Jr. and Newberg, Heidi Jo and Newman, Peter
+                  R. and Nichol, Robert C. and Nicinski, Tom and
+                  Nieto-Santisteban, Maria and Nitta, Atsuko and
+                  Okamura, Sadanori and Oravetz, Daniel J. and
+                  Ostriker, Jeremiah P. and Owen, Russell and
+                  Padmanabhan, Nikhil and Pan, Kaike and Park,
+                  Changbom and Pauls, George and Peoples, John,
+                  Jr. and Percival, Will J. and Pier, Jeffrey R. and
+                  Pope, Adrian C. and Pourbaix, Dimitri and Price,
+                  Paul A. and Purger, Norbert and Quinn, Thomas and
+                  Raddick, M. Jordan and Re Fiorentin, Paola and
+                  Richards, Gordon T. and Richmond, Michael W. and
+                  Riess, Adam G. and Rix, Hans-Walter and Rockosi,
+                  Constance M. and Sako, Masao and Schlegel, David
+                  J. and Schneider, Donald P. and Scholz, Ralf-Dieter
+                  and Schreiber, Matthias R. and Schwope, Axel D. and
+                  Seljak, Uro and Sesar, Branimir and Sheldon, Erin
+                  and Shimasaku, Kazu and Sibley, Valena C. and
+                  Simmons, A. E. and Sivarani, Thirupathi and Allyn
+                  Smith, J. and Smith, Martin C. and Smolcic, Vernesa
+                  and Snedden, Stephanie A. and Stebbins, Albert and
+                  Steinmetz, Matthias and Stoughton, Chris and
+                  Strauss, Michael A. and SubbaRao, Mark and Suto,
+                  Yasushi and Szalay, Alexander S. and Szapudi, Istvn
+                  and Szkody, Paula and Tanaka, Masayuki and Tegmark,
+                  Max and Teodoro, Luis F. A. and Thakar, Aniruddha
+                  R. and Tremonti, Christy A. and Tucker, Douglas
+                  L. and Uomoto, Alan and Vanden Berk, Daniel E. and
+                  Vandenberg, Jan and Vidrih, S. and Vogeley, Michael
+                  S. and Voges, Wolfgang and Vogt, Nicole P. and
+                  Wadadekar, Yogesh and Watters, Shannon and Weinberg,
+                  David H. and West, Andrew A. and White, Simon
+                  D. M. and Wilhite, Brian C. and Wonders, Alainna
+                  C. and Yanny, Brian and Yocum, D. R. and York,
+                  Donald G. and Zehavi, Idit and Zibetti, Stefano and
+                  Zucker, Daniel B.},
+  title =        "{THE SEVENTH DATA RELEASE OF THE SLOAN DIGITAL SKY
+                  SURVEY}",
+  journal =      {The Astrophysical Journal Supplement Series},
+  keywords =     {atlases; catalogs; surveys},
+  year =         2009,
+  month =        jun,
+  volume =       182,
+  number =       2,
+  doi =          {10.1088/0067-0049/182/2/543},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009ApJS..182..543A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009SPIE.7439E..14V,
+  author =       {{Vosteen}, L.~L.~A. and {Draaisma}, F. and {van
+                  Werkhoven}, W.~P. and {van Riel}, L.~J.~M. and
+                  {Mol}, M.~H. and {den Ouden}, G.},
+  title =        "{Wavefront sensor for the ESA-GAIA mission}",
+  booktitle =    {Astronomical and Space Optical Systems},
+  year =         2009,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7439,
+  month =        aug,
+  eid =          743914,
+  pages =        743914,
+  doi =          {10.1117/12.825240},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009SPIE.7439E..14V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009SPIE.7439E..29V,
+  author =       {{Vosteen}, L.~L.~A. and {Draaisma}, F. and {van
+                  Werkhoven}, W.~P. and {van Riel}, L.~J.~M. and
+                  {Mol}, M.~H. and {den Ouden}, G.},
+  title =        "{Wavefront sensor for the ESA-GAIA mission}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2009,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7439,
+  month =        aug,
+  doi =          {10.1117/12.825240},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009SPIE.7439E..29V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...516A..77B,
+  author =       {{Bombrun}, A. and {Lindegren}, L. and {Holl}, B. and
+                  {Jordan}, S.  },
+  title =        "{Complexity of the Gaia astrometric least-squares
+                  problem and the (non-)feasibility of a direct
+                  solution method}",
+  journal =      {\aap},
+  keywords =     {methods: data analysis, methods: numerical, space
+                  vehicles: instruments, astrometry, reference
+                  systems},
+  year =         2010,
+  month =        jun,
+  volume =       516,
+  pages =        {A77},
+  doi =          {10.1051/0004-6361/200913503},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A%26A...516A..77B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...518A..10V,
+  author =       {{Veron-Cetty}, M.P. and {Veron}, P.},
+  title =        "{A catalogue of quasars and active nuclei: 13th
+                  edition}",
+  journal =      {Astronomy and Astrophysics},
+  keywords =     {quasars: general, galaxies: Seyfert, BL Lacertae
+                  objects: general},
+  year =         2010,
+  month =        jul,
+  volume =       518,
+  doi =          {10.1051/0004-6361/201014188},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A&A...518A..10V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...523A..48J,
+  author =       {{Jordi}, C. and {Gebran}, M. and {Carrasco},
+                  J.~M. and {de Bruijne}, J.  and {Voss}, H. and
+                  {Fabricius}, C. and {Knude}, J. and {Vallenari},
+                  A. and {Kohley}, R. and {Mora}, A.},
+  title =        "{Gaia broad band photometry}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1008.0815},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: photometers, techniques:
+                  photometric, Galaxy: general, dust, extinction,
+                  stars: evolution},
+  year =         2010,
+  month =        nov,
+  volume =       523,
+  eid =          {A48},
+  pages =        {A48},
+  doi =          {10.1051/0004-6361/201015441},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A%26A...523A..48J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010AAS...21641512W,
+  author =       {Wood-Vasey, W. Michael and Rest, A. and Smartt,
+                  S. and Huber, M. and Narayan, G. and Price, P. and
+                  Valenti, S. and Smith, K. and Botticella, M. and
+                  Foley, R. J. and Rodney, S. and Young, D. and
+                  Gezari, S. and Chornock, R. and Challis, P. and
+                  Tonry, J. and Chornock, R. and Stubbs, C. and
+                  Welling, J. and Riess, A. and Berger, E. and
+                  Soderberg, A. M. and Sand, D. J. and Kirshner,
+                  R. P. and Builders, PS1},
+  title =        "{The Pan-STARRS 1 Survey Transient Identification
+                  System}",
+  booktitle =    {Bulletin of the American Astronomical Society},
+  year =         2010,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       42,
+  month =        may,
+  adsurl =       {http://adsabs.harvard.edu/abs/2010AAS...21641512W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010IAUS..261..320H,
+  author =       {{Holl}, B. and {Hobbs}, D. and {Lindegren}, L.},
+  title =        "{Spatial correlations in the Gaia astrometric
+                  solution}",
+  keywords =     {Astrometry, reference systems, catalogs, methods:
+                  data analysis, methods: statistical, space vehicles},
+  booktitle =    {IAU Symposium},
+  year =         2010,
+  series =       {IAU Symposium},
+  volume =       261,
+  editor =       "{S.~A.~Klioner, P.~K.~Seidelmann, \& M.~H.~Soffel}",
+  month =        jan,
+  pages =        {320-324},
+  doi =          {10.1017/S1743921309990573},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010IAUS..261..320H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010ISSIR...9..279L,
+  author =       {{Lindegren}, L.},
+  title =        "{High-accuracy positioning: astrometry}",
+  journal =      {ISSI Scientific Reports Series},
+  year =         2010,
+  volume =       9,
+  pages =        {279-291},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010ISSIR...9..279L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7731E..35D,
+  author =       {{de Bruijne}, J. and {Kohley}, R. and {Prusti}, T.},
+  title =        "{Gaia: 1,000 million stars with 100 CCD detectors}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2010,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7731,
+  month =        jul,
+  doi =          {10.1117/12.862062},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7731E..35D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7740E..51G,
+  author =       {{Gaudet}, S. and {Hill}, N. and {Armstrong}, P. and
+                  {Ball}, N. and {Burke}, J. and {Chapel}, B. and
+                  {Chapin}, E. and {Damian}, A. and {Dowler}, P. and
+                  {Gable}, I. and {Goliath}, S. and {Ghiurea}, I. and
+                  {Fabbro}, S. and {Gwyn}, S. and {Jenkins}, D. and
+                  {Kavelaars}, J. and {Major}, B. and {Ouellette},
+                  J. and {Paterson}, M. and {Peddle}, M. and
+                  {Penfold-Brown}, D. and {Pritchet}, C. and {Schade},
+                  D. and {Sobie}, R. and {Woods}, D. and {Yeung},
+                  A. and {Zhang}, Y.},
+  title =        "{CANFAR: the Canadian Advanced Network for
+                  Astronomical Research}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2010,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7740,
+  month =        jul,
+  doi =          {10.1117/12.858026},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7740E..51G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011A&A...530A..76W,
+  author =       {{Windmark}, F. and {Lindegren}, L. and {Hobbs}, D.},
+  title =        "{Using Galactic Cepheids to verify Gaia parallaxes}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1104.2348},
+  primaryClass = "astro-ph.IM",
+  keywords =     {stars: variables: Cepheids, space vehicles:
+                  instruments, parallaxes},
+  year =         2011,
+  month =        jun,
+  volume =       530,
+  eid =          {A76},
+  pages =        {A76},
+  doi =          {10.1051/0004-6361/201116929},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011A%26A...530A..76W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011AAS...21734408S,
+  author =       {{Schmitz}, M. and {Baker}, K. and {Chan}, B. and
+                  {Corwin}, H., Jr. and {Ebert}, R. and {Frayer},
+                  C. and {Helou}, G. and {LaGue}, C. and {Lo}, T. and
+                  {Madore}, B. and {Mazzarella}, J. and {Pevunova},
+                  O. and {Steer}, I. and {Terek}, S.},
+  title =        "{The NASA/IPAC Extragalactic Database (NED):
+                  Enhanced Content and New Functionality}",
+  booktitle =    {Bulletin of the American Astronomical Society},
+  year =         2011,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       43,
+  month =        jan,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011AAS...21734408S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011ASPC..442..351O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and {Hernandez},
+                  J.},
+  title =        "{Gaia: Processing to Archive}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       "{I.~N.~Evans, A.~Accomazzi, D.~J.~Mink, \&
+                  A.~H.~Rots}",
+  month =        jul,
+  pages =        351,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..351O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011ASPC..442..443C,
+  author =       {{Connolly}, A.~J. and {Smith}, I. and {Krughoff},
+                  K.~S. and {Gibson}, R.},
+  title =        "{Using the Browser for Science: A Collaborative
+                  Toolkit for Astronomy}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       {{Evans}, I.~N. and {Accomazzi}, A. and {Mink},
+                  D.~J. and {Rots}, A.~H.  },
+  month =        jul,
+  pages =        443,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..443C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2011EAS....45..109L,
-   author = {{Lindegren}, L. and {Bastian}, U.},
-    title = "{Basic principles of scanning space astrometry}",
-booktitle = {EAS Publications Series},
-     year = 2011,
-   series = {EAS Publications Series},
-   volume = 45,
-    month = feb,
-    pages = {109-114},
-      doi = {10.1051/eas/1045018},
-   adsurl = {http://adsabs.harvard.edu/abs/2011EAS....45..109L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Lindegren}, L. and {Bastian}, U.},
+  title =        "{Basic principles of scanning space astrometry}",
+  booktitle =    {EAS Publications Series},
+  year =         2011,
+  series =       {EAS Publications Series},
+  volume =       45,
+  month =        feb,
+  pages =        {109-114},
+  doi =          {10.1051/eas/1045018},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011EAS....45..109L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2012SPIE.8442E..1PK,
-   author = {{Kohley}, R. and {Gar{\'e}}, P. and {V{\'e}tel}, C. and {Marchais}, D. and
-	{Chassat}, F.},
-    title = "{Gaia's FPA: sampling the sky in silicon}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2012,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 8442,
-    month = sep,
-      eid = {84421P},
-      doi = {10.1117/12.926144},
-   adsurl = {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1PK},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2011EAS....45..351H,
+  author =       {{Hogg}, D.~W. and {Lang}, D.},
+  title =        "{Telescopes don't make catalogues!}",
+  booktitle =    {EAS Publications Series},
+  year =         2011,
+  series =       {EAS Publications Series},
+  volume =       45,
+  archivePrefix ="arXiv",
+  eprint =       {1008.0738},
+  primaryClass = "astro-ph.IM",
+  month =        feb,
+  pages =        {351-358},
+  doi =          {10.1051/eas/1045059},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011EAS....45..351H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2012SPIE.8442E..1QM,
-   author = {{Mora}, A. and {Vosteen}, A.},
-    title = "{Gaia in-orbit realignment: overview and data analysis}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2012,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 8442,
-archivePrefix = "arXiv",
-   eprint = {1207.2087},
- primaryClass = "astro-ph.IM",
-    month = sep,
-      eid = {84421Q},
-      doi = {10.1117/12.926313},
-   adsurl = {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1QM},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2011ExA....31..157H,
+  author =       {{Harrison}, D.~L.},
+  title =        "{A fast 2D image reconstruction algorithm from 1D
+                  data for the Gaia mission}",
+  journal =      {Experimental Astronomy},
+  archivePrefix ="arXiv",
+  eprint =       {1107.0210},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Methods, Data analysis},
+  year =         2011,
+  month =        oct,
+  volume =       31,
+  pages =        {157-175},
+  doi =          {10.1007/s10686-011-9240-7},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/2011ExA....31..157H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{2012SPIE.8442E..1RG,
-   author = {{Gielesen}, W. and {de Bruijn}, D. and {van den Dool}, T. and
-	{Kamphues}, F. and {Meijer}, E. and {Calvel}, B. and {Laborie}, A. and
-	{Monteiro}, D. and {Coatantiec}, C. and {Touzeau}, S. and {Erdmann}, M. and
-	{Gare}, P.},
-    title = "{Gaia basic angle monitoring system}",
-booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-     year = 2012,
-   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-   volume = 8442,
-    month = sep,
-      eid = {84421R},
-      doi = {10.1117/12.926322},
-   adsurl = {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1RG},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2011ExA....31..215O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and {Lindegren},
+                  L. and {Hernandez}, J. and {Hobbs}, D.},
+  title =        "{Implementing the Gaia Astrometric Global Iterative
+                  Solution (AGIS) in Java}",
+  journal =      {Experimental Astronomy},
+  archivePrefix ="arXiv",
+  eprint =       {1108.2206},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrometry, Satellite, Algorithms, Implementation,
+                  Data management},
+  year =         2011,
+  month =        oct,
+  volume =       31,
+  pages =        {215-241},
+  doi =          {10.1007/s10686-011-9248-z},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ExA....31..215O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2014A&A...566A.119L,
-   author = {{Luri}, X. and {Palmer}, M. and {Arenou}, F. and {Masana}, E. and
-	{de Bruijne}, J. and {Antiche}, E. and {Babusiaux}, C. and {Borrachero}, R. and
-	{Sartoretti}, P. and {Julbe}, F. and {Isasi}, Y. and {Martinez}, O. and
-	{Robin}, A.~C. and {Reyl{\'e}}, C. and {Jordi}, C. and {Carrasco}, J.~M.
-	},
-    title = "{Overview and stellar statistics of the expected Gaia Catalogue using the Gaia Object Generator}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1404.5861},
- primaryClass = "astro-ph.IM",
- keywords = {stars: statistics, galaxies: statistics, Galaxy: stellar content, methods: data analysis, astrometry, catalogs},
-     year = 2014,
-    month = jun,
-   volume = 566,
-      eid = {A119},
-    pages = {A119},
-      doi = {10.1051/0004-6361/201423636},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/2014A%26A...566A.119L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1995A&A...304...61L,
-   author = {{Lindegren}, L.},
-    title = "{Estimating the external accuracy of HIPPARCOS parallaxes by deconvolution.}",
-  journal = {\aap},
- keywords = {ASTROMETRY, METHODS: DATA ANALYSIS, METHODS: NUMERICAL, STARS: DISTANCES},
-     year = 1995,
-    month = dec,
-   volume = 304,
-    pages = {61},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/1995A%26A...304...61L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1995A&A...304...52A,
-   author = {{Arenou}, F. and {Lindegren}, L. and {Froeschle}, M. and {Gomez}, A.~E. and
-	{Turon}, C. and {Perryman}, M.~A.~C. and {Wielen}, R.},
-    title = "{Zero-point and external errors of HIPPARCOS parallaxes}",
-  journal = {\aap},
-     year = 1995,
-    month = dec,
-   volume = 304,
-    pages = {52},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/1995A%26A...304...52A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1990ApJ...361..667T,
-   author = {{Taff}, L.~G. and {Bucciarelli}, B. and {Lattanzi}, M.~G.},
-    title = "{Catalog-to-catalog reductions}",
-  journal = {\apj},
- keywords = {Astrometry, Astronomical Catalogs, Computerized Simulation, Monte Carlo Method},
-     year = 1990,
-    month = oct,
-   volume = 361,
-    pages = {667-672},
-      doi = {10.1086/169230},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/1990ApJ...361..667T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1994ApJ...433..831B,
-   author = {{Bucciarelli}, B. and {Lattanzi}, M.~G. and {Taff}, L.~G.},
-    title = "{The analysis of star catalogs. 1: an intercomparison among the FK3, the FK4, and the FK5}",
-  journal = {\apj},
- keywords = {Astrometry, Astronomical Catalogs, Comparison, Error Analysis, Reference Stars, Statistical Analysis, Statistical Correlation},
-     year = 1994,
-    month = oct,
-   volume = 433,
-    pages = {831-844},
-      doi = {10.1086/174692},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/1994ApJ...433..831B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1985ApJ...298...80C,
-   author = {{Casertano}, S. and {Hut}, P.},
-    title = "{Core radius and density measurements in N-body experiments Connections with theoretical and observational definitions}",
-  journal = {\apj},
- keywords = {Astronomical Models, Density Distribution, Galactic Clusters, Many Body Problem, Star Clusters, Gravitational Effects, Monte Carlo Method},
-     year = 1985,
-    month = nov,
-   volume = 298,
-    pages = {80-94},
-      doi = {10.1086/163589},
-   adsurl = {http://adsabs.harvard.edu/abs/1985ApJ...298...80C},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{1986ApJ...304...62O,
-   author = {{Otto}, S. and {Politzer}, H.~D. and {Preskill}, J. and {Wise}, M.~B.
-	},
-    title = "{The significance of voids}",
-  journal = {\apj},
- keywords = {Cosmology, Galactic Clusters, Galaxies, Spatial Distribution, Statistical Analysis, Void Ratio, Density Distribution, Probability Distribution Functions, Significance, Statistical Correlation, Statistical Distributions},
-     year = 1986,
-    month = may,
-   volume = 304,
-    pages = {62-74},
-      doi = {10.1086/164144},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/1986ApJ...304...62O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2011ExA....31..243O,
+  author =       {{O'Mullane}, W. and {Luri}, X. and {Parsons}, P. and
+                  {Lammers}, U. and {Hoar}, J. and {Hernandez}, J.},
+  title =        "{Using Java for distributed computing in the Gaia
+                  satellite data processing}",
+  journal =      {Experimental Astronomy},
+  archivePrefix ="arXiv",
+  eprint =       {1108.0355},
+  primaryClass = "cs.CE",
+  keywords =     {Distributed computing, Java, Astrometry, Cloud
+                  computing, Mathematics},
+  year =         2011,
+  month =        oct,
+  volume =       31,
+  pages =        {243-258},
+  doi =          {10.1007/s10686-011-9241-6},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ExA....31..243O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2011JPhCS.328a2006S,
-   author = {{Sordo}, R. and {Vallenari}, A. and {Tantalo}, R. and {Liu}, C. and
-	{Smith}, K. and {Allard}, F. and {Blomme}, R. and {Bouret}, J.-C. and
-	{Brott}, I. and {de Laverny}, P. and {Edvardsson}, B. and {Fr{\'e}mat}, Y. and
-	{Heber}, U. and {Josselin}, E. and {Kochukhov}, O. and {Korn}, A. and
-	{Lanzafame}, A. and {Martayan}, C. and {Martins}, F. and {Plez}, B. and
-	{Schweitzer}, A. and {Th{\'e}venin}, F. and {Zorec}, J.},
-    title = "{Stellar libraries for Gaia}",
-  journal = {Journal of Physics Conference Series},
-     year = 2011,
-    month = dec,
-   volume = 328,
-   number = 1,
-      eid = {012006},
-    pages = {012006},
-      doi = {10.1088/1742-6596/328/1/012006},
-   adsurl = {http://esoads.eso.org/abs/2011JPhCS.328a2006S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Sordo}, R. and {Vallenari}, A. and {Tantalo},
+                  R. and {Liu}, C. and {Smith}, K. and {Allard},
+                  F. and {Blomme}, R. and {Bouret}, J.-C. and {Brott},
+                  I. and {de Laverny}, P. and {Edvardsson}, B. and
+                  {Fr{\'e}mat}, Y. and {Heber}, U. and {Josselin},
+                  E. and {Kochukhov}, O. and {Korn}, A. and
+                  {Lanzafame}, A. and {Martayan}, C. and {Martins},
+                  F. and {Plez}, B. and {Schweitzer}, A. and
+                  {Th{\'e}venin}, F. and {Zorec}, J.},
+  title =        "{Stellar libraries for Gaia}",
+  journal =      {Journal of Physics Conference Series},
+  year =         2011,
+  month =        dec,
+  volume =       328,
+  number =       1,
+  eid =          012006,
+  pages =        012006,
+  doi =          {10.1088/1742-6596/328/1/012006},
+  adsurl =       {http://esoads.eso.org/abs/2011JPhCS.328a2006S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2015A&A...583A..68M,
-   author = {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D. and {Butkevich}, A.~G.
-	},
-    title = "{Gaia astrometry for stars with too few observations. A Bayesian approach}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1507.02963},
- primaryClass = "astro-ph.IM",
- keywords = {astrometry, methods: data analysis, methods: numerical, parallaxes, proper motions, space vehicles: instruments},
-     year = 2015,
-    month = nov,
-   volume = 583,
-      eid = {A68},
-    pages = {A68},
-      doi = {10.1051/0004-6361/201526936},
-   adsurl = {http://adsabs.harvard.edu/abs/2015A%26A...583A..68M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2011MNRAS.414.2215P,
+  author =       {{Prod'homme}, T. and {Brown}, A.~G.~A. and
+                  {Lindegren}, L. and {Short}, A.~D.~T. and {Brown},
+                  S.~W.},
+  title =        "{Electrode level Monte Carlo model of radiation
+                  damage effects on astronomical CCDs}",
+  journal =      {\mnras},
+  archivePrefix ="arXiv",
+  eprint =       {1103.3630},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: detectors, methods: analytical,
+                  methods: data analysis, methods: numerical, space
+                  vehicles, astrometry},
+  year =         2011,
+  month =        jul,
+  volume =       414,
+  pages =        {2215-2228},
+  doi =          {10.1111/j.1365-2966.2011.18537.x},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011MNRAS.414.2215P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2015A&A...574A.115M,
-   author = {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D.},
-    title = "{The Tycho-Gaia astrometric solution . How to get 2.5 million parallaxes with less than one year of Gaia data}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1412.8770},
- primaryClass = "astro-ph.IM",
- keywords = {astrometry, methods: data analysis, methods: numerical, space vehicles: instruments, parallaxes, proper motions},
-     year = 2015,
-    month = feb,
-   volume = 574,
-      eid = {A115},
-    pages = {A115},
-      doi = {10.1051/0004-6361/201425310},
-   adsurl = {http://adsabs.harvard.edu/abs/2015A%26A...574A.115M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@ARTICLE{2011arXiv1102.5123H,
+  author =       {{Hassan}, A. and {Fluke}, C.~J.},
+  title =        "{Scientific Visualization in Astronomy: Towards the
+                  Petascale Astronomy Era}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1102.5123},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics, Computer Science - Graphics},
+  year =         2011,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1102.5123H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011arXiv1108.0355O,
+  author =       {{O'Mullane}, W. and {Luri}, X. and {Parsons}, P. and
+                  {Lammers}, U. and {Hoar}, J. and {Hernandez}, J.},
+  title =        "{Using Java for distributed computing in the Gaia
+                  satellite data processing}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1108.0355},
+  primaryClass = "cs.CE",
+  keywords =     {Computer Science - Computational Engineering,
+                  Finance, and Science, Astrophysics - Instrumentation
+                  and Methods for Astrophysics, Computer Science -
+                  Mathematical Software},
+  year =         2011,
+  month =        aug,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1108.0355O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011arXiv1110.0497D,
+  author =       {{Dowler}, P. and {Rixon}, G. and {Tody}, D.},
+  title =        "{IVOA Recommendation: Table Access Protocol Version
+                  1.0}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1110.0497},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics},
+  year =         2011,
+  month =        oct,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1110.0497D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011arXiv1110.0528T,
+  author =       {{Taylor}, M. and {Boch}, T. and {Fitzpatrick},
+                  M. and {Allan}, A. and {Paioro}, L. and {Taylor},
+                  J. and {Tody}, D.},
+  title =        "{IVOA Recommendation: SAMP - Simple Application
+                  Messaging Protocol Version 1.2}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1110.0528},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics},
+  year =         2011,
+  month =        oct,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1110.0528T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...538A..78L,
+  author =       {{Lindegren}, L. and {Lammers}, U. and {Hobbs},
+                  D. and {O'Mullane}, W. and {Bastian}, U. and
+                  {Hern{\'a}ndez}, J.},
+  title =        "{The astrometric core solution for the Gaia
+                  mission. Overview of models, algorithms, and
+                  software implementation}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1112.4139},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, space vehicles: instruments},
+  year =         2012,
+  month =        feb,
+  volume =       538,
+  eid =          {A78},
+  pages =        {A78},
+  doi =          {10.1051/0004-6361/201117905},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...538A..78L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...543A..14H,
+  author =       {{Holl}, B. and {Lindegren}, L.},
+  title =        "{Error characterization of the Gaia astrometric
+                  solution. I. Mathematical basis of the covariance
+                  expansion model}",
+  journal =      {\aap},
+  keywords =     {astrometry, catalogs, methods: data analysis,
+                  methods: statistical, space vehicles: instruments},
+  year =         2012,
+  month =        jul,
+  volume =       543,
+  eid =          {A14},
+  pages =        {A14},
+  doi =          {10.1051/0004-6361/201218807},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...543A..14H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...543A..15H,
+  author =       {{Holl}, B. and {Lindegren}, L. and {Hobbs}, D.},
+  title =        "{Error characterization of the Gaia astrometric
+                  solution. II. Validating the covariance expansion
+                  model}",
+  journal =      {\aap},
+  keywords =     {astrometry, catalogs, methods: data analysis,
+                  methods: statistical, space vehicles: instruments},
+  year =         2012,
+  month =        jul,
+  volume =       543,
+  eid =          {A15},
+  pages =        {A15},
+  doi =          {10.1051/0004-6361/201218808},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...543A..15H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...543A.100R,
+  author =       {{Robin}, A.~C. and {Luri}, X. and {Reyl{\'e}},
+                  C. and {Isasi}, Y. and {Grux}, E. and
+                  {Blanco-Cuaresma}, S. and {Arenou}, F. and
+                  {Babusiaux}, C. and {Belcheva}, M. and {Drimmel},
+                  R. and {Jordi}, C. and {Krone-Martins}, A. and
+                  {Masana}, E. and {Mauduit}, J.~C. and {Mignard},
+                  F. and {Mowlavi}, N. and {Rocca-Volmerange}, B. and
+                  {Sartoretti}, P. and {Slezak}, E. and {Sozzetti},
+                  A.},
+  title =        "{Gaia Universe model snapshot. A statistical
+                  analysis of the expected contents of the Gaia
+                  catalogue}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1202.0132},
+  primaryClass = "astro-ph.GA",
+  keywords =     {methods: data analysis, Galaxy: stellar content,
+                  catalogs, Galaxy: structure, galaxies: statistics,
+                  stars: statistics},
+  year =         2012,
+  month =        jul,
+  volume =       543,
+  eid =          {A100},
+  pages =        {A100},
+  doi =          {10.1051/0004-6361/201118646},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...543A.100R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...547A..59M,
+  author =       {{Mignard}, F. and {Klioner}, S.},
+  title =        "{Analysis of astrometric catalogues with vector
+                  spherical harmonics}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1207.0025},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, proper motions, reference systems,
+                  methods: data analysis},
+  year =         2012,
+  month =        nov,
+  volume =       547,
+  eid =          {A59},
+  pages =        {A59},
+  doi =          {10.1051/0004-6361/201219927},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2012A%26A...547A..59M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012ASPC..461..549M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Lammers}, U. and {Yamada}, Y.},
+  title =        "{Combining and Comparing Astrometric Data from
+                  Different Epochs: A Case Study with Hipparcos and
+                  Nano-JASMINE}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XXI},
+  year =         2012,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       461,
+  archivePrefix ="arXiv",
+  eprint =       {1201.2849},
+  primaryClass = "astro-ph.IM",
+  editor =       {{Ballester}, P. and {Egret}, D. and {Lorente},
+                  N.~P.~F.},
+  month =        sep,
+  pages =        549,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012ASPC..461..549M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012ASPC..461..585Y,
+  author =       {{Yamada}, Y. and {Hara}, T. and {Yoshioka}, S. and
+                  {Kobayashi}, Y. and {Gouda}, N. and {Miyashita},
+                  H. and {Hatsutori}, Y. and {Lammers}, U. and
+                  {Michalik}, D.},
+  title =        "{Nano-JASMINE Data Analysis and Publication}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XXI},
+  year =         2012,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       461,
+  editor =       {{Ballester}, P. and {Egret}, D. and {Lorente},
+                  N.~P.~F.},
+  month =        sep,
+  pages =        585,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012ASPC..461..585Y},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012ExA....34..669R,
+  author =       {{Risquez}, D. and {van Leeuwen}, F. and {Brown},
+                  A.~G.~A.},
+  title =        "{Dynamical attitude model for Gaia}",
+  journal =      {Experimental Astronomy},
+  keywords =     {Gaia, Spacecraft attitude, Astrometry, Simulation},
+  year =         2012,
+  month =        nov,
+  volume =       34,
+  pages =        {669-703},
+  doi =          {10.1007/s10686-012-9310-5},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012ExA....34..669R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@PHDTHESIS{2012PhDT.......175S,
+  author =       {{Sahlmann}, J.},
+  title =        "{Observing exoplanet populations with high-precision
+                  astrometry}",
+  keywords =     {extrasolar planets, astrometry, radial velocities,
+                  interferometry, brown dwarfs, stars: binaries,
+                  stars: low-mass},
+  school =       {Observatoire de Gen{\`e}ve, Universit{\'e} de
+                  Gen{\`e}ve
+                  <EMAIL>Johannes.Sahlmann@unige.ch</EMAIL>},
+  year =         2012,
+  month =        jun,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012PhDT.......175S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8442E..1PK,
+  author =       {{Kohley}, R. and {Gar{\'e}}, P. and {V{\'e}tel},
+                  C. and {Marchais}, D. and {Chassat}, F.},
+  title =        "{Gaia's FPA: sampling the sky in silicon}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8442,
+  month =        sep,
+  eid =          {84421P},
+  doi =          {10.1117/12.926144},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1PK},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8442E..1QM,
+  author =       {{Mora}, A. and {Vosteen}, A.},
+  title =        "{Gaia in-orbit realignment: overview and data
+                  analysis}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8442,
+  archivePrefix ="arXiv",
+  eprint =       {1207.2087},
+  primaryClass = "astro-ph.IM",
+  month =        sep,
+  eid =          {84421Q},
+  doi =          {10.1117/12.926313},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1QM},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8442E..1RG,
+  author =       {{Gielesen}, W. and {de Bruijn}, D. and {van den
+                  Dool}, T. and {Kamphues}, F. and {Meijer}, E. and
+                  {Calvel}, B. and {Laborie}, A. and {Monteiro},
+                  D. and {Coatantiec}, C. and {Touzeau}, S. and
+                  {Erdmann}, M. and {Gare}, P.},
+  title =        "{Gaia basic angle monitoring system}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8442,
+  month =        sep,
+  eid =          {84421R},
+  doi =          {10.1117/12.926322},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1RG},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8449E..0GC,
+  author =       {{Comoretto}, G. and {Gallegos}, J. and {Els}, S. and
+                  {Gracia}, G. and {Lock}, T. and {Mercier}, E. and
+                  {O'Mullane}, W.},
+  title =        "{The Information Management Tool (IMT) of Gaia DPAC
+                  and its potential as tool for large scale software
+                  development projects}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8449,
+  month =        sep,
+  eid =          {84490G},
+  doi =          {10.1117/12.926797},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8449E..0GC},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@BOOK{2012adm..book.....S,
+  author =       {{Sarro}, L.~M. and {Eyer}, L. and {O'Mullane},
+                  W. and {De Ridder}, J.  },
+  title =        "{Astrostatistics and Data Mining}",
+  keywords =     {Physics},
+  booktitle =    {Astrostatistics and Data Mining},
+  year =         2012,
+  doi =          {10.1007/978-1-4614-3323-1},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012adm..book.....S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012arXiv1202.0132R,
+  author =       {{Robin}, A.~C. and {Luri}, X. and {Reyl{\'e}},
+                  C. and {Isasi}, Y. and {Grux}, E. and
+                  {Blanco-Cuaresma}, S. and {Arenou}, F. and
+                  {Babusiaux}, C. and {Belcheva}, M. and {Drimmel},
+                  R. and {Jordi}, C. and {Krone-Martins}, A. and
+                  {Masana}, E. and {Mauduit}, J.~C. and {Mignard},
+                  F. and {Mowlavi}, N. and {Rocca-Volmerange}, B. and
+                  {Sartoretti}, P. and {Slezak}, E. and {Sozzetti},
+                  A.},
+  title =        "{Gaia Universe Model Snapshot : A statistical
+                  analysis of the expected contents of the Gaia
+                  catalogue}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1202.0132},
+  primaryClass = "astro-ph.GA",
+  keywords =     {Astrophysics - Galaxy Astrophysics, Astrophysics -
+                  Cosmology and Extragalactic Astrophysics,
+                  Astrophysics - Instrumentation and Methods for
+                  Astrophysics, Astrophysics - Solar and Stellar
+                  Astrophysics},
+  year =         2012,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012arXiv1202.0132R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012arXiv1210.5007W,
+  author =       {{Wyrzykowski}, L. and {Hodgkin}, S. and
+                  {Blogorodnova}, N. and {Koposov}, S. and {Burgon},
+                  R.},
+  title =        "{Photometric Science Alerts from Gaia}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1210.5007},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics},
+  year =         2012,
+  month =        oct,
+  adsurl =       {http://ads.nao.ac.jp/abs/2012arXiv1210.5007W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013A&A...559A..74B,
+  author =       {{Bailer-Jones}, C.~A.~L. and {Andrae}, R. and
+                  {Arcay}, B. and {Astraatmadja}, T. and
+                  {Bellas-Velidis}, I. and {Berihuete}, A. and
+                  {Bijaoui}, A. and {Carri{\'o}n}, C. and {Dafonte},
+                  C. and {Damerdji}, Y. and {Dapergolas}, A. and {de
+                  Laverny}, P. and {Delchambre}, L. and {Drazinos},
+                  P. and {Drimmel}, R. and {Fr{\'e}mat}, Y. and
+                  {Fustes}, D. and {Garc{\'{\i}}a-Torres}, M. and
+                  {Gu{\'e}d{\'e}}, C. and {Heiter}, U. and {Janotto},
+                  A.-M. and {Karampelas}, A. and {Kim}, D.-W. and
+                  {Knude}, J. and {Kolka}, I. and {Kontizas}, E. and
+                  {Kontizas}, M. and {Korn}, A.~J. and {Lanzafame},
+                  A.~C. and {Lebreton}, Y. and {Lindstr{\o}m}, H. and
+                  {Liu}, C. and {Livanou}, E. and {Lobel}, A. and
+                  {Manteiga}, M. and {Martayan}, C. and {Ordenovic},
+                  C. and {Pichon}, B. and {Recio-Blanco}, A. and
+                  {Rocca-Volmerange}, B. and {Sarro}, L.~M. and
+                  {Smith}, K. and {Sordo}, R. and {Soubiran}, C. and
+                  {Surdej}, J. and {Th{\'e}venin}, F. and
+                  {Tsalmantza}, P. and {Vallenari}, A. and {Zorec},
+                  J.},
+  title =        "{The Gaia astrophysical parameters inference system
+                  (Apsis). Pre-launch description}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1309.2157},
+  primaryClass = "astro-ph.IM",
+  keywords =     {galaxies: fundamental parameters, methods: data
+                  analysis, methods:, statistical, stars: fundamental
+                  parameters, surveys},
+  year =         2013,
+  month =        nov,
+  volume =       559,
+  eid =          {A74},
+  pages =        {A74},
+  doi =          {10.1051/0004-6361/201322344},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2013A%26A...559A..74B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013GWN.....6....4A,
+  author =       {{Amaro-Seoane}, P. and {Aoudia}, S. and {Babak},
+                  S. and {Bin{\'e}truy}, P. and {Berti}, E. and
+                  {Boh{\'e}}, A. and {Caprini}, C. and {Colpi}, M. and
+                  {Cornish}, N.~J. and {Danzmann}, K. and {Dufaux},
+                  J.-F. and {Gair}, J. and {Hinder}, I. and
+                  {Jennrich}, O. and {Jetzer}, P. and {Klein}, A. and
+                  {Lang}, R.~N. and {Lobo}, A. and {Littenberg},
+                  T. and {McWilliams}, S.~T. and {Nelemans}, G. and
+                  {Petiteau}, A. and {Porter}, E.~K. and {Schutz},
+                  B.~F. and {Sesana}, A. and {Stebbins}, R. and
+                  {Sumner}, T. and {Vallisneri}, M. and {Vitale},
+                  S. and {Volonteri}, M. and {Ward}, H. and {Wardell},
+                  B.},
+  title =        "{eLISA: Astrophysics and cosmology in the millihertz
+                  regime}",
+  journal =      {GW Notes, Vol.~6, p.~4-110},
+  archivePrefix ="arXiv",
+  eprint =       {1201.3621},
+  primaryClass = "astro-ph.CO",
+  keywords =     {Astrophysics - Cosmology and Extragalactic
+                  Astrophysics, Astrophysics - Galaxy Astrophysics,
+                  General Relativity and Quantum Cosmology, black
+                  holes, gravitational waves},
+  year =         2013,
+  month =        may,
+  volume =       6,
+  pages =        {4-110},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013GWN.....6....4A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2013IAUS..289..414M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Lammers}, U. and {Yamada}, Y.},
+  title =        "{Improving distance estimates to nearby bright
+                  stars: Combining astrometric data from Hipparcos,
+                  Nano-JASMINE and Gaia}",
+  keywords =     {astrometry, catalogs, methods: data analysis,
+                  methods: statistical, reference systems,},
+  booktitle =    {IAU Symposium},
+  year =         2013,
+  series =       {IAU Symposium},
+  volume =       289,
+  editor =       {{de Grijs}, R.},
+  month =        feb,
+  pages =        {414-417},
+  doi =          {10.1017/S1743921312021849},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013IAUS..289..414M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013MNRAS.430.3155S,
+  author =       {{Seabroke}, G.~M. and {Prod'homme}, T. and {Murray},
+                  N.~J. and {Crowley}, C. and {Hopkinson}, G. and
+                  {Brown}, A.~G.~A. and {Kohley}, R. and {Holland},
+                  A.},
+  title =        "{Digging supplementary buried channels:
+                  investigating the notch architecture within the CCD
+                  pixels on ESA's Gaia satellite}",
+  journal =      {\mnras},
+  archivePrefix ="arXiv",
+  eprint =       {1302.1873},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: detectors, methods: laboratory,
+                  methods: numerical, space vehicles: instruments,
+                  astrometry, galaxies: general},
+  year =         2013,
+  month =        apr,
+  volume =       430,
+  pages =        {3155-3170},
+  doi =          {10.1093/mnras/stt121},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013MNRAS.430.3155S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014A&A...566A.119L,
+  author =       {{Luri}, X. and {Palmer}, M. and {Arenou}, F. and
+                  {Masana}, E. and {de Bruijne}, J. and {Antiche},
+                  E. and {Babusiaux}, C. and {Borrachero}, R. and
+                  {Sartoretti}, P. and {Julbe}, F. and {Isasi}, Y. and
+                  {Martinez}, O. and {Robin}, A.~C. and {Reyl{\'e}},
+                  C. and {Jordi}, C. and {Carrasco}, J.~M.  },
+  title =        "{Overview and stellar statistics of the expected
+                  Gaia Catalogue using the Gaia Object Generator}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1404.5861},
+  primaryClass = "astro-ph.IM",
+  keywords =     {stars: statistics, galaxies: statistics, Galaxy:
+                  stellar content, methods: data analysis, astrometry,
+                  catalogs},
+  year =         2014,
+  month =        jun,
+  volume =       566,
+  eid =          {A119},
+  pages =        {A119},
+  doi =          {10.1051/0004-6361/201423636},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2014A%26A...566A.119L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2014A&A...571A..85M,
-   author = {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D. and {Lammers}, U.
-	},
-    title = "{Joint astrometric solution of HIPPARCOS and Gaia. A recipe for the Hundred Thousand Proper Motions project}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1407.4025},
- primaryClass = "astro-ph.IM",
- keywords = {astrometry, methods: data analysis, methods: numerical, space vehicles: instruments, proper motions, planets and satellites: detection},
-     year = 2014,
-    month = nov,
-   volume = 571,
-      eid = {A85},
-    pages = {A85},
-      doi = {10.1051/0004-6361/201424606},
-   adsurl = {http://adsabs.harvard.edu/abs/2014A%26A...571A..85M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Lammers}, U.  },
+  title =        "{Joint astrometric solution of HIPPARCOS and Gaia. A
+                  recipe for the Hundred Thousand Proper Motions
+                  project}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1407.4025},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, space vehicles: instruments, proper
+                  motions, planets and satellites: detection},
+  year =         2014,
+  month =        nov,
+  volume =       571,
+  eid =          {A85},
+  pages =        {A85},
+  doi =          {10.1051/0004-6361/201424606},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014A%26A...571A..85M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2000A&A...355L..27H,
-   author = {{H{\o}g}, E. and {Fabricius}, C. and {Makarov}, V.~V. and {Urban}, S. and
-	{Corbin}, T. and {Wycoff}, G. and {Bastian}, U. and {Schwekendiek}, P. and
-	{Wicenec}, A.},
-    title = "{The Tycho-2 catalogue of the 2.5 million brightest stars}",
-  journal = {\aap},
- keywords = {ASTROMETRY, STARS: FUNDAMENTAL PARAMETERS, CATALOGS},
-     year = 2000,
-    month = mar,
-   volume = 355,
-    pages = {L27-L30},
-   adsurl = {http://adsabs.harvard.edu/abs/2000A%26A...355L..27H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2014EAS....67...15P,
+  author =       {{Prusti}, T.},
+  title =        "{Gaia Mission Status}",
+  booktitle =    {EAS Publications Series},
+  year =         2014,
+  series =       {EAS Publications Series},
+  volume =       67,
+  month =        jul,
+  pages =        {15-21},
+  doi =          {10.1051/eas/1567003},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014EAS....67...15P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-@ARTICLE{2013A&A...559A..74B,
-   author = {{Bailer-Jones}, C.~A.~L. and {Andrae}, R. and {Arcay}, B. and
-	{Astraatmadja}, T. and {Bellas-Velidis}, I. and {Berihuete}, A. and
-	{Bijaoui}, A. and {Carri{\'o}n}, C. and {Dafonte}, C. and {Damerdji}, Y. and
-	{Dapergolas}, A. and {de Laverny}, P. and {Delchambre}, L. and
-	{Drazinos}, P. and {Drimmel}, R. and {Fr{\'e}mat}, Y. and {Fustes}, D. and
-	{Garc{\'{\i}}a-Torres}, M. and {Gu{\'e}d{\'e}}, C. and {Heiter}, U. and
-	{Janotto}, A.-M. and {Karampelas}, A. and {Kim}, D.-W. and {Knude}, J. and
-	{Kolka}, I. and {Kontizas}, E. and {Kontizas}, M. and {Korn}, A.~J. and
-	{Lanzafame}, A.~C. and {Lebreton}, Y. and {Lindstr{\o}m}, H. and
-	{Liu}, C. and {Livanou}, E. and {Lobel}, A. and {Manteiga}, M. and
-	{Martayan}, C. and {Ordenovic}, C. and {Pichon}, B. and {Recio-Blanco}, A. and
-	{Rocca-Volmerange}, B. and {Sarro}, L.~M. and {Smith}, K. and
-	{Sordo}, R. and {Soubiran}, C. and {Surdej}, J. and {Th{\'e}venin}, F. and
-	{Tsalmantza}, P. and {Vallenari}, A. and {Zorec}, J.},
-    title = "{The Gaia astrophysical parameters inference system (Apsis). Pre-launch description}",
-  journal = {\aap},
-archivePrefix = "arXiv",
-   eprint = {1309.2157},
- primaryClass = "astro-ph.IM",
- keywords = {galaxies: fundamental parameters, methods: data analysis, methods:, statistical, stars: fundamental parameters, surveys},
-     year = 2013,
-    month = nov,
-   volume = 559,
-      eid = {A74},
-    pages = {A74},
-      doi = {10.1051/0004-6361/201322344},
-   adsurl = {http://cdsads.u-strasbg.fr/abs/2013A%26A...559A..74B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+@INPROCEEDINGS{2014SPIE.9143E..0XM,
+  author =       {{Mora}, A. and {Biermann}, M. and {Brown},
+                  A.~G.~A. and {Busonero}, D. and {Carminati}, L. and
+                  {Carrasco}, J.~M. and {Chassat}, F. and {Erdmann},
+                  M. and {Gielesen}, W.~L.~M. and {Jordi}, C. and
+                  {Katz}, D. and {Kohley}, R. and {Lindegren}, L. and
+                  {Loeffler}, W. and {Marchal}, O. and {Panuzzo},
+                  P. and {Seabroke}, G. and {Sahlmann}, J. and
+                  {Serpell}, E. and {Serraller}, I. and {van Leeuwen},
+                  F. and {van Reeven}, W. and {van den Dool},
+                  T.~C. and {Vosteen}, L.~L.~A.},
+  title =        "{Gaia on-board metrology: basic angle and best
+                  focus}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2014,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       9143,
+  archivePrefix ="arXiv",
+  eprint =       {1407.3729},
+  primaryClass = "astro-ph.IM",
+  month =        aug,
+  eid =          {91430X},
+  pages =        0,
+  doi =          {10.1117/12.2054602},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014SPIE.9143E..0XM},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2014SPIE.9150E..1EG,
-	   author = {{Gill}, R. and {Gracia}, G. and {Lupton}, R.~H. and {O'Mullane}, W.
-		   	},
-	       title = "{Novel technique for tracking manpower and work packages: a useful tool for the team and management}",
-	       booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
-	            year = 2014,
-		       series = {SPIE},
-		          volume = 9150,
-			      month = aug,
-			            eid = {91501E},
-				        pages = {91501E},
-					      doi = {10.1117/12.2054745},
-					         adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..1EG},
-						   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Gill}, R. and {Gracia}, G. and {Lupton}, R.~H. and
+                  {O'Mullane}, W.  },
+  title =        "{Novel technique for tracking manpower and work
+                  packages: a useful tool for the team and
+                  management}",
+  booktitle =    {Modeling, Systems Engineering, and Project
+                  Management for Astronomy VI},
+  year =         2014,
+  series =       {SPIE},
+  volume =       9150,
+  month =        aug,
+  eid =          {91501E},
+  pages =        {91501E},
+  doi =          {10.1117/12.2054745},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014SPIE.9150E..1EG},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INPROCEEDINGS{2014SPIE.9154E..0MJ,
+  author =       {{Jorden}, P.~R. and {Jordan}, D. and {Jerram},
+                  P.~A. and {Pratlong}, J. and {Swindells}, I.},
+  title =        "{e2v new CCD and CMOS technology developments for
+                  astronomical sensors}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2014,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       9154,
+  month =        jul,
+  eid =          {91540M},
+  pages =        {91540M},
+  doi =          {10.1117/12.2069423},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014SPIE.9154E..0MJ},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
 
+@ARTICLE{2015A&A...574A.115M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D.},
+  title =        "{The Tycho-Gaia astrometric solution . How to get
+                  2.5 million parallaxes with less than one year of
+                  Gaia data}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1412.8770},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, space vehicles: instruments, parallaxes,
+                  proper motions},
+  year =         2015,
+  month =        feb,
+  volume =       574,
+  eid =          {A115},
+  pages =        {A115},
+  doi =          {10.1051/0004-6361/201425310},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015A%26A...574A.115M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015A&A...583A..68M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Butkevich}, A.~G.  },
+  title =        "{Gaia astrometry for stars with too few
+                  observations. A Bayesian approach}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1507.02963},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, parallaxes, proper motions, space
+                  vehicles: instruments},
+  year =         2015,
+  month =        nov,
+  volume =       583,
+  eid =          {A68},
+  pages =        {A68},
+  doi =          {10.1051/0004-6361/201526936},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015A%26A...583A..68M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015arXiv150906868H,
+  author =       {{Hees}, A. and {Hestroffer}, D. and {Le
+                  Poncin-Lafitte}, C. and {David}, P.},
+  title =        "{Tests of gravitation with Gaia observations of
+                  Solar System Objects}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1509.06868},
+  primaryClass = "gr-qc",
+  keywords =     {General Relativity and Quantum Cosmology,
+                  Astrophysics - Earth and Planetary Astrophysics},
+  year =         2015,
+  month =        sep,
+  adsurl =       {http://adsabs.harvard.edu/abs/2015arXiv150906868H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @INPROCEEDINGS{2016SPIE.9913E..1VV,
-	   author = {{Vagg}, D. and {O'Callaghan}, D. and {O'H{\'o}g{\'a}in}, F. and
-		   	{McBreen}, S. and {Hanlon}, L. and {Lynn}, D. and {O'Mullane}, W.
-				},
-	       title = "{GAVIP: a platform for Gaia data analysis}",
-	       booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-	            year = 2016,
-		       series = {SPIE},
-		          volume = 9913,
-			  archivePrefix = "arXiv",
-			     eprint = {1605.09287},
-			      primaryClass = "astro-ph.IM",
-			          month = jul,
-				        eid = {99131V},
-					    pages = {99131V},
-					          doi = {10.1117/12.2233619},
-						     adsurl = {http://ads.nao.ac.jp/abs/2016SPIE.9913E..1VV},
-						       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+  author =       {{Vagg}, D. and {O'Callaghan}, D. and
+                  {O'H{\'o}g{\'a}in}, F. and {McBreen}, S. and
+                  {Hanlon}, L. and {Lynn}, D. and {O'Mullane}, W.  },
+  title =        "{GAVIP: a platform for Gaia data analysis}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2016,
+  series =       {SPIE},
+  volume =       9913,
+  archivePrefix ="arXiv",
+  eprint =       {1605.09287},
+  primaryClass = "astro-ph.IM",
+  month =        jul,
+  eid =          {99131V},
+  pages =        {99131V},
+  doi =          {10.1117/12.2233619},
+  adsurl =       {http://ads.nao.ac.jp/abs/2016SPIE.9913E..1VV},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@PHDTHESIS{crosta03,
+  author =       {{Crosta}, M.~T.},
+  title =        "{Methods of Relativistic Astrometry for the analysis
+                  of astrometric data in the Solar System
+                  gravitational field}",
+  year =         2003
 }


### PR DESCRIPTION
The sorting/reformatting was done using Emacs in order to standardize
all entries.

Also replaced SUIT-VISION with LDM-492.