### PR TITLE
Refactor submodule docs from installation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ lsst-texmf is on GitHub at https://github.com/lsst/lsst-texmf.
    :maxdepth: 2
 
    install
+   submodule
    docker
    examples/index
    templates/index

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,11 @@
 Installing lsst-texmf
 #####################
 
-You can get the LSST LaTeX classes and style files from GitHub:
+There are three ways to install and use lsst-texmf: as a single centralized installation on your computer, as a submodule of individual document Git repositories, and as a Docker container.
+This page describes how to install lsst-texmf centrally.
+See :doc:`submodule` and :doc:`docker` for the other approaches.
+
+To install lsst-texmf, clone the lsst-texmf repository:
 
 .. code-block:: bash
 
@@ -17,29 +21,13 @@ For example, the following can be used if you are in the directory from which yo
 
    export TEXMFHOME=`pwd`/lsst-texmf/texmf
 
-A single :file:`texmf` directory can be reused for multiple documents, or else, it is possible to have separate :file:`texmf` directories for each document, having the environment variable set by a make file.
-A particularly useful way of doing the latter is to install :file:`lsst-texmf` as a git submodule.
-To do this, execute this within your document's repository:
-
-.. code-block:: bash
-
-    git submodule add https://github.com/lsst/lsst-texmf
-    
-Add and commit as usual.
-Later, when making a fresh clone of the repository, users will have to execute this within the repository:
-
-.. code-block:: bash
-
-    git submodule init
-    git submodule update
-
 If you do not want to override this environment setting but wish to have the files always available you can move the entire :file:`texmf` tree to the default home location which can be found using:
 
 .. code-block:: bash
 
    kpsewhich -var-value TEXMFHOME
 
-which on a Mac reports :file:`~/Library/texmf`.
+On a Mac this is :file:`~/Library/texmf`.
 
 Once this environment variable is set, :command:`xelatex` and :command:`pdflatex` will find the relevant files automatically.
 

--- a/docs/submodule.rst
+++ b/docs/submodule.rst
@@ -1,0 +1,46 @@
+.. _install:
+
+###################################
+Using lsst-texmf as a Git submodule
+###################################
+
+Instead of a :doc:`centralized installation of lsst-texmf <install>`, many LSST documents include a specific copy of lsst-texmf as a Git submodule.
+This page describes how to set up a document repository to use an lsst-texmf submodule, and how to work with these repositories.
+
+Adding a lsst-texmf submodule
+=============================
+
+To install lsst-texmf as a Git submodule, execute this within your document's repository:
+
+.. code-block:: bash
+
+   git submodule add https://github.com/lsst/lsst-texmf
+    
+Add and commit as usual.
+
+Second, ensure that the document's :file:`Makefile` uses the lsst-texmf submodule.
+Typically, you can do this exporting the ``TEXMFHOME`` at the beginning of the Makefile:
+
+.. code-block:: make
+
+   export TEXMFHOME = lsst-texmf/texmf
+
+If your :file:`Makefile` uses scripts in the :file:`lsst-texmf/bin` directory, you can point to that script relative to the ``$TEXMFHOME`` directory.
+For example:
+
+.. code-block:: make
+
+   acronyms.tex :$(tex) myacronyms.txt skipacronyms.txt
+       python3 ${TEXMFHOME}/../bin/generateAcronyms.py $(tex)
+
+Lastly, it's a good idea to include the ``git submodule`` code snippet from the next section in the document's README to remind others how to set up the submodule.
+
+Cloning a document Git repository with a submodule
+==================================================
+
+When making a fresh clone of the repository, you will have to execute this within the repository:
+
+.. code-block:: bash
+
+    git submodule init
+    git submodule update

--- a/etc/glossary.txt
+++ b/etc/glossary.txt
@@ -46,6 +46,7 @@ deg        : degree; unit of angle
 DoF        : Degree(s) of Freedom (also known as DOF)
 DOM        : Document Object Model
 DoNM       : Date of Next Meeting
+DPAC       : Data Processing and Analysis Consortium (Gaia)
 DS9        : Deep Space 9 (specific astronomical data visualisation application; SAOImage)
 DWDM       : Dense Wave Division Multiplex
 EEPROM     : Electrically Erasable Programmable Read-Only Memory
@@ -54,11 +55,13 @@ eV         : electron-Volt
 FAQ        : Frequently Asked Question
 FFT        : Fast Fourier Transform
 FIFO       : First In, First Out
+FITS       : Flexible Image Transport System
 FK5        : Fifth Fundamental Catalogue
 FoM        : Figure of Merit
 FoV        : Field of View (also denoted FOV)
 FPGA       : Field-Programmable Gate Array
 FS         : File System
+FTE        : Full Time Equivalent
 FWHM       : Full Width at Half-Maximum
 Gb         : Gigabit
 GB         : GigaByte
@@ -70,6 +73,7 @@ GPFS       : General Parallel File System
 GPS        : Global Positioning System
 GRB        : Gamma-Ray Burst
 GST        : Greenwich Sidereal Time
+GUI        : Graphical User Interface 
 HEALPix    : Hierarchical Equal-Area iso-Latitude Pixelisation
 HST        : Hubble Space Telescope
 HTM        : Hierarchical Triangular Mesh
@@ -147,11 +151,13 @@ SDSS       : Sloan Digital Sky Survey
 SI         : Syst\`eme International (International System of units, defined by ISO)
 SLA        : Service Level Agreement
 SOAP       : Simple Object Access Protocol
+SODA       : Server-side Operations for Data Access
 SSD        : Solid-State Disk
 SSH        : Secure SHell
 stdin      : standard input
 stdout     : standard output
 SW         : Software (also denoted S/W)
+SQL        : Structured Query Language
 TAI        : International Atomic Time
 TAP        : Table Access Protocol
 TB         : TeraByte

--- a/etc/lsstacronyms.txt
+++ b/etc/lsstacronyms.txt
@@ -52,6 +52,7 @@ NET        : Network Engineering Team
 OCS        : Observatory Control System
 OSS        : Observatory System Specifications; LSE-30
 PDR        : Preliminary Design Review
+PDU        : Power Distribution Unit 
 PM         : Project Manager
 PMCS       : Project Management Control System
 PS         : Project Scientist


### PR DESCRIPTION
At some point some notes on setting up lsst-texmf as a Git submodule got added to the installation page, which is good content but not the right place or presentation in my opinion.

This change:

- Creates a new page all about submodule usage (set up and cloning)
- Clarifies that the install page is all about creating a centralized installation and links to the docker and submodule pages for alternative approaches.

Preview:

- [Installing lsst-texmf](
https://lsst-texmf.lsst.io/v/u-jonathansick-submodules-docs/install.html)
- [Using lsst-texmf as a Git submodule](
https://lsst-texmf.lsst.io/v/u-jonathansick-submodules-docs/submodule.html)

I could also add notes on adding `bin/` to `$PATH`, but I'm not sure that'll be tackled in #140.