### PR TITLE
DM-13140: Docker improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ script:
   - make
   - make test-pybtex
   - make docs
-after_success:
-  # Deploy https://lsst-texmf.lsst.io site
-  - make lsstthedocs
   # Build the Docker image
   - "docker build -t ${IMAGE_NAME}:build ."
   # Deploy the Docker image
   - ./bin/travis-docker-deploy.sh
+after_success:
+  # Deploy https://lsst-texmf.lsst.io site
+  - make lsstthedocs
 env:
   global:
     - LTD_MASON_BUILD=false  # disable builds in regular text matrix

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,16 @@ MAINTAINER LSST SQuaRE <sqre-admin@lists.lsst.org>
 # exists for container runs by a user.
 ENV TEXMFHOME "/texmf"
 
-# Create $TEXMFHOME directory in the container
-RUN mkdir $TEXMFHOME
+# Add lsst-texmf's bin/ directory to the path
+ENV PATH="/lsst-texmf-bin:${PATH}"
+
+RUN mkdir $TEXMFHOME && mkdir /lsst-texmf-bin
 
 # Contents of the lsst-texmf Git repo's texmf/ directory copied to container's
 # $TEXMFHOME directory.
 COPY texmf $TEXMFHOME/
+
+# Copy contents of lsst-texmf's bin directory to the image
+COPY bin /lsst-texmf-bin/
 
 CMD ["/bin/echo", "See https://lsst-texmf.lsst.io/docker.html for usage."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@
 FROM lsstsqre/lsst-texlive:latest
 MAINTAINER LSST SQuaRE <sqre-admin@lists.lsst.org>
 
+# Additional dependencies for lsst-texmf (acronyms.csh)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        csh \
+        default-jre && \
+    apt-get clean
+
 # Point $TEXMFHOME to the container's lsst-texmf. This environment variable
 # exists for container runs by a user.
 ENV TEXMFHOME "/texmf"

--- a/bin/travis-docker-deploy.sh
+++ b/bin/travis-docker-deploy.sh
@@ -25,10 +25,12 @@ else
     TAG=`echo "$TRAVIS_BRANCH" | sed "s/\//-/"`;
 fi
 
-# Tag and push the branch-based name
-docker tag ${IMAGE_NAME}:build ${IMAGE_NAME}:${TAG}
-docker push ${IMAGE_NAME}:${TAG}
+# Only deploy the `latest` image
+if [ ${TAG} == "latest" ]; then
+    # Tag and push the branch-based name
+    docker tag ${IMAGE_NAME}:build ${IMAGE_NAME}:${TAG}
+    docker push ${IMAGE_NAME}:${TAG}
 
-# Tag and push based on the Travis build number for forensics
-docker tag ${IMAGE_NAME}:build ${IMAGE_NAME}:travis-${TRAVIS_BUILD_NUMBER}
-docker push ${IMAGE_NAME}:travis-${TRAVIS_BUILD_NUMBER}
+else
+    echo "Skipping docker push (not 'latest')"
+fi

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -58,7 +58,7 @@ It contains a full `TeX Live`_ distribution, as well as ``make`` and ``git`` via
 ``lsst-texmf`` is installed in the container's ``/texmf`` directory, with :envvar:`TEXMFHOME` pre-set to that directory.
 
 The ``latest`` tag tracks the ``master`` branch.
-Tags are also published for all Git branches and tags pushed to GitHub, as well as tags for individual Travis builds.
+Other tags may be available for pinned versions and development branches.
 See the list of `tags on Docker Hub`_.
 
 Usually you'll want to use the ``latest`` tag.

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -54,8 +54,10 @@ About the lsst-texmf Docker image
 =================================
 
 The `lsstsqre/lsst-texmf`_ Docker image is based on Ubuntu 14.04 (trusty).
-It contains a full `TeX Live`_ distribution, as well as ``make`` and ``git`` via the `lsstsqre/lsst-texlive`_ image.
+It contains a full `TeX Live`_ distribution, as well as ``make`` and ``git``, via the `lsstsqre/lsst-texlive`_ image.
+The image also contains a Java runtime for ``acronyms.csh``.
 ``lsst-texmf`` is installed in the container's ``/texmf`` directory, with :envvar:`TEXMFHOME` pre-set to that directory.
+Scripts from ``lsst-texmf``\ ’s :file:`/bin` directory are available in the container's ``PATH``.
 
 The ``latest`` tag tracks the ``master`` branch.
 Other tags may be available for pinned versions and development branches.


### PR DESCRIPTION
Small improvements to the Docker build toolchain:

1. Only push the `latest` docker tag (corresponding to the `master` branch on GitHub) up to Docker Hub with Travis CI. Having tags for other branches and individual Travis builds turned out not to be useful.
2. Move the Docker build to Travis's `script` phase to provide warning if the Docker build is broken.
3. Install lsst-texmf's scripts from the `bin` directory into the Docker image and make them available from the `$PATH`.
4. Include the Java runtime and `csh` in the Docker image for `acronyms.csh`. See https://github.com/lsst/LDM-294/pull/50
  