### PR TITLE
DM-11334: Pin documenteer to <0.2.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx>=1.5.5,<1.6
-documenteer>=0.1.11
+documenteer>=0.1.11,<0.2.0
 sphinx-rtd-theme==0.2.4


### PR DESCRIPTION
This lets us continue to get pybtex as assumed by documenteer 0.1.11. We can upgrade and sort out required Sphinx extensions later when necessary.