### PR TITLE
Work around pdflatex problem

### DIFF
--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -609,12 +609,17 @@
 \newlength{\lsstheadlogooffset}
 \setlength{\lsstheadlogooffset}{\headextrawidth}
 
-% Calculate space taken up by the LSST header text
-\newlength{\lsstheadertextwidth}
+% Text to use below the logo in the header
 \newcommand{\headertext}{\tiny LARGE SYNOPTIC SURVEY TELESCOPE}
 
-% Include space around the text width calculation
-\settowidth{\lsstheadertextwidth}{\headertext}
+% Calculate space taken up by the LSST header text
+% \settowidth does not seem to work properly with pdflatex
+\newlength{\lsstheadertextwidth}
+\ifxetex
+  \settowidth{\lsstheadertextwidth}{\headertext}
+\else
+  \setlength{\lsstheadertextwidth}{105pt}
+\fi
 
 % Additional space between rule and header LSST text
 \newlength{\lsstheadergap}


### PR DESCRIPTION
`\settowidth` calculates 145pt on pdflatex and 105pt on xelatex. Xelatex is correct. I'm not sure why pdflatex is getting the wrong answer but the simplest fix is to fallback to 105pt if we detect we are using pdflatex.