### PR TITLE
DM-10311: Fix page layout and header spacing anomalies

### DIFF
--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -361,7 +361,7 @@
     }%
 
    \setlength{\parindent}{0pt}
-   \vspace*{-5cm}
+   \vspace*{-4cm}
    \putlogo
    \vspace*{1cm}
    \begin{center}
@@ -543,19 +543,19 @@
 %
 % Page layout
 %
-\setlength{\textwidth}{6.5in}
-\setlength{\textheight}{8.5in}
-
-\setlength{\topmargin}{0cm}
-\setlength{\oddsidemargin}{0cm}
-\setlength{\evensidemargin}{0cm}
-\setlength{\leftmargin}{1in}
-\setlength{\marginparwidth}{1in}
+% use the "showframe" option to draw margins
+\usepackage{geometry}
+\geometry{textheight=8.5in,
+          letterpaper,
+          textwidth=6.5in,
+          includeall,
+          lmargin=1in,
+          headheight=40pt,
+          headsep=2em,
+          footskip=40pt}
 
 \setlength{\parindent}{0cm}             % No indent at start of paragraphs
 \setlength{\parskip}{\baselineskip}     % Blank line between paragraph
-
-\setlength\headheight{15pt}     % Make space for logo
 
 \pagenumbering{arabic}
 \mark{{}{}}
@@ -582,46 +582,42 @@
 \setcounter{secnumdepth}{5}    % numbering level of sections
 \setcounter{tocdepth}{4}       % appearance level in table of contents
 
+% Header and footer definitions
+
 \pagestyle{fancy}
 
-\addtolength{\headsep}{4.2mm}
-
-% Shift everything up a bit
-\setlength{\topmargin}{-0.5cm}
-
+% Clear all headings
+\fancyhead{}
 \fancyheadoffset{0pt}
-\lhead{
-\color{lsstblue}
- \vspace{-4cm}
-  \IfFileExists{lsst_logo_notext.png}{
-    \resizebox{0.18\textwidth}{!}{\includegraphics{lsst_logo_notext}}
-    %\hspace{5pt}{\bfseries\large\sf{\CU\DU}}
-  } {
-       {\bfseries\large\sf{LSST: \CU\DU}}
-  }\\\vspace{-8pt}
-\color{lsstblue}
+
+% Left heading is the logo and horizontal rule
+\lhead{%
+\includegraphics[width=0.18\textwidth]{lsst_logo_notext}\\
+\vskip -1ex
 \begin{minipage}{7.5in}
-%    \hspace{-1.5cm}\rule{0.55cm}{1.0pt} \lower.1em\hbox{
-    \hspace{-1.8cm}\rule{1.4cm}{2.0pt} \lower.1em\hbox{
-	{ \hspace{-0.1cm}\tiny \color{lssthead}LARGE SYNOPTIC SURVEY TELESCOPE}\hspace{-0.1cm}
-   }
+    \hspace{-1.8cm}
+    \color{lsstblue}
+    \rule{1.4cm}{2.0pt}
+    \lower 1pt
+    \hbox{
+	      {\hspace{-0.1cm}\tiny \color{lsstblue}LARGE SYNOPTIC SURVEY TELESCOPE}
+        \hspace{-0.1cm}
+    }
     \color{lsstblue}
     \rule{14.8cm}{2.0pt}
-\end{minipage}
-\vspace{-30pt}
-\begin{flushright}
-\begin{minipage}{12.5cm}
-\tiny
-\sffamily
-\begin{tabularx}{\textwidth}{XXr}
-\@docShortTitle & \docRef & Latest Revision \docDate \\
-\end{tabularx}
-\end{minipage}
-\end{flushright}
-  \vskip -2\baselineskip
+\end{minipage}%
 }
 
-\rhead{
+% Right heading is the document description.
+\rhead{%
+\begin{minipage}{11.5cm}
+  % The skip is used to go below the horizontal rule from the lhead
+  \vskip 1.2em
+  \tiny
+  \color{lssthead}
+  \sffamily
+  \textbf{\@docShortTitle \hfill \docRef \hfill Latest Revision \docDate}
+\end{minipage}%
 }
 
 \renewcommand{\headrulewidth}{0.0pt}

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -594,6 +594,7 @@
 
 % Left heading is the logo and horizontal rule
 \lhead{%
+\hskip 1.8cm
 \includegraphics[width=0.18\textwidth]{lsst_logo_notext}\\
 \vskip -1ex
 \begin{minipage}{3.6cm+\textwidth}

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -73,6 +73,7 @@
 \definecolor{lsstsect}{RGB}{ 23, 54, 93}
 \definecolor{lssttitle}{RGB}{ 54, 95,145}
 \definecolor{lssthead}{RGB}{ 79,129,189}
+\definecolor{lsstfoot}{RGB}{ 31, 73,125}
 
 % Switch off the onecolumn and twocolumn options
 \DeclareOption{onecolumn}{\OptionNotUsed}
@@ -651,9 +652,9 @@
   \if@isdraft
     \color{red}
     DRAFT NOT YET APPROVED
-    \color{lssthead} --
+    \color{lsstfoot} --
   \fi
-  \color{lssthead}
+  \color{lsstfoot}
   \@controlFootText
   \if@isdraft
     --

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -602,7 +602,7 @@
     \rule{1.4cm}{2.0pt}
     \lower 1pt
     \hbox{
-	      {\hspace{-0.1cm}\tiny \color{lsstblue}LARGE SYNOPTIC SURVEY TELESCOPE}
+        {\hspace{-0.1cm}\tiny \color{lsstblue}LARGE SYNOPTIC SURVEY TELESCOPE}
         \hspace{-0.1cm}
     }
     \color{lsstblue}

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -590,23 +590,54 @@
 \fancyhead{}
 
 % Expand the width of the header into the margins by 1.8cm on each side
-\fancyhfoffset[LH,RH]{1.8cm}
+\newlength{\headextrawidth}
+\setlength{\headextrawidth}{1.8cm}
+\fancyhfoffset[LH,RH]{\headextrawidth}
+
+% Dynamically calculate the spacing so that it is driven solely by
+% the amount of overhang required and the width of the logo.
+\newlength{\lsstheadlogowidth}
+\setlength{\lsstheadlogowidth}{0.18\textwidth}
+
+% Total width of header minipage
+\newlength{\lsstheadwidth}
+\setlength{\lsstheadwidth}{2\headextrawidth + \textwidth}
+
+% Horizontal offset of logo into header
+\newlength{\lsstheadlogooffset}
+\setlength{\lsstheadlogooffset}{\headextrawidth}
+
+% Calculate space taken up by the LSST header text
+\newlength{\lsstheadertextwidth}
+\newcommand{\headertext}{\tiny LARGE SYNOPTIC SURVEY TELESCOPE}
+
+% Include space around the text width calculation
+\settowidth{\lsstheadertextwidth}{\headertext}
+
+% Additional space between rule and header LSST text
+\newlength{\lsstheadergap}
+\setlength{\lsstheadergap}{0.0cm}
+
+% Length of first part of ruler depends on text being centred below the logo.
+\newlength{\lsstleftheadrule}
+\setlength{\lsstleftheadrule}{\lsstheadlogooffset + 0.5\lsstheadlogowidth -
+                              0.5\lsstheadertextwidth - \lsstheadergap}
+
+% Define command to fill the rest of the line with a rule of specified thickness
+\def\vhrulefill#1{\leavevmode\leaders\hrule\@height#1\hfill \kern\z@}
 
 % Left heading is the logo and horizontal rule
 \lhead{%
-\hskip 1.8cm
-\includegraphics[width=0.18\textwidth]{lsst_logo_notext}\\
+\hspace{\lsstheadlogooffset}
+\includegraphics[width=\lsstheadlogowidth]{lsst_logo_notext}\\
 \vskip -1ex
-\begin{minipage}{3.6cm+\textwidth}
+\begin{minipage}{\lsstheadwidth}
     \color{lsstblue}
-    \rule{1.4cm}{2.0pt}
+    \rule{\lsstleftheadrule}{2.0pt}
     \lower 1pt
-    \hbox{
-        {\hspace{-0.1cm}\tiny \color{lsstblue}LARGE SYNOPTIC SURVEY TELESCOPE}
-        \hspace{-0.1cm}
-    }
+    \hbox{\hspace{\lsstheadergap}\headertext\hspace{\lsstheadergap}}
     \color{lsstblue}
-    \rule{14.8cm}{2.0pt}
+    \vhrulefill{2.0pt}
 \end{minipage}%
 }
 
@@ -619,7 +650,7 @@
   \color{lssthead}
   \sffamily
   \textbf{\@docShortTitle \hfill \docRef \hfill Latest Revision \docDate}
-  \hspace{1.8cm}
+  \hspace{\headextrawidth}
 \end{minipage}%
 }
 


### PR DESCRIPTION
This commit splits the header definition into two parts. The left header is the logo and horizontal rule and the right header is now the document description text. Previously they were a single left header but this led to spacing anomalies between pages where the spacing between the top of the logo and the top of the page could vary and the spacing between the ruler and the document identifier. Separating these into two unrelated entities seems to have stabilized the spacing issues.

In order to simplify the investigation, the page layout has now been defined using the geometry package rather than distinct settings that may interact unexpectedly. This has the side effect that the margins can now easily be displayed for debugging purposes using the `showframe` option.

All page layout was tweaked to make the spacing correct for the header. This led to the footer spacing now being more consitent, although page numbers do seem to move around from page to page.
