### PR TITLE
Fix the combination of CCB notices and the glossaries package

### DIFF
--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -750,23 +750,22 @@
   \relax
 \else
 \begin{minipage}{0.9\textwidth}
-\begin{center}
-  \vspace*{0.2cm}
-  \scriptsize
-  \bfseries
-  \if@isdraft
-    \color{red}
-    DRAFT NOT YET APPROVED
-    \color{lsstfoot} --
-  \fi
-  \color{lsstfoot}
-  \@controlFootText
-  \if@isdraft
-    --
-    \color{red}
-    DRAFT NOT YET APPROVED
-  \fi
-\end{center}
+\centering
+\vspace*{0.2cm}
+\scriptsize
+\bfseries
+\if@isdraft
+  \color{red}
+  DRAFT NOT YET APPROVED
+  \color{lsstfoot} --
+\fi
+\color{lsstfoot}
+\@controlFootText
+\if@isdraft
+  --
+  \color{red}
+  DRAFT NOT YET APPROVED
+\fi
 \end{minipage}
 \\
 \fi

--- a/texmf/tex/latex/lsst/lsstdoc.cls
+++ b/texmf/tex/latex/lsst/lsstdoc.cls
@@ -16,7 +16,6 @@
 \RequirePackage{bm}
 \RequirePackage{amsbsy}
 
-\usepackage[nonumberlist,nogroupskip,toc,numberedsection=autolabel,style=index]{glossaries}
 \usepackage{environ}
 \usepackage{enumitem}
 
@@ -69,6 +68,10 @@
 
 %\RequirePackage[linkcolor=blue,colorlinks=true]{hyperref}
 \RequirePackage{hyperref}
+
+% Must be loaded AFTER hyperref (page 3 of the glossaries manual)
+\RequirePackage[nonumberlist,nogroupskip,toc,numberedsection=autolabel,style=index]{glossaries}
+
 \RequirePackage{numprint}
 \RequirePackage[english,iso]{isodate}
 \RequirePackage{titlesec}


### PR DESCRIPTION
Previously, the CCB notice added to the bottom of LDM/LSE/LPM documents was upsetting glossaries by doing something weird to the vertical spacing. This change reduces the vertical space used by the CCB notice, and so glossaries appears to be happy.