### PR TITLE
Always get latest setuptools in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
 before_install:
   - "sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latexmk poppler-utils latex-xcolor latex-beamer lmodern texlive-xetex texlive-generic-recommended texlive-math-extra"
 install:
+  - pip install -U setuptools
   - pip install -r docs/requirements.txt
   - pip install "ltd-mason>=0.2,<0.3"
 script:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -T
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
Normally Travis provides setuptools with its Python environment. In this case it seems we were getting an old, and possibly broken, version of setuptools. In the Travis install phase we force an upgrade of
setuptools; this solves the build issue:

```
making output directory...
Exception occurred:
File "<environment marker>", line 1, in <module>
  NameError: name 'platform_system' is not defined
```

Also passed the -T flag to Travis to get more verbose exception tracebacks.