### PR TITLE
DM-13069: Move template lander command to Travis script phase

### DIFF
--- a/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.travis.yml
+++ b/templates/document/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.travis.yml
@@ -10,10 +10,8 @@ before_install:
 script:
   # Compile PDF using containerized lsst-texmf
   - "docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'"
-after_success:
   # Deploy website. See https://github.com/lsst-sqre/lander for CLI options
-  - "lander --pdf {{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.pdf --upload --lsstdoc {{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.tex --env=travis --ltd-product $PRODUCT"
+  - "lander --pdf {{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.pdf --upload --lsstdoc {{ cookiecutter.series.upper() }}-{{ cookiecutter.serial_number }}.tex --env=travis --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}"
 env:
   global:
-    - PRODUCT="{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}"
     # Add LSST the Docs credentials


### PR DESCRIPTION
This pr moves the `lander` command in the template project to the Travis CI `script` phase (from the `after_success` phase).

Doing so ensures that if the landing page fails to deploy the build will be marked as a failure. This should reduce confusion.

Previously the landing pages were treated as an optional outcome from a build.