### PR TITLE
DM-10642: Containerized lsst-texmf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 sudo: true
 language: python
 dist: trusty
+services:
+  - docker
 matrix:
   include:
     - python: "3.5"
-      env: LTD_MASON_BUILD=true
+      # Enable docker and documentation deployments
+      env: LTD_MASON_BUILD=true DEPLOY_DOCKER_IMAGE=true
 before_install:
   - "sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latexmk poppler-utils latex-xcolor latex-beamer lmodern texlive-xetex texlive-generic-recommended texlive-math-extra"
 install:
@@ -16,11 +19,22 @@ script:
   - make
   - make docs
 after_success:
+  # Deploy https://lsst-texmf.lsst.io site
   - make lsstthedocs
+  # Build the Docker image
+  - "docker build -t ${IMAGE_NAME}:build ."
+  # Deploy the Docker image
+  - ./bin/travis-docker-deploy.sh
 env:
   global:
     - LTD_MASON_BUILD=false  # disable builds in regular text matrix
     - LTD_MASON_PRODUCT="lsst-texmf"
+    - DEPLOY_DOCKER_IMAGE=false  # disable docker builds in regular test matrix
+    - IMAGE_NAME="lsstsqre/lsst-texmf"  # Docker image name
     # AWS and LTD Keeper credentials as encrypted secrets here
     - secure: "rmK3azL0TZmEoZ3nObhiWr1Sr79Z9gHXHVFLV1dJ8hpTKee+qF6HSYZ4CT2SrbzCx/X4WLSOiVfvxDYyOeZUQUTdLxf+8AytORtX7s1F5/4IW2Va7XyJztAL7yI9SVs9pKlB+craO8P5ljxm7ReqahRkitog8i9few2WdYDozsm80MNDuU+bmet4o3dLyVOtgmb0YroY7+E0NminHNCalv8ekUHA+VemgG6549VazcNtXrTkIKQBKWbSZmGwAJDa5YzQOQJIV1TQ0PXX1gARpeVe6Mm5YBnWpzWtG016QC+ZwdHSS5Pjh9S5+2eaYey7F157q7bODcfMt1RU09p360RU7KVgezBElyZvus/q4pZnfd8VARl+7EzG9m8AaqBDuFhJex2A4iZbk4fMOmywtPDpMGzmDZOLOxa47cUu1KVFKarMm8ILY9QBUI8u84DqYrLuYVfMTvcXro6PG1QIMgzhe4H4Qd5wrJggnRuyBVZajWhPFNioBouq0DtbyxPUE9J7z7ki3VV2cu7Nxdat0snmFRfayfJt0fHj3h1J7HCt2JF83ZdyqG5Y28b/GpEydyBnIyBzhNbMlbQJl/g/39Zfgq2EJB8tmWyCii5Fi7QSxRW6DR35mCB2ztejNsHpT23qaxhxlZGD+xFdTBejGFbrV/SukqJuDAkpxAwu1wQ="
     - secure: "wMjSG3rFs/RMqL9k8sSGpqH9OKyre6gBzU6FuhUcOIlCkzuws+bJ4L2xGIbIBun+FdzxIBCePaxvSxV4waFV67Q9BOOfno96ZxwHUL8URFx/x7xN3Djb6gS0VIQ/5Hg5xEmYvNCdLzw9GB2Ka4alQxOvIC6hNhxPmCDxwTru5H8uggSM7LTFK1wnAOF1VO2483llbNJ1HkVkWMi/+OFlUjdxPEmnEcAVMyGv8pfZ30fBjKRmBpIj3zK+kbX6XW0wcu8sEOleMgHpcpvq/zCrsWJF+K/b4jKyadPNoudp+hnOvj4dV480SZt9Iu/AWQ0N5oy+GyFKJtoIpl+I85t3DQflFaTR9k6Hdk8RvdGb7DNo55iyWyohj1ClN0qxq4SLyP0/z8RQNZOWjcjJUtIlQxLkFxDceNhEqKegU+dg+XZOSt9LzA0/6c6tsa4bg3J0lYqDHTJ2oQfQ/fA/cVWRNvPhDZoAxr/pYRdo2+eRfX+A2XfBVbbr5lm02UmkcrBqfO9fuUZZDRdssrIXKl31QGNcxyxr3lRHKBYza/7Bh5hNTNHs8NEcoZh+GaIp1cZzjboGO/XAJzopxVv99H0n0buCUa06NjiKwlxgh78XXerQNXgYq80bYy4uGqtsdb8oKf6MCPlkuPMtKw+GVFG42/PCgfzqqUJ5hjfKzImYuko="
+    # DOCKER_USERNAME
+    - secure: "v0n7Vva6qx9OrA3BoaqJv0U3gpbkGXtKIcYdJ+2jHyt+vlhYx6qQUS/UGIiBxZmu4NuVxsB8TFOV3qQm47+NzwsdE64Y6/V/rTEgeZUd9JEOqeyO7o9lnrqjPCvBLMmdn1Qfc13AZ/hrNvOgVHzlSD1QVfQdh0mJvwWr2WsSIb9AJKsEI8yJTIW46OQv5CmICc98s27/aPMwbneDuHYcnUFg4cpCZ88LFkFAprrRJk8vwYiSYS7L1eNv55mPVyUe37Wuy1ncmwhV/r4b2H8RaTPlVDfVRtaCd5k2eZJ4olcoIZUpnNHTBbdqCTUsVUhP8L3IPtA48XTxGjZ2FN3e5g3cZ+3QTdemFCjAYUeXPYzzyiyhCNj1cIg4g13CGh39Mjwaice3zDJJ9ifJ3bZoCnN3FDnl0DjSrauj32ZyAyV1NTM1b36MkYwwXqoed+MZkOhIveCXSSDttK3ICeOdsnuCawK/eUDLGD3iQzyO7W/NWiUXG46nTiKHDYAZLEfDqEaaqaccQOqCZDNoYJZGwW5D53QN0hmFUsB2fMHtsNy/DvNhPv+NaG280sXPaqnhM71BStQlstRZFvXYYzJOMKB7DzafyCPI35Nak5PCfMD+PCI+FX95QBNXFzjthZ2qAAXvvsHzVYtnxz3I0+yvUwehITPjWimFMyvLXudQubw="
+    # DOCKER_PASSWORD
+    - secure: "6w/pJJKIm6+JxhXictGnkFB6W22EdQBKFwXQ7Ct0v40o4+O0mzcQd5SoVHmkg0OoFHTn/f1lCUf/0ry/FQl4wVFIUnWeomqp3VRWx7snH1UsrjdqedvvmelzhEJLpCqhXoOHCesSfzojh4JWHcT+pdjd0cYj9qmoILtmrSbdLif5HG5h12QzM78fSmh0U8kBMTSD7OcltWYKoAWtfK17EDn+rbZkcBz5odMLdglosE6kKgdRf2cs9xqHGmeBdfvH0wcIT8FGHucSSKnOJkHJxkrt1SK8dgSNVf3YCCEC7BK6WyNqBPYkJNaxzcZURcWKQ+lJPA4oTNukmAwVEudjPfu8SOfqF7hORY4ceJG1amy33rpHumiYrc8cXHew/JxJ8bIiVIkFXOVy+GT5IOE+wSnHyF+i4PuN+C2FtYPr7Md11myYTPatm52p4NjcXKHN0u5dgvLDrY1EkSj6bZ+CKPm/gFfHIy4ESocmdGGiGvLV9B/aQIVXXRp3FrsBCl566YieP+Yh23Zie0UKeZWmWnPgwHAZoFPie4LuCNSG8nHiZNDa7+lS+E+c2IanwUhZNIKAP/548GMKeVxHGEgLTbYJR/2qGRzIY4zU9lpiPu2LBCE3JHTXW8T5k29c+u7l8ygZpOXNrRXh7FHO7ny9k7Zq5ZWznI60JprCVn5ZLJo="

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerized lsst-texmf
+#
+# https://github.com/lsst/lsst-texmf
+#
+# Base image: https://github.com/lsst-sqre/lsst-texlive
+
+FROM lsstsqre/lsst-texlive:latest
+MAINTAINER LSST SQuaRE <sqre-admin@lists.lsst.org>
+
+# Point $TEXMFHOME to the container's lsst-texmf. This environment variable
+# exists for container runs by a user.
+ENV TEXMFHOME "/texmf"
+
+# Create $TEXMFHOME directory in the container
+RUN mkdir $TEXMFHOME
+
+# Contents of the lsst-texmf Git repo's texmf/ directory copied to container's
+# $TEXMFHOME directory.
+COPY texmf $TEXMFHOME/
+
+CMD ["/bin/echo", "See https://lsst-texmf.lsst.io/docker.html for usage."]

--- a/bin/travis-docker-deploy.sh
+++ b/bin/travis-docker-deploy.sh
@@ -1,0 +1,34 @@
+set -ex
+
+# Manage the image build from Travis CI
+# This assumes that the image is initially built with the "build" tag.
+
+# Skip deployments in PRs
+if [ $TRAVIS_PULL_REQUEST != "false" ]; then
+    exit 0;
+fi
+
+# Only build DEPLOY_DOCKER_IMAGE is explicitly set in .travis.yml.
+if [ $DEPLOY_DOCKER_IMAGE == "false" ]; then
+    echo "Skipping docker build. \$DEPLOY_DOCKER_IMAGE=false";
+    exit 0;
+fi
+
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+# Create tag; latest for master; otherwise use branch name
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+    TAG="latest";
+
+else
+    # need to sanitize any "/" from git branches
+    TAG=`echo "$TRAVIS_BRANCH" | sed "s/\//-/"`;
+fi
+
+# Tag and push the branch-based name
+docker tag ${IMAGE_NAME}:build ${IMAGE_NAME}:${TAG}
+docker push ${IMAGE_NAME}:${TAG}
+
+# Tag and push based on the Travis build number for forensics
+docker tag ${IMAGE_NAME}:build ${IMAGE_NAME}:travis-${TRAVIS_BUILD_NUMBER}
+docker push ${IMAGE_NAME}:travis-${TRAVIS_BUILD_NUMBER}

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -62,3 +62,31 @@ For more information on writing reStructuredText-formatted documentation, see `D
 You can contribute to the documentation using `DM's normal workflow <https://developer.lsst.io/processes/workflow.html>`_.
 When you have pushed a ticket branch to GitHub, you can find a rendered draft at https://lsst-texmf.lsst.io/v.
 The main site at https://lsst-texmf.lsst.io updates automatically once your PR is merged to ``master``.
+
+.. _contrib-docker:
+
+Maintaining the Docker distribution
+===================================
+
+Docker images are automatically published as `lsstsqre/lsst-texmf`_ on Docker Hub through Travis CI.
+Contributors shouldn't need to worry about updating the Docker distribution.
+
+The following tags are generated through Travis:
+
+- ``latest`` corresponds to ``master`` on GitHub.
+- Tags also correspond to git branches and tags on GitHub.
+  The build system converts forward slashes in branch names to dashes in tags.
+  For example, the ``tickets/DM-10642`` Git branch is published on Docker Hub as ``tickets-DM-10642``.
+- ``travis-N`` tags correspond to individual Travis CI builds.
+
+The following components are involved in the Docker toolchain:
+
+- The ``Dockerfile`` defines the container.
+  Note that ``lsst-texmf``\ ’s :file:`Dockerfile` is only concerned with installing ``lsst-texmf`` and setting :envvar:`TEXMFHOME`.
+  The `lsstsqre/lsst-texlive`_ base image provides `TeX Live`_ and tools like :command:`make` and :command:`git`.
+- The ``.travis.yml`` file runs the Docker image build and push in the Travis CI environment.
+- The ``bin/travis-docker-deploy.sh`` script tags the images according to the above scheme and pushes those images to Docker Hub.
+
+.. _`lsstsqre/lsst-texmf`: https://hub.docker.com/r/lsstsqre/lsst-texmf/
+.. _`lsstsqre/lsst-texlive`: https://hub.docker.com/r/lsstsqre/lsst-texlive/
+.. _`TeX Live`: http://tug.org/texlive/

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,0 +1,71 @@
+.. _docker:
+
+############################
+Using lsst-texmf with Docker
+############################
+
+Besides installing ``lsst-texmf`` on your computer, you can compile ``lsst-texmf``\ -based documents with Docker.
+This setup is useful for continuous integration environments since it avoids having to re-install `TeX Live`_ and ``lsst-texmf`` in each build.
+A Docker workflow is also useful for local writing since it turns ``lsst-texmf`` installation and document compilation into a single command.
+There's no need to worry about installing LaTeX dependencies and setting a :envvar:`TEXMFHOME` environment variable.
+
+.. _docker-quick-start:
+
+Quick start
+===========
+
+To get started, you'll need to `install Docker`_.
+
+Then from your LaTeX document's directory, run:
+
+.. code-block:: bash
+
+   docker run --rm -v `pwd`:/build -w /build lsstsqre/lsst-texmf:latest sh -c 'make'
+
+Here's what's happening:
+
+- ``docker run`` downloads the Docker image (if necessary) and runs a container.
+- ``--rm`` removes the container once the run completes.
+- ``lsstsqre/lsst-texmf:latest`` is the name of the Docker image.
+  This tracks the ``master`` branch of the `lsst-texmf GitHub repository`_.
+- ``-v `pwd`:/build`` *binds* the current directory (containing your document) into the ``/build`` directory in the container
+- ``-w /build`` makes the bound volume the working directory in the container.
+- ``sh -c 'make'`` is the command that's run from the container's working directory to compile your document.
+  The example uses a :file:`Makefile`, but this command can be customized for your project.
+- The compiled PDF is written into the current directory on your computer since it was bound to the container.
+
+.. _docker-image-refresh:
+
+Deleting or refreshing the Docker image
+=======================================
+
+Once downloaded, Docker caches the ``lsstsqre/lsst-texmf:latest`` image on your computer.
+If ``lsst-texmf`` is updated, you can refresh your image by deleting the cached copy:
+
+.. code-block:: bash
+
+   docker rmi lsstsqre/lsst-texmf:latest
+
+The next time you :command:`docker run` the new ``lsst-texmf:latest`` image will be downloaded.
+
+.. _docker-details:
+
+About the lsst-texmf Docker image
+=================================
+
+The `lsstsqre/lsst-texmf`_ Docker image is based on Ubuntu 14.04 (trusty).
+It contains a full `TeX Live`_ distribution, as well as ``make`` and ``git`` via the `lsstsqre/lsst-texlive`_ image.
+``lsst-texmf`` is installed in the container's ``/texmf`` directory, with :envvar:`TEXMFHOME` pre-set to that directory.
+
+The ``latest`` tag tracks the ``master`` branch.
+Tags are also published for all Git branches and tags pushed to GitHub, as well as tags for individual Travis builds.
+See the list of `tags on Docker Hub`_.
+
+Usually you'll want to use the ``latest`` tag.
+
+.. _`install Docker`: https://www.docker.com/community-edition#/download
+.. _`tags on Docker Hub`: https://hub.docker.com/r/lsstsqre/lsst-texmf/tags/
+.. _`lsstsqre/lsst-texmf`: https://hub.docker.com/r/lsstsqre/lsst-texmf/
+.. _`lsstsqre/lsst-texlive`: https://hub.docker.com/r/lsstsqre/lsst-texlive/
+.. _`TeX Live`: http://tug.org/texlive/
+.. _`lsst-texmf GitHub repository`: https://github.com/lsst/lsst-texmf

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ lsst-texmf is on GitHub at https://github.com/lsst/lsst-texmf.
    :maxdepth: 2
 
    install
+   docker
    examples/index
    lsstdoc
    beamer


### PR DESCRIPTION
This PR adds containerized builds of lsst-texmf. This allows users, or CI machines, to use lsst-texmf without having to install their own tex and set up `$TEXMFHOME` to point to lsst-texmf. Building a document becomes a one-line `docker run` command.

- Usage documentation: https://lsst-texmf.lsst.io/v/DM-10642/docker.html
- Developer documentation: https://lsst-texmf.lsst.io/v/DM-10642/developer.html#maintaining-the-docker-distribution