### PR TITLE
Update documenteer to 0.4.x range

### DIFF
--- a/bin/validate_bib.py
+++ b/bin/validate_bib.py
@@ -30,8 +30,7 @@ def main():
             print('Cannot find bib for testing: {}'.format(bibpath))
             sys.exit(1)
 
-    # We use the latex+latin code with Sphinx workflows.
-    parser = bibtex.Parser('latex+latin')
+    parser = bibtex.Parser()
     for bibpath in args.paths:
         print('Parsing {}'.format(bibpath))
         parser.parse_file(bibpath)

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -5,5 +5,4 @@ References
 ##########
 
 .. bibliography:: ../texmf/bibtex/bib/lsst.bib
-   :encoding: latex+latin
    :style: lsst_aa

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-Sphinx>=1.5.5,<1.6
-documenteer>=0.1.11,<0.2.0
+Sphinx>=1.7,<1.8
+documenteer>=0.4.3,<0.5.0
+sphinxcontrib-bibtex==0.4.0
 sphinx-rtd-theme==0.2.4


### PR DESCRIPTION
Documenteer 0.4.3 includes a new version requirement on sphinxcontrib-bibtex to avoid Sphinx 1.7.x compatibility issues introduced by sphinxcontrib-bibtex 0.4.1.