### PR TITLE
DM-6033: pybtex / latexcodec bibtex compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 script:
   - export TEXMFLOCAL=./texmf
   - make
+  - make test-pybtex
   - make docs
 after_success:
   # Deploy https://lsst-texmf.lsst.io site

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,15 @@ LDM-nnn.tex
 TESTFILES = \
 test-bibtex.tex
 
+# Bibliographies that are tested for pybtex compatibility
+# Ignores the gaialink bibliography
+BIBFILES = \
+texmf/bibtex/bib/books.bib \
+texmf/bibtex/bib/lsst.bib \
+texmf/bibtex/bib/lsst-dm.bib \
+texmf/bibtex/bib/refs.bib \
+texmf/bibtex/bib/refs_ads.bib
+
 .SUFFIXES:
 .SUFFIXES: .tex .pdf
 PDF = $(EXAMPLES:.tex=.pdf)
@@ -22,6 +31,12 @@ $(PDF): %.pdf: examples/%.tex
 
 $(TESTS): %.pdf: tests/%.tex
 	latexmk -pdf -bibtex -f $<
+
+.PHONY: test-pybtex
+test-pybtex:
+	@echo "Testing pybtex compatibility"
+	@echo
+	bin/validate_bib.py $(BIBFILES)
 
 .PHONY: docs
 docs: $(PDF) $(TESTS)

--- a/bin/validate_bib.py
+++ b/bin/validate_bib.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Ensure that lsst-texmf bibliographies can be opened by pybtex [1].
+
+pybtex compatibility is required for Sphinx documentation workflows.  This also
+helps us discover issues like unescaped ``%`` signs and duplicate keys.
+
+[1] https://docs.pybtex.org/
+"""
+
+import argparse
+import os
+import sys
+
+from pybtex.database.input import bibtex
+import latexcodec  # noqa provides the latex+latin codec
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'paths',
+        nargs='*',
+        help='Paths to bib files.'
+    )
+    args = parser.parse_args()
+
+    # Validate input paths
+    for bibpath in args.paths:
+        if not os.path.exists(bibpath):
+            print('Cannot find bib for testing: {}'.format(bibpath))
+            sys.exit(1)
+
+    # We use the latex+latin code with Sphinx workflows.
+    parser = bibtex.Parser('latex+latin')
+    for bibpath in args.paths:
+        print('Parsing {}'.format(bibpath))
+        parser.parse_file(bibpath)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -41,6 +41,17 @@ Bibliography file organization
 * :file:`refs.bib` should be used for non-LSST references that can not be located on ADS.
 * :file:`books.bib` should be used for books that are not indexed by ADS.
 
+%-escaping for Sphinx
+---------------------
+
+Sphinx documents also use ``lsst-texmf``\ ’s bibliographies through `sphinxcontrib-bibtex <http://sphinxcontrib-bibtex.readthedocs.io/en/latest/>`_.
+The Sphinx workflow requires that any non-comment ``%`` character be escaped.
+ADS includes un-escaped ``%`` characters in URLs for A&A journal articles, for instance.
+To work around this for now, ensure that these URLs are escaped (that is: ``\%``).
+Travis CI is testing bibliographies for Sphinx compatibility.
+
+See :jira:`DM-11358` for progress towards resolving this issue.
+
 .. _updating-examples:
 
 Updating examples and tests

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -26,18 +26,17 @@ If a document is being cited that is not part of the current list, a pull reques
 If the automated tests pass, the PR can be self-merged without review.
 In this way, we can ensure that all documents agree on references without duplication and with minimum overhead.
 
-Some things to remember:
+Bibliography file organization
+------------------------------
 
-* LSST documents are added to :file:`lsst.bib`.
+* :file:`lsst.bib` includes LSST documents (DocuShare documents and technical notes).
   Any document available on DocuShare should use the ``@DocuShare`` bib entry using the document handle as the key in the bib file.
   In the longer term, this file will be auto-generated from DocuShare and should always be up to date and should not require manual editing.
-  Tech notes will also be defined in this file.
-* LSST Data Management publications are added to :file:`lsst-dm.bib`.
-  This file is used for published papers (ADS and non-ADS) and presentations.
-  Do not use it for items stored on DocuShare.
+* :file:`lsst-dm.bib` includes LSST Data Management publications (ADS and non-ADS) and presentations.
+  Do not include DocuShare items in this file.
   Presentations should use a key of form ``YYYYauthor-meeting``. 
-* Any reference that can be found on ADS should be stored in :file:`refs_ads.bib` using the standard ADS bibtex export.
-  ADS entries should always be cited using the ADS Bibcode.
+* :file:`refs_ads.bib` includes any reference that can be found on ADS (aside from those in :file:`lsst-dm.bib`).
+  Entries must be the standard ADS bibtex export and use the ADS Bibcode.
   This file should be used for arXiv entries obtained from ADS.
 * :file:`refs.bib` should be used for non-LSST references that can not be located on ADS.
 * :file:`books.bib` should be used for books that are not indexed by ADS.

--- a/texmf/bibtex/bib/README.md
+++ b/texmf/bibtex/bib/README.md
@@ -1,14 +1,9 @@
+# Shared Publications
 
-Shared Publications
--------------------
+- `lsst.bib`: LSST Docushare and Tech Notes.
+- `lsst-dm.bib`: LSST DM external papers and talks (can include ADS).
+- `refs_ads.bib`: Publications used by our documents obtained from ADS.
+- `refs.bib`: Other publications not from ADS and not books.
+- `books.bib`: Books that are not on ADS.
 
-lsst.bib
-    LSST Docushare and Tech Notes
-lsst-dm.bib
-    LSST DM external papers and talks (can include ADS)
-refs_ads.bib
-    Publications used by our documents obtained from ADS
-refs.bib
-    Other publications not from ADS and not books
-books.bib
-    Books that are not on ADS.
+Contributors: see https://lsst-texmf.lsst.io/developer.html#updating-bibliographies for more information.

--- a/texmf/bibtex/bib/lsst-dm.bib
+++ b/texmf/bibtex/bib/lsst-dm.bib
@@ -1366,8 +1366,7 @@ adsnote = {Provided by the SAO/NASA Astrophysics Data System}
   note =         {XLDB Asia, Beijing, China, June 22-23 2012 },
   month =        jun,
   year =         2012,
-  url =
-                  {http://idke.ruc.edu.cn/xldb/www.xldb-asia.org/slides/XLDB%20Asia%20-%20LSST.pdf},
+  url =          {http://idke.ruc.edu.cn/xldb/www.xldb-asia.org/slides/XLDB\%20Asia\%20-\%20LSST.pdf},
 }
 
 @INPROCEEDINGS{2012SPIE.8448E..0PG,
@@ -2342,7 +2341,7 @@ booktitle = {Python in Astronomy 2016},
     month = jun,
     year = 2016,
     note = {Presented on 2016-06-20 at the LSST@Europe2 conference held in Serbia},
-    url = {https://project.lsst.org/meetings/lsst-europe-2016/sites/lsst.org.meetings.lsst-europe-2016/files/02%20-%20juric-LSST-LSSTEurope2-DataProducts-4.pptx}
+    url = {https://project.lsst.org/meetings/lsst-europe-2016/sites/lsst.org.meetings.lsst-europe-2016/files/02\%20-\%20juric-LSST-LSSTEurope2-DataProducts-4.pptx}
 }
 
 % Optional fields: author, title, howpublished, month, year, note

--- a/texmf/bibtex/bib/refs.bib
+++ b/texmf/bibtex/bib/refs.bib
@@ -385,7 +385,7 @@ requirements},
   year =         1993,
   month =        {October},
   url =
-                  {http://www.astro.lu.se/%7Elennart/Astrometry/gaia_proposal.PDF}
+                  {http://www.astro.lu.se/\%7Elennart/Astrometry/gaia_proposal.PDF}
 }
 
 @TechReport{NGST.BRDF.Lallo,
@@ -1544,7 +1544,7 @@ keywords = {methods: data analysis, techniques: radial velocities, stars: binari
 volume = 426,
  pages = {695-698},
    doi = {10.1051/0004-6361:20040384},
-adsurl = {http://adsabs.harvard.edu/abs/2004A%26A...426..695Z},
+adsurl = {http://adsabs.harvard.edu/abs/2004A\%26A...426..695Z},
 adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 

--- a/texmf/bibtex/bib/refs_ads.bib
+++ b/texmf/bibtex/bib/refs_ads.bib
@@ -39,7 +39,7 @@
   volume =       114,
   pages =        {278-288},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1982A%26A...114..278B&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1982A\%26A...114..278B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -54,7 +54,7 @@
   volume =       120,
   pages =        {197-202},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1983A%26A...120..197S&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1983A\%26A...120..197S&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -139,7 +139,7 @@
   volume =       202,
   pages =        {309-315},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1988A%26A...202..309B&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1988A\%26A...202..309B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -194,7 +194,7 @@
   month =        jul,
   volume =       287,
   pages =        {338-347},
-  adsurl =       {http://adsabs.harvard.edu/abs/1994A%26A...287..338N},
+  adsurl =       {http://adsabs.harvard.edu/abs/1994A\%26A...287..338N},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -234,7 +234,7 @@
   volume =       304,
   pages =        {34-+},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1995A%26A...304...34K&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1995A\%26A...304...34K&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -251,7 +251,7 @@
   volume =       304,
   pages =        52,
   adsurl =
-                  {http://cdsads.u-strasbg.fr/abs/1995A%26A...304...52A},
+                  {http://cdsads.u-strasbg.fr/abs/1995A\%26A...304...52A},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -270,7 +270,7 @@
   volume =       304,
   pages =        61,
   adsurl =
-                  {http://cdsads.u-strasbg.fr/abs/1995A%26A...304...61L},
+                  {http://cdsads.u-strasbg.fr/abs/1995A\%26A...304...61L},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -311,7 +311,7 @@
   month =        jan,
   volume =       305,
   pages =        {146-+},
-  adsurl =       {http://adsabs.harvard.edu/abs/1996A%26A...305..146G},
+  adsurl =       {http://adsabs.harvard.edu/abs/1996A\%26A...305..146G},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -339,7 +339,7 @@
   volume =       320,
   pages =        {428-439},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997A%26A...320..428H&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997A\%26A...320..428H&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -357,7 +357,7 @@
   month =        nov,
   volume =       327,
   pages =        {1253-1261},
-  adsurl =       {http://adsabs.harvard.edu/abs/1997A%26A...327.1253M},
+  adsurl =       {http://adsabs.harvard.edu/abs/1997A\%26A...327.1253M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -462,7 +462,7 @@
   month =        apr,
   volume =       332,
   pages =        {1133-1141},
-  adsurl =       {http://adsabs.harvard.edu/abs/1998A%26A...332.1133D},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998A\%26A...332.1133D},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -477,7 +477,7 @@
   month =        dec,
   volume =       340,
   pages =        {309-314},
-  adsurl =       {http://adsabs.harvard.edu/abs/1998A%26A...340..309M},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998A\%26A...340..309M},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -495,7 +495,7 @@
   volume =       130,
   pages =        {65-75},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998A%26AS..130...65L&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998A\%26AS..130...65L&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -524,7 +524,7 @@
   pages =        {99-130},
   doi =          {10.1146/annurev.astro.36.1.99},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA%26A..36...99K&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA\%26A..36...99K&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -577,7 +577,7 @@
   volume =       137,
   pages =        {521-528},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1999A%26AS..137..521M&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1999A\%26AS..137..521M&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -629,7 +629,7 @@
   month =        feb,
   volume =       354,
   pages =        {522-536},
-  adsurl =       {http://adsabs.harvard.edu/abs/2000A%26A...354..522M},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26A...354..522M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -648,7 +648,7 @@
   month =        mar,
   volume =       355,
   pages =        {L27-L30},
-  adsurl =       {http://adsabs.harvard.edu/abs/2000A%26A...355L..27H},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26A...355L..27H},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -669,7 +669,7 @@
   volume =       143,
   pages =        {33-40},
   doi =          {10.1051/aas:2000331},
-  adsurl =       {http://adsabs.harvard.edu/abs/2000A%26AS..143...33B},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26AS..143...33B},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -836,7 +836,7 @@
   pages =        {339-363},
   doi =          {10.1051/0004-6361:20010085},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...369..339P&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A\%26A...369..339P&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -856,7 +856,7 @@
   pages =        {336-344},
   doi =          {10.1051/0004-6361:20010499},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...373..336D&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A\%26A...373..336D&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -876,7 +876,7 @@
   pages =        {L21-L24},
   doi =          {10.1051/0004-6361:20010788},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A%26A...373L..21S&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A\%26A...373L..21S&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1006,7 +1006,7 @@ booktitle = {Mining the Sky},
   pages =        {686-692},
   doi =          {10.1051/0004-6361:20020149},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002A%26A...385..686P&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002A\%26A...385..686P&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1070,7 +1070,7 @@ booktitle = {Mining the Sky},
   volume =       280,
   pages =        {21-29},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Ap%26SS.280...21B&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Ap\%26SS.280...21B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1181,7 +1181,7 @@ booktitle = {Mining the Sky},
   pages =        {337-342},
   doi =          {10.1051/0004-6361:20021785},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...399..337V&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A\%26A...399..337V&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1201,7 +1201,7 @@ booktitle = {Mining the Sky},
   pages =        {523-540},
   doi =          {10.1051/0004-6361:20031117},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...409..523R&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A\%26A...409..523R&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1220,7 +1220,7 @@ booktitle = {Mining the Sky},
   pages =        {1063-1074},
   doi =          {10.1051/0004-6361:20031283},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A%26A...410.1063K&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A\%26A...410.1063K&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1240,7 +1240,7 @@ booktitle = {Mining the Sky},
   volume =       412,
   pages =        {105-120},
   doi =          {10.1051/0004-6361:20031478},
-  adsurl =       {http://adsabs.harvard.edu/abs/2003A%26A...412..105M},
+  adsurl =       {http://adsabs.harvard.edu/abs/2003A\%26A...412..105M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -1380,7 +1380,7 @@ booktitle = {Mining the Sky},
   pages =        {385-403},
   doi =          {10.1051/0004-6361:20035779},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004A%26A...419..385B&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004A\%26A...419..385B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1667,7 +1667,7 @@ booktitle = {Mining the Sky},
   pages =        {745-755},
   doi =          {10.1051/0004-6361:20042372},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...438..745B&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A\%26A...438..745B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1685,7 +1685,7 @@ booktitle = {Mining the Sky},
   pages =        {791-803},
   doi =          {10.1051/0004-6361:20053193},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...439..791V&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A\%26A...439..791V&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -1704,7 +1704,7 @@ booktitle = {Mining the Sky},
   pages =        {805-822},
   doi =          {10.1051/0004-6361:20053192},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A%26A...439..805V&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A\%26A...439..805V&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -2157,7 +2157,7 @@ booktitle = {Mining the Sky},
   pages =        {827-836},
   doi =          {10.1051/0004-6361:20054180},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006A%26A...449..827B&db_key=AST},
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006A\%26A...449..827B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -2186,7 +2186,7 @@ booktitle = {Mining the Sky},
    volume = 457,
     pages = {841-856},
       doi = {10.1051/0004-6361:20065138},
-   adsurl = {http://adsabs.harvard.edu/abs/2006A%26A...457..841I},
+   adsurl = {http://adsabs.harvard.edu/abs/2006A\%26A...457..841I},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -2447,7 +2447,7 @@ booktitle = {Mining the Sky},
   pages =        {1373-1387},
   doi =          {10.1051/0004-6361:20077334},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/abs/2007A%26A...467.1373R},
+                  {http://cdsads.u-strasbg.fr/abs/2007A\%26A...467.1373R},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -2604,7 +2604,7 @@ archivePrefix = "arXiv",
   volume =       478,
   pages =        {951-958},
   doi =          {10.1051/0004-6361:20077786},
-  adsurl =       {http://adsabs.harvard.edu/abs/2008A%26A...478..951K},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008A\%26A...478..951K},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -2623,7 +2623,7 @@ archivePrefix = "arXiv",
   volume =       488,
   pages =        {401-408},
   doi =          {10.1051/0004-6361:200809775},
-  adsurl =       {http://adsabs.harvard.edu/abs/2008A%26A...488..401R},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008A\%26A...488..401R},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -2810,7 +2810,7 @@ archivePrefix = "arXiv",
    volume = 496,
     pages = {577-584},
       doi = {10.1051/0004-6361:200811296},
-   adsurl = {http://adsabs.harvard.edu/abs/2009A%26A...496..577Z},
+   adsurl = {http://adsabs.harvard.edu/abs/2009A\%26A...496..577Z},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3016,7 +3016,7 @@ archivePrefix = "arXiv",
   volume =       516,
   pages =        {A77},
   doi =          {10.1051/0004-6361/200913503},
-  adsurl =       {http://adsabs.harvard.edu/abs/2010A%26A...516A..77B},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...516A..77B},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3054,7 +3054,7 @@ archivePrefix = "arXiv",
   eid =          {A48},
   pages =        {A48},
   doi =          {10.1051/0004-6361/201015441},
-  adsurl =       {http://adsabs.harvard.edu/abs/2010A%26A...523A..48J},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...523A..48J},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3077,7 +3077,7 @@ archivePrefix = "arXiv",
       eid = {A31},
     pages = {A31},
       doi = {10.1051/0004-6361/201014885},
-   adsurl = {http://adsabs.harvard.edu/abs/2010A%26A...523A..31H},
+   adsurl = {http://adsabs.harvard.edu/abs/2010A\%26A...523A..31H},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3272,7 +3272,7 @@ booktitle = {Observatory Operations: Strategies, Processes, and Systems III},
   eid =          {A76},
   pages =        {A76},
   doi =          {10.1051/0004-6361/201116929},
-  adsurl =       {http://adsabs.harvard.edu/abs/2011A%26A...530A..76W},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011A\%26A...530A..76W},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3623,7 +3623,7 @@ archivePrefix = "arXiv",
   eid =          {A78},
   pages =        {A78},
   doi =          {10.1051/0004-6361/201117905},
-  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...538A..78L},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...538A..78L},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3641,7 +3641,7 @@ archivePrefix = "arXiv",
   eid =          {A14},
   pages =        {A14},
   doi =          {10.1051/0004-6361/201218807},
-  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...543A..14H},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...543A..14H},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3659,7 +3659,7 @@ archivePrefix = "arXiv",
   eid =          {A15},
   pages =        {A15},
   doi =          {10.1051/0004-6361/201218808},
-  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...543A..15H},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...543A..15H},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3689,7 +3689,7 @@ archivePrefix = "arXiv",
   eid =          {A100},
   pages =        {A100},
   doi =          {10.1051/0004-6361/201118646},
-  adsurl =       {http://adsabs.harvard.edu/abs/2012A%26A...543A.100R},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...543A.100R},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3710,7 +3710,7 @@ archivePrefix = "arXiv",
   pages =        {A59},
   doi =          {10.1051/0004-6361/201219927},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/abs/2012A%26A...547A..59M},
+                  {http://cdsads.u-strasbg.fr/abs/2012A\%26A...547A..59M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4007,7 +4007,7 @@ archivePrefix = "ascl",
   pages =        {A74},
   doi =          {10.1051/0004-6361/201322344},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/abs/2013A%26A...559A..74B},
+                  {http://cdsads.u-strasbg.fr/abs/2013A\%26A...559A..74B},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4190,7 +4190,7 @@ archivePrefix = "arXiv",
   pages =        {A119},
   doi =          {10.1051/0004-6361/201423636},
   adsurl =
-                  {http://cdsads.u-strasbg.fr/abs/2014A%26A...566A.119L},
+                  {http://cdsads.u-strasbg.fr/abs/2014A\%26A...566A.119L},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4213,7 +4213,7 @@ archivePrefix = "arXiv",
   eid =          {A85},
   pages =        {A85},
   doi =          {10.1051/0004-6361/201424606},
-  adsurl =       {http://adsabs.harvard.edu/abs/2014A%26A...571A..85M},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014A\%26A...571A..85M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4441,7 +4441,7 @@ archivePrefix = "arXiv",
   eid =          {A115},
   pages =        {A115},
   doi =          {10.1051/0004-6361/201425310},
-  adsurl =       {http://adsabs.harvard.edu/abs/2015A%26A...574A.115M},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015A\%26A...574A.115M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4469,7 +4469,7 @@ archivePrefix = "arXiv",
       eid = {A79},
     pages = {A79},
       doi = {10.1051/0004-6361/201423829},
-   adsurl = {http://adsabs.harvard.edu/abs/2015A%26A...576A..79L},
+   adsurl = {http://adsabs.harvard.edu/abs/2015A\%26A...576A..79L},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4491,7 +4491,7 @@ archivePrefix = "arXiv",
   eid =          {A68},
   pages =        {A68},
   doi =          {10.1051/0004-6361/201526936},
-  adsurl =       {http://adsabs.harvard.edu/abs/2015A%26A...583A..68M},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015A\%26A...583A..68M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4564,7 +4564,7 @@ archivePrefix = "arXiv",
       eid = {A1},
     pages = {A1},
       doi = {10.1051/0004-6361/201629272},
-   adsurl = {http://adsabs.harvard.edu/abs/2016A%26A...595A...1G},
+   adsurl = {http://adsabs.harvard.edu/abs/2016A\%26A...595A...1G},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 


### PR DESCRIPTION
- Adds pybtex-based testing script for CI
- Applies '%' encoding to existing bibliographies for compatiblity with pybtex/latexcodec.
- Add developer documentation about this issue in https://lsst-texmf.lsst.io/v/DM-6033/developer.html#updating-bibliographies

I've verified that URLs appear properly in latex output: https://lsst-texmf.lsst.io/v/DM-6033/_static/examples/test-bibtex.pdf