### PR TITLE
DM-16905: Copy full lsst-textmf project to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Repo files not needed in the image
+.github
+docs
+.gitignore
+.travis.yml
+Makefile
+
+# Files built by tests
+*.pdf
+*.aux
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.pdf
+*.toc
+*.nav
+*.snm

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,20 +14,17 @@ RUN apt-get update && \
         default-jre && \
     apt-get clean
 
+# Create a directory the lsst-texmf installation
+RUN mkdir lsst-texmf
+
 # Point $TEXMFHOME to the container's lsst-texmf. This environment variable
 # exists for container runs by a user.
-ENV TEXMFHOME "/texmf"
+ENV TEXMFHOME "/lsst-texmf/texmf"
 
 # Add lsst-texmf's bin/ directory to the path
-ENV PATH="/lsst-texmf-bin:${PATH}"
+ENV PATH="/lsst-texmf/bin:${PATH}"
 
-RUN mkdir $TEXMFHOME && mkdir /lsst-texmf-bin
-
-# Contents of the lsst-texmf Git repo's texmf/ directory copied to container's
-# $TEXMFHOME directory.
-COPY texmf $TEXMFHOME/
-
-# Copy contents of lsst-texmf's bin directory to the image
-COPY bin /lsst-texmf-bin/
+# Copy lsst-texmf repo in /lsst-texmf/
+COPY . /lsst-texmf
 
 CMD ["/bin/echo", "See https://lsst-texmf.lsst.io/docker.html for usage."]


### PR DESCRIPTION
Rather than than trying to copy over just the parts of lsst-texmf that we think are necessary, this commit copies over lsst-texmf in full into `/lsst-texmf/` of the image. This prevents issues like #147 where `generateAcronyms.py` looks for a file in the `etc` directory of `lsst-texmf`.

The `.dockerignore` file helps to avoid adding truly unnecessary files.

Fixes #147