### PR TITLE
Remove Gaia document commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ EXAMPLES = \
 presentation.tex \
 beamer-desc.tex \
 beamer-LSST2016.tex \
+DMTN-nnn.tex \
 LDM-nnn.tex
 
 TESTFILES = \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -142,22 +142,27 @@ The date for a draft document can float during development, but should be fixed 
 
   \date{\today}
 
+Some documents, have a secondary title that can be included as follows.
+This is optional.
+
+.. code-block:: latex
+
+  \setDocSubtitle{A subtitle}
+
 The document reference ("document handle" in DocuShare) is set next.
 The ``\setDocRef`` command controls whether the document will be include change control messaging.
 ``LDM`` and ``LSE`` documents are in this category, but a ``DMTN`` will not display change control statements.
-
 
 .. code-block:: latex
 
   \setDocRef{LDM-nnn}
 
-The document status and revision number are not usually required for LSST documentation matching the project style, but currently must be set in the class as a holdover from the Gaia original.
-The document revision is normally included in the change record, and the document status is currently draft (indicated by the use of the ``lsstdraft`` class option), or released (not in draft, change record indicating so).
+Optionally, the document curator can be defined here.
+LSST change-controlled documents do not require this information, but sometimes it is beneficial to indicate a point of contact who is not necessarily the person listed as author or the person most recently mentioned in the change record.
 
 .. code-block:: latex
 
-  \setDocRevision{TBD}
-  \setDocStatus{draft}
+  \setDocCurator{A Person}
 
 The abstract can be defined with this command and will be inserted in the correct place in the document preamble.
 
@@ -170,6 +175,7 @@ The abstract can be defined with this command and will be inserted in the correc
 
 The change record should be updated whenever a document is to be released (by a merge to ``master``).
 For change-controlled documents, the change record should include the relevant RFC or LCR number.
+The revision number should follow the policy defined in :cite:`LPM-51`.
 
 .. code-block:: latex
 

--- a/examples/DMTN-nnn.tex
+++ b/examples/DMTN-nnn.tex
@@ -14,8 +14,6 @@ C.~Author}
 
 \setDocRef{DMTN-nnn}
 \date{\today}
-\setDocRevision{TBD}
-\setDocStatus{draft}
 
 \setDocAbstract{%
 This document demonstrates how to use the LSST \LaTeX\ class files to make a Data Management

--- a/examples/LDM-nnn.tex
+++ b/examples/LDM-nnn.tex
@@ -14,8 +14,10 @@ C.~Author}
 
 \setDocRef{LDM-nnn}
 \date{\today}
-\setDocRevision{TBD}
-\setDocStatus{draft}
+
+% Optional
+\setDocCurator{The Curator of this Document}
+
 
 \setDocAbstract{%
 This document demonstrates how to use the LSST \LaTeX\ class files to make Data Management

--- a/tests/test-bibtex.tex
+++ b/tests/test-bibtex.tex
@@ -4,9 +4,7 @@
 \author{Automated~Content}
 \date{\today}
 
-\setDocStatus{generated}
 \setDocRef{LSST-test}
-\setDocRevision{1}
 
 \setDocAbstract{%
 Standard LSST document class example but using all bibtex entries.

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -229,15 +229,8 @@
              {\def\@docShortTitle{#2}}
              {\def\@docShortTitle{#1}}
 }
-
-\newcommand{\docTitle}{No Title}
-\providecommand{\setDocTitle}[2][@shorttitle@]{
-  \def\@docTitle{\Huge #2}
-  \ifthenelse{\equal{@shorttitle@}{#1}}
-             {\def\@docShortTitle{}}
-             {\def\@docShortTitle{#1}}
-  \renewcommand{\docTitle}{#2}
-}
+\title{Set the document title with $\backslash$title}
+\author{Set the document author with $\backslash$author}
 
 \newcommand{\docSubtitle}{No Subtitle}
 \newcommand{\setDocSubtitle}[1]{\def\@docSubtitle{#1}
@@ -249,22 +242,11 @@
 \setDocCompact{}
 \def\@docCompact{false}
 
-\setDocTitle{Set the document title with $\backslash$setDocTitle}
-
 \newcommand{\docDate}{set the date with {$\backslash$}setDocDate}
 \newcommand{\setDocDate}[1]{\renewcommand{\docDate}{#1}}
 
 % allow standard \date{} to work as an alias of \setDocDate
 \renewcommand{\date}[1]{\setDocDate{#1}}
-
-\newcommand{\docIssue}{none}
-\newcommand{\setDocIssue}[1]{\renewcommand{\docIssue}{#1}}
-
-\newcommand{\docStatus}{set the Status with {$\backslash$}setDocStatus}
-\newcommand{\setDocStatus}[1]{\renewcommand{\docStatus}{#1}}
-
-\newcommand{\docRevision}{set the Revision with {$\backslash$}setDocRevision}
-\newcommand{\setDocRevision}[1]{\renewcommand{\docRevision}{#1}}
 
 \newif\if@dmtct
 \@dmtctfalse
@@ -282,15 +264,6 @@
 
 \newcommand{\setDocCurator}[1]{\def\@docCurator{#1}}
 \setDocCurator{}
-
-\newcommand{\setDocAffil}[1]{\def\@docAffil{#1}}
-\setDocAffil{}
-
-\newcommand{\docApprove}{@noapprove@}
-\newcommand{\setDocApprove}[1]{\renewcommand{\docApprove}{#1}}
-
-\newcommand{\docAuthorize}{@noauthorize@}
-\newcommand{\setDocAuthorize}[1]{\renewcommand{\docAuthorize}{#1}}
 
 \newcommand{\docAbstract}{}
 \newcommand{\setDocAbstract}[1]{\renewcommand{\docAbstract}
@@ -335,13 +308,33 @@
    \end{center}
 }
 
+% These commands are not used by LSST but are retained as no-ops for
+% compatibility with earlier usage from Gaia.
+\newcommand{\setDocIssue}[1]{%
+\ClassWarning{lsstdoc}{For setDocIssue please use the Change Record}}
 
+\newcommand{\setDocStatus}[1]{%
+\ClassWarning{lsstdoc}{For setDocStatus use the lsstdraft option to enable draft mode. Document is released by default.}}
+
+\newcommand{\setDocRevision}[1]{%
+\ClassWarning{lsstdoc}{For setDocRevision please use the Change Record}}
+
+\newcommand{\setDocAffil}[1]{%
+\ClassWarning{lsstdoc}{setDocAffil is no longer supported}}
+
+\newcommand{\setDocApprove}[1]{%
+\ClassWarning{lsstdoc}{For setDocApprove please use the Change Record}}
+
+\newcommand{\setDocAuthorize}[1]{%
+\ClassWarning{lsstdoc}{For setDocAuthorize authorized person is implied by document series}}
 
 \newcommand{\mkshorttitle}{
      \begin{center}
-        \@docTitle \\
+        \color{lssttitle}
+        \@title \\
+        \color{black}
         \normalsize {\bf \docAuthor}\\
-	Issue \docIssue.\docRevision ~~ \docDate\\
+	      \docDate\\
      \end{center}
 
 }
@@ -457,30 +450,7 @@
      \else
      \relax
     \fi
-   \color{black}
-   {\large\textsf{
-      \begin{tabbing}
-         XXXXXXXXX: \=\kill
-    \ifx \@docAffil \@empty
-     \relax
-     \else
-         affiliation :\> \@docAffil\\
-    \fi
-    \ifx \@docCurator \@empty
-         \relax
-         \else
-         curator:\> \@docCurator\\
-     \fi
-    \ifthenelse{\equal{@noapprove@}{\docApprove}}%
-    {}{approved by:\> \docApprove\\}%
-    \ifthenelse{\equal{@noauthorize@}{\docAuthorize}}%
-    {}{authorized by:\> \docAuthorize\\}%
-\ifthenelse{\equal{\docIssue}{none}}{\relax}{%
-         issue:\>       \docIssue\\}%
-revision:\>    \docRevision\\
-         status:\>      \docStatus
-      \end{tabbing}
-   }}
+    \color{black}
 
     \ifx \@docCompact \@empty
            \pagebreak
@@ -540,6 +510,11 @@ revision:\>    \docRevision\\
 }{
 \end{longtable}
 \end{small}
+\ifx \@docCurator \@empty
+    \relax
+\else
+    \emph{Document curator:} \@docCurator\\
+\fi
 \clearpage
 %        \ifx \@docCompact \@empty
 %           \pagebreak
@@ -638,7 +613,7 @@ revision:\>    \docRevision\\
 \tiny
 \sffamily
 \begin{tabularx}{\textwidth}{XXr}
-\@docShortTitle & \docRef~ \docStatus & Latest Revision \docDate \\
+\@docShortTitle & \docRef & Latest Revision \docDate \\
 \end{tabularx}
 \end{minipage}
 \end{flushright}


### PR DESCRIPTION
LSST style does not require Authorize, Revision, Issue, Status, Affil or Approve. These have been removed and replaced by class warnings.

Authorize is implied by the document series. Approve, Revision and Issue are handled by the change record. Affil is not used. Status is released by default, or draft if the lsstdraft option is enabled.