### PR TITLE
 Add pst and put group name on title page

### DIFF
--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -203,8 +203,12 @@
    \renewcommand{\docType}{Software System Specification}
 }
 %
-% Define the CUs -- and the DPACE
+% Define the groups  
 %
+\DeclareOption{PST}{
+   \renewcommand{\CU}{PST}
+   \renewcommand{\docType}{Project Science Team}
+}
 \DeclareOption{DM}{
    \renewcommand{\CU}{DM}
    \renewcommand{\docType}{Data Management}
@@ -407,6 +411,8 @@
      \begin{center}
     \color{lssttitle}
     \textsf{\LARGE \bfseries Large Synoptic Survey Telescope (LSST)} \\
+    \vspace*{0.1cm}
+    \textsf{\LARGE \bfseries \docType } \\
     \vspace*{0.5cm}
     \begin{spacing}{2}
       \textsf{\Huge \bfseries \@title} \\


### PR DESCRIPTION
We should allow PST as a group in the doc.
Also I think it may be good to indicate that on the title page .. under Large Synoptic Survey Telescope (LSST) 
e..g Project Science Team

before the title...  these are all defined already when you do e.g. \documentclass[PST,toc]{lsstdoc}
we just do not use them.

