### PR TITLE
Adding LSE document type option. Updating default year to 2018

### DIFF
--- a/templates/document/cookiecutter.json
+++ b/templates/document/cookiecutter.json
@@ -4,6 +4,7 @@
     "DMTN",
     "SQR",
     "SMTN",
+    "LSE",
     "TEST"],
   "serial_number": "000",
   "github_org": [
@@ -16,7 +17,7 @@
   "title": "Document Title",
   "first_author": "First Last",
   "abstract": "Abstract text.",
-  "copyright_year": "2017",
+  "copyright_year": "2018",
   "copyright_holder": "Association of Universities for Research in Astronomy, Inc.",
   "license_cc_by": [true, false]
 }


### PR DESCRIPTION
In `templates/document/cookiecutter.json`, adding an option to create templates for Systems Engineering (LSE) type documents. Also updating to the present calendar year 2018 as the default.