### PR TITLE
DM-10641: Add cookiecutter templates for documents and presentations.

### DIFF
--- a/docs/beamer.rst
+++ b/docs/beamer.rst
@@ -4,7 +4,12 @@
 Writing Presentations
 #####################
 
-You can use `beamer <https://en.wikipedia.org/wiki/Beamer_(LaTeX)>`_ to make LSST-flavoured talks by adding something like:
+.. _lsst-beamer-quick-start:
+
+Quick start
+===========
+
+You can use `beamer`_ to make LSST-flavoured talks by adding something like:
 
 .. code-block:: latex
 
@@ -12,6 +17,11 @@ You can use `beamer <https://en.wikipedia.org/wiki/Beamer_(LaTeX)>`_ to make LSS
 
 to your beamer presentation.
 You need the ``fonts=false`` if you want to use :command:`pdflatex`; if you're happy with :command:`xelatex` it may be omitted.
+
+.. _lsst-beamer-theming:
+
+Alternate themes
+================
 
 The backgrounds for the title and main pages are found in the directory :file:`LSST-themes/`.
 Two files are required:
@@ -28,14 +38,19 @@ Default may be a symbolic link to choose the proper background, or you may speci
    \usepackage[backgroundTheme=LSST2016]{LSST-beamer}
 
 You may use ``footline=XXX`` to put text in the footer, generally with the default "generic" ``backgroundTheme``, as many ``backgroundThemes`` already have something there.
-The text may use ``{}`` to quote spaces; see :file:`examples/Example-beamer-LSST2016.tex` for an example.
+The text may use ``{}`` to quote spaces; see :ref:`beamer-LSST2016` for an example.
 
 You may use ``\position`` as an alias for ``\institute`` (e.g. ``\position{DM Boss}``) (but only if you declare it after importing the ``LSST-beamer`` package).
 
 Another common problem is DESC; they use a different layout for their cover slides --- see
-:file:`examples/Example-beamer-desc.tex`.
+:ref:`beamer-desc`.
 
-The full set of options that the LSST-beamer package accepts are:
+.. _lsst-beamer-reference:
+
+Options reference
+=================
+
+The full set of options that the ``LSST-beamer`` package accepts are:
 
 ``quiet``
    Suppress some pdf warnings.
@@ -97,3 +112,5 @@ The full set of options that the LSST-beamer package accepts are:
 
 ``monoFontScale``
    Scaling for mono font (default: ``1``; only takes effect if ``fonts=true``).
+
+.. _beamer: https://en.wikipedia.org/wiki/Beamer_(LaTeX)

--- a/docs/beamer.rst
+++ b/docs/beamer.rst
@@ -4,6 +4,13 @@
 Writing Presentations
 #####################
 
+This page describes how to use the ``LSST-beamer`` class to make LSST-style presentations with beamer_.
+
+.. seealso::
+
+   - :ref:`presentation-template`
+   - :ref:`examples`
+
 .. _lsst-beamer-quick-start:
 
 Quick start

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ lsst-texmf is on GitHub at https://github.com/lsst/lsst-texmf.
    install
    docker
    examples/index
+   templates/index
    lsstdoc
    beamer
    developer

--- a/docs/lsstdoc.rst
+++ b/docs/lsstdoc.rst
@@ -6,8 +6,12 @@ Using the lsstdoc document class
 
 The :file:`lsstdoc` document class should be used for all LaTeX LSST documents.
 The class file defines the document fonts and page dimensions, imports commonly used packages, defines journal macros and other common commands and defines the main title page and the page headers and footers.
-In this section we will explain how to create a document using the LSST document class.
-A full example can be seen in the :file:`examples` directory in the repository.
+In this section we will explain how to use ``lsstdoc``.
+
+.. seealso::
+
+   - :ref:`document-template`
+   - :ref:`examples`
 
 .. Consider moving the macros into a separate style file in order to make it easier to document them.
 

--- a/docs/templates/document.rst
+++ b/docs/templates/document.rst
@@ -1,0 +1,109 @@
+.. _document-template:
+
+############################################
+LSST document (including LDM, DMTN) template
+############################################
+
+The ``document`` template lets you create new documents using the :ref:`lsstdoc <lsstdoc>` class.
+These can be project controlled documents (LPM, LSE, LDM, for example) or technical notes (DMTN, SQR, SMTN).
+This page describes how to use the ``document`` template.
+
+.. seealso::
+
+   For background, see :ref:`templates`.
+
+   For help with using the ``lsstdoc`` class, see :ref:`lsstdoc`.
+
+.. note::
+
+   We intend to provide a chatbot for creating new documents that handles creating a GitHub repository, filling in the template, and deploying the document as a website.
+   In the meantime, you can still manually create new documents with this template.
+
+.. _document-template-invocation:
+
+Invoking the template
+=====================
+
+After you have :ref:`set up <template-set-up>` cookiecutter and cloned the ``lsst-texmf`` repository, you can create a document by pointing :command:`cookiecutter` at ``lsst-texmf``\ ’s :file:`templates/document` directory.
+For example, from a directory containing a ``lsst-texmf`` clone:
+
+.. code-block:: bash
+
+   cookiecutter lsst-texmf/templates/document
+
+Cookiecutter will prompt you to configure your document.
+See the next section for details.
+
+.. _document-template-configs:
+
+Template configurations
+=======================
+
+This section describes configurations requested by :command:`cookiecutter`.
+
+``series``
+   Handle of the documentation series.
+   Technical notes can be ``DMTN``, ``SQR``, or ``SMTN`` (see the `DM Developer Guide <https://developer.lsst.io/docs/technotes.html>`__ for more information).
+
+``serial_number``
+   Serial number of the document.
+   For project documents, this number is pre-assigned by DocuShare.
+   For technical notes, you can claim the next available number yourself.
+   These links show existing technical notes in each series:
+
+   - `DMTN <https://github.com/lsst-dm?utf8=✓&q=DMTN-&type=&language=>`__
+   - `SQR <https://github.com/lsst-sqre?utf8=✓&q=SQR-&type=&language=>`__
+   - `SMTN <https://github.com/lsst-sims?utf8=✓&q=SMTN-&type=&language=>`__
+
+``github_org``
+    Documents belong in specific GitHub organizations:
+
+    - LDM: `lsst <https://github.com/lsst>`__
+    - DMTN: `lsst-dm <https://github.com/lsst-dm>`__
+    - SQR: `lsst-sqr <https://github.com/lsst-sqre>`__
+    - SMTN: `lsst-sims <https://github.com/lsst-sims>`__
+
+``docushare_url``
+   Provide a URL to the document in DocuShare, if available.
+   Technotes might not have DocuShare handles.
+   Using the https://ls.st short link to the document's version page in DocuShare is effective.
+   For example: ``'https://ls.st/ldm-151*'``.
+
+``title``
+   Title of the document, without a handle prefix.
+
+``first_author``
+   The first and last name of the document's primary author.
+   You can add additional authors later to the ``\author`` command in the generated document.
+
+``abstract``
+   Abstract or summary of the document.
+   This abstract appears both in the document's ``\setDocAbstract`` command an in the :file:`README`.
+
+``copyright_year``
+   Year when copyright is first claimed.
+
+``copyright_hold``
+   Institution that holds the document's copyright.
+
+``license_cc_by``
+   If ``true``, a Creative Commons Attribution license is added to the :file:`README`.
+
+.. _document-template-deploy:
+
+Deploying the document
+======================
+
+.. note::
+
+   These instructions will help you deploy your documentation project to GitHub and LSST the Docs.
+   In the future, a chatbot service will automate these steps.
+
+After creating a document directory with `cookiecutter`_\ , the next step is to initialize it as a Git repository and push that repository to GitHub.
+Keep in mind the organization you host the repository in must match the organization name provided to `cookiecutter`_.
+Also, the repository name should be the document's handle in lowercase (for example, `lsst-sqre/sqr-019 <https://github.com/lsst-sqre/sqr-019>`__ for the `SQR-019 <https://sqr-019.lsst.io>`__ technical note).
+
+Once the document is on GitHub, notify the `#dm-docs`_ channel on Slack that a new document is ready to be deployed to LSST the Docs.
+
+.. _cookiecutter: https://cookiecutter.readthedocs.io/en/latest/index.html
+.. _`#dm-docs`: https://lsstc.slack.com/messages/C2B6DQBAL

--- a/docs/templates/index.rst
+++ b/docs/templates/index.rst
@@ -1,0 +1,69 @@
+.. _templates:
+
+#####################################
+Creating new documents with templates
+#####################################
+
+``lsst-texmf`` includes cookiecutter_ templates that help you start new projects more quickly.
+
+.. _template-set-up:
+
+Set up
+======
+
+To use the templates, you'll need to install cookiecutter_ and have a local clone of the ``lsst-texmf`` repository.
+
+Cookiecutter
+------------
+
+You can install cookiecutter_ with :command:`pip`:
+
+.. code-block:: bash
+
+   pip install cookiecutter
+
+Or with Anaconda_:
+
+.. code-block:: bash
+
+   conda install cookiecutter
+
+lsst-texmf
+----------
+
+You need a local copy of ``lsst-texmf`` to use the templates.
+If you have :ref:`installed <install>` ``lsst-texmf``, you'll have a ``lsst-texmf`` clone at ``$TEXMFHOME/..``.
+Otherwise, you can clone the repository now:
+
+.. code-block:: bash
+
+   git clone https://github.com/lsst/lsst-texmf
+
+Quick start
+===========
+
+Templates are located in the :file:`lsst-texmf/templates` directory.
+You can create a new document by passing the template's directory path to :command:`cookiecutter`.
+For example:
+
+.. code-block:: bash
+
+   cookiecutter lsst-texmf/templates/document
+
+Then answer the prompts to initialize the document.
+See the :ref:`template-list` section for information about specific templates.
+
+.. _template-list:
+
+Templates
+=========
+
+These templates are included with ``lsst-texmf``:
+
+.. toctree::
+
+   document
+   presentation
+
+.. _cookiecutter: https://cookiecutter.readthedocs.io/en/latest/index.html
+.. _Anaconda: https://www.continuum.io/downloads

--- a/docs/templates/presentation.rst
+++ b/docs/templates/presentation.rst
@@ -1,0 +1,70 @@
+.. _presentation-template:
+
+#################################
+LSST beamer presentation template
+#################################
+
+The ``presentation`` template lets you create new beamer_ presentations using the :ref:`LSST-beamer <lsst-texmf-beamer>` class.
+
+.. seealso::
+
+   For background, see :ref:`templates`.
+
+   For help with using the ``LSST-beamer`` class, see :ref:`lsst-texmf-beamer`.
+
+.. _presentation-template-invocation:
+
+Invoking the template
+=====================
+
+After you have :ref:`set up <template-set-up>` cookiecutter and cloned the ``lsst-texmf`` repository, you can create a document by pointing :command:`cookiecutter` at ``lsst-texmf``\ ’s :file:`templates/presentation` directory.
+For example, from a directory containing a ``lsst-texmf`` clone:
+
+.. code-block:: bash
+
+   cookiecutter lsst-texmf/templates/presentation
+
+Cookiecutter will prompt you to configure your document.
+
+.. _presentation-template-configs:
+
+Template configurations
+=======================
+
+This section describes configurations requested by :command:`cookiecutter`.
+
+``title``
+   The presentation's title (used in the :file:`README` and the ``\title`` command).
+
+``short_title``
+   A shortened title that appears in the footer of slides.
+
+``slug``
+   A string that determines the presentation's directory and file name.
+   Being a file name, the ``slug`` should contain no white space, ``/``, or other characters not valid in file names.
+
+``presenter``
+   Name of the presenter (formatted "First Last").
+
+``presenter_role``
+   Position of the presenter in the organization (such as "Manager" or "Software Developer").
+
+``presenter_institution``
+   Presenter's home institution (such as "AURA/LSST" or "University of Washington").
+
+``date``
+   Date of the presentation, following ISO 8601 formatting: ``YYYY-MM-DD``.
+
+``venue``
+   Institution or event where the presentation is being given.
+
+``copyright_year``
+   Year when copyright is first claimed.
+
+``copyright_hold``
+   Institution that holds the presentation's copyright.
+
+``license_cc_by``
+   If ``true``, a Creative Commons Attribution license is added to the :file:`README`.
+
+.. _beamer: https://en.wikipedia.org/wiki/Beamer_(LaTeX)

--- a/templates/README.rst
+++ b/templates/README.rst
@@ -1,0 +1,9 @@
+#####################
+Cookecutter templates
+#####################
+
+These cookiecutter_ templates will help you start a new document more quickly.
+
+See https://lsst-texmf.lsst.io/templates for more information.
+
+.. _cookiecutter: https://cookiecutter.readthedocs.io/en/latest/index.html

--- a/templates/document/README.rst
+++ b/templates/document/README.rst
@@ -1,0 +1,9 @@
+#################
+Document template
+#################
+
+This cookiecutter_ template will help you create a new LSST project document (LDM, LSE, etc.) or technical note (DMTN, SQR, SMTN).
+
+See https://lsst-texmf.lsst.io/templates/document.html for more information.
+
+.. _cookiecutter: https://cookiecutter.readthedocs.io/en/latest/index.html

--- a/templates/document/cookiecutter.json
+++ b/templates/document/cookiecutter.json
@@ -1,0 +1,22 @@
+{
+  "series": [
+    "LDM",
+    "DMTN",
+    "SQR",
+    "SMTN",
+    "TEST"],
+  "serial_number": "000",
+  "github_org": [
+    "lsst",
+    "lsst-dm",
+    "lsst-sqre",
+    "lsst-sims"
+  ],
+  "docushare_url": "",
+  "title": "Document Title",
+  "first_author": "First Last",
+  "abstract": "Abstract text.",
+  "copyright_year": "2017",
+  "copyright_holder": "Association of Universities for Research in Astronomy, Inc.",
+  "license_cc_by": [true, false]
+}

--- a/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.gitignore
+++ b/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.gitignore
@@ -1,0 +1,181 @@
+## Products (published by CI)
+{{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.pdf
+
+one.*
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+
+
+## Intermediate documents:
+*.dvi
+*-converted-to.*
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.brf
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.snm
+*.vrb
+
+# cprotect
+*.cpt
+
+# fixme
+*.lox
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+
+# gnuplottex
+*-gnuplottex-*
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Comment the next line if you want to keep your tikz graphics files
+*.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+*.ist
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc
+*.mtc[0-9]
+*.mtc[1-9][0-9]
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# mylatexformat
+*.fmt
+
+# nomencl
+*.nlo
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices
+*.xyc
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# Kile
+*.backup
+
+# KBibTeX
+*~[0-9]*

--- a/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.travis.yml
+++ b/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.travis.yml
@@ -1,0 +1,19 @@
+sudo: true
+dist: trusty
+services:
+  - docker
+language: python
+python:
+  - '3.5'
+before_install:
+  - "pip install 'lander>=0.1.0,<0.2'"
+script:
+  # Compile PDF using containerized lsst-texmf
+  - "docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'"
+after_success:
+  # Deploy website. See https://github.com/lsst-sqre/lander for CLI options
+  - "lander --pdf {{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.pdf --upload --lsstdoc {{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.tex --env=travis --ltd-product $PRODUCT"
+env:
+  global:
+    - PRODUCT="{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}"
+    # Add LSST the Docs credentials

--- a/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/Makefile
+++ b/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/Makefile
@@ -1,0 +1,2 @@
+{{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.pdf: *.tex
+	latexmk -bibtex -pdf -f {{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.tex

--- a/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
+++ b/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
@@ -1,0 +1,29 @@
+.. image:: https://img.shields.io/badge/{{ cookiecutter.series.lower() }}--{{ cookiecutter.serial_number }}-lsst.io-brightgreen.svg
+   :target: https://{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}-lsst.io
+.. image:: https://travis-ci.org/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.svg
+   :target: https://travis-ci.org/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+
+{{ "#" * cookiecutter.title|length }}
+{{ cookiecutter.title }}
+{{ "#" * cookiecutter.title|length }}
+
+{{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}
+{{ "-" * (cookiecutter.series|length + cookiecutter.serial_number|length + 1) }}
+
+{{ cookiecutter.abstract }}
+
+**Links**
+
+{% if cookiecutter.docushare_url|length > 0 %}
+- Accepted version on DocuShare: {{ cookiecutter.docushare_url }}
+{% endif %}
+- Live drafts: https://{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.lsst.io
+- GitHub: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+
+****
+
+Copyright {{ cookiecutter.copyright_year }} {{ cookiecutter.copyright_holder }}
+
+{% if cookiecutter.license_cc_by %}
+This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/.
+{% endif %}

--- a/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}.tex
+++ b/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}.tex
@@ -1,0 +1,58 @@
+{% if cookiecutter.series in ['LDM', 'LSE', 'LPM'] -%}
+\documentclass[DM,lsstdraft,toc]{lsstdoc}
+{% else %}
+{# skip draft watermark for technotes and use author-year citations #}
+\documentclass[DM,authoryear,toc]{lsstdoc}
+{%- endif %}
+% lsstdoc documentation: https://lsst-texmf.lsst.io/lsstdoc.html
+
+% Package imports go here.
+
+% Local commands go here.
+
+% To add a short-form title:
+% \title[Short title]{Title}
+\title{ {{- cookiecutter.title -}} }
+
+% Optional subtitle
+% \setDocSubtitle{A subtitle}
+
+{% raw -%}
+\author{%{%- endraw %}
+{{ cookiecutter.first_author }}
+}
+
+\setDocRef{ {{- cookiecutter.series.upper() -}}-{{- cookiecutter.serial_number -}} }
+
+\date{\today}
+
+% Optional: name of the document's curator
+% \setDocCurator{The Curator of this Document}
+
+{% raw -%}
+\setDocAbstract{%{%- endraw %}
+{{ cookiecutter.abstract }}
+}
+
+% Change history defined here.
+% Order: oldest first.
+% Fields: VERSION, DATE, DESCRIPTION, OWNER NAME.
+% See LPM-51 for version number policy.
+{% raw -%}
+\setDocChangeRecord{%{%- endraw %}
+  \addtohist{1}{YYY-MM-DD}{Unreleased.}{ {{- cookiecutter.first_author -}} }
+}
+
+\begin{document}
+
+% Create the title page.
+% Table of contents is added automatically with the "toc" class option.
+\maketitle
+
+% ADD CONTENT HERE
+
+% Include all the relevant bib files.
+% https://lsst-texmf.lsst.io/lsstdoc.html#bibliographies
+\bibliography{lsst,lsst-dm,refs_ads,refs,books}
+
+\end{document}

--- a/templates/presentation/README.rst
+++ b/templates/presentation/README.rst
@@ -1,0 +1,9 @@
+#####################
+Presentation template
+#####################
+
+This cookiecutter_ template will help you create a new presentation.
+
+See https://lsst-texmf.lsst.io/templates/presentation.html for more information.
+
+.. _cookiecutter: https://cookiecutter.readthedocs.io/en/latest/index.html

--- a/templates/presentation/cookiecutter.json
+++ b/templates/presentation/cookiecutter.json
@@ -1,0 +1,13 @@
+{
+  "title": "Presentation title",
+  "short_title": "{{ cookiecutter.title }}",
+  "slug": "Project directory name (will be created)",
+  "presenter": "First Last",
+  "presenter_role": "Presenter's role",
+  "presenter_institution": "AURA/LSST",
+  "date": "YYYY-MM-DD",
+  "venue": "Event or venue name",
+  "copyright_year": "2017",
+  "copyright_holder": "Association of Universities for Research in Astronomy, Inc.",
+  "license_cc_by": [true, false]
+}

--- a/templates/presentation/{{cookiecutter.slug}}/Makefile
+++ b/templates/presentation/{{cookiecutter.slug}}/Makefile
@@ -1,0 +1,6 @@
+{{ cookiecutter.slug }}.pdf: *.tex
+	latexmk -bibtex -pdf -f {{ cookiecutter.slug }}.tex
+
+.PHONY: clean
+clean:
+	latexmk -c {{ cookiecutter.slug }}.tex

--- a/templates/presentation/{{cookiecutter.slug}}/README.rst
+++ b/templates/presentation/{{cookiecutter.slug}}/README.rst
@@ -1,0 +1,28 @@
+{{ "#" * cookiecutter.title|length }}
+{{ cookiecutter.title }}
+{{ "#" * cookiecutter.title|length }}
+
+Presentation by {{ cookiecutter.presenter }} at {{ cookiecutter.venue }} on {{ cookiecutter.date }}.
+
+How to compile
+==============
+
+This presentation is built with the ``LSST-beamer`` package that comes with `lsst-texmf <https://lsst-texmf.lsst.io>`_.
+To compile:
+
+1. Ensure the ``TEXMFHOME`` environment variable is set to ``lsst-texmf``.
+   See `Installing lsst-texmf <https://lsst-texmf.lsst.io/install.html>`_ for details.
+2. Run ``make``.
+
+For more information about LSST-beamer:
+
+- Documentation: https://lsst-texmf.lsst.io/beamer.html
+- Examples: https://lsst-texmf.lsst.io/examples/index.html#presentations
+
+****
+
+Copyright {{ cookiecutter.copyright_year }} {{ cookiecutter.copyright_holder }}
+
+{% if cookiecutter.license_cc_by %}
+This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/.
+{% endif %}

--- a/templates/presentation/{{cookiecutter.slug}}/{{cookiecutter.slug}}.tex
+++ b/templates/presentation/{{cookiecutter.slug}}/{{cookiecutter.slug}}.tex
@@ -1,0 +1,44 @@
+\documentclass[t]{beamer}
+\usepackage{longtable}
+
+\usepackage[fonts=false, footline={ {{- cookiecutter.short_title -}} }]{LSST-beamer}
+
+
+\title{ {{- cookiecutter.title -}} }
+\date[ {{- cookiecutter.date -}} ]{ {{- cookiecutter.date}}, {{ cookiecutter.venue -}} }
+
+\author[ {{-cookiecutter.presenter -}} ]{ {{- cookiecutter.presenter -}} }
+\position{ {{- cookiecutter.presenter_role -}} }
+\institute{ {{- cookiecutter.presenter_institution -}} }
+
+
+% Added at the start of every section
+\AtBeginSection[]
+{
+\begin{frame}<beamer>
+\frametitle{Outline} % make a frame titled "Outline"
+\tableofcontents[currentsection]  % show TOC and highlight current section
+\end{frame}
+}
+
+
+\AtBeginSubsection[]
+{
+\begin{frame}
+  \frametitle{Outline}
+  \tableofcontents[currentsection,currentsubsection]
+\end{frame}
+}
+
+
+\begin{document}
+\frame{\titlepage}
+
+\frame{\frametitle{For more information}
+   \begin{itemize}
+    \item \url{https://lsst-texmf.lsst.io/beamer.html}
+    \item \url{https://lsst-texmf.lsst.io/examples/index.html\#presentations}
+   \end{itemize}
+}
+
+\end{document}


### PR DESCRIPTION
Adds two [cookiecutter](https://cookiecutter.readthedocs.io/en/latest/index.html) project templates. One for a lsstdoc document, another for an LSST-beamer presentation.

Docs: https://lsst-texmf.lsst.io/v/DM-10641/templates (I also improved other reference pages to cross-link to the template pages).

Note: we'll need to revisit the document template documentation (https://lsst-texmf.lsst.io/v/DM-10641/templates) to better link to process documentation. The lsst-texmf docs should be responsible for documenting the technical usage of the template but not the organizational policies. That page will also need to be changed with the `project create` chatbot service comes online.