### PR TITLE
Glossary fixes.

### DIFF
--- a/etc/broke.csv
+++ b/etc/broke.csv
@@ -1,3 +1,0 @@
-deVaucouleurs profile,"The radial distribution of flux of an astronomical source that is characterized as: 
-I(r)=I0exp(7.67(r/re)1/4) 
-An elliptical version of this profile can be fit to every detected source, yielding the deVaucouleurs parameters. See the page on Measurement in the LSST Stack for details.",Sci,,

--- a/etc/glossarydefs.csv
+++ b/etc/glossarydefs.csv
@@ -1,717 +1,720 @@
-Term,Description,Subsystem Tags,Documentation Tags,Associated Acronyms and Alternative Terms
-1D,One-dimensional,Gen,,
-2D,Two-dimensional,Gen,,
-2MASS,Two-Micron All Sky Survey,Gen,,
-3D,Three-dimensional,Gen,,
-A/D,Analogue-to-Digital (converter),Gen,,
-AAS,American Astronomical Society,Gen,,
-ABI,Application Binary Interface,Gen,,
-AC,Alternating Current,Gen,,
-ACWP,Actual Cost of Work Performed,Gen,,
-ADASS,Astronomical Data Analysis Software and Systems,Gen,,
-ADC,Analogue-to-Digital Converter,Gen,,
-ADQL,Astronomical Data Query Language,Gen,,
-ADU,Analogue-to-Digital Unit,Gen,,
-AIT,Assembly Integration and Test,Gen,,
-AIV,Assembly Integration and Verification,Gen,,
-ALMA,Atacama Large Millimeter Array (ESO),Gen,,
-AMCL,\gls{AURA Management Council for LSST},LSST,,
-AWS,Amazon Web Services,Gen,,
-AOB,Any Other Business,Gen,,
-API,Application Programming Interface,Gen,,
-arcmin,arcminute minute of arc (unit of angle),Gen,,
-arcsec,arcsecond second of arc (unit of angle),Gen,,
-ASAP,As Soon As Possible,Gen,,
-ASCII,American Standard Code for Information Interchange,Gen,,
-au,astronomical unit,Gen,,
-AU,deprecated acronym for astronomical unit; use au instead,Gen,,
-AURA,\gls{Association of Universities for Research in Astronomy},Gen,,
-b,bit,Gen,,
-B,Byte (8 bit),Gen,,
-BAC,Budget At Complete,Gen,,
-BCWP,Budgeted Cost of Work Performed,Gen,,
-BCWS,Budgeted Cost of Work Scheduled,Gen,,
-BDC, Base Data Center, DM IT,,
-BNF,Backus-Naur Form,Gen,,
-BOE,\gls{Basis of Estimate},Gen,,
-BPS,Batch Production Service,LDF DM,,
-bps,bit(s) per second,Gen,,
-Bps,Bytes per second,Gen,,
-CADC,Canadian Astronomy Data Centre,Gen,,
-CAOM,Common Archive Observation Model,DM Gen,,
-CAM,Control (or Cost) Account Manager,Gen,,
-CC,Change Control,Gen,,
-CCD,\gls{Charge-Coupled Device},Gen,,
-CDS,Centre de Donnes astronomiques de Strasbourg,Gen,,
-CfA,(Harvard-Smithsonian) Center for Astrophysics,Gen,,
-CI,Cyber Infrastructure,Petabytes,,
-CI,Continuous Integration,Gen,,
-COMPASS,Catalogues of Objects and Measured Parameters from All Sky Surveys,Gen,,
-CORBA,Common Object Request Broker Architecture,Gen,,
-COTS,Commercial-Off-The-Shelf,Gen,,
-CPI,Cost Performance Index,Gen,,
-CPU,Central Processing Unit,Gen,,
-CR,Cosmic Ray,Gen,,
-CSV,Comma Separated Values,Gen,,
-CTIO,Cerro Tololo Inter-American Observatory,Gen,,
-CV,Curriculum Vitae,Gen,,
-DB,DataBase,Gen,,
-Db,Decibel,Gen,,
-DBMS,DataBase Management System,Gen,,
-DCR,Differential Chromatic Refraction,Gen,,
-DEC,Declination,Gen,,
-deg,degree; unit of angle,Gen,,
-DIA,Difference Image Analysis,DM,,
-DIMM,Differential Image Motion Monitor,Gen,,
-DOE,\gls{Department of Energy},Gen,,
-DoF,Degree(s) of Freedom (also known as DOF),Gen,,
-DOM,Document Object Model,Gen,,
-DoNM,Date of Next Meeting,Gen,,
-DPAC,Data Processing and Analysis Consortium (Gaia),Gen,,
-DS9,Deep Space 9 (specific astronomical data visualisation application; SAOImage),Gen,,
-DWDM,Dense Wave Division Multiplex,Gen,,
-EEPROM,Electrically Erasable Programmable Read-Only Memory,Gen,,
-ESA,European Space Agency,Gen,,
-ESAC,European Space Astronomy Centre,Gen,,
-ESNET,Energy Sciences Network,Gen,,
-ETC,Estimate To Complete,Gen,,
-eV,electron-Volt,Gen,,
-EVM,Earned Value Management,Gen,,
-EVMS,Earned Value Management System,Gen,,
-FAQ,Frequently Asked Question,Gen,,
-FFT,Fast Fourier Transform,Gen,,
-FGCM, Forward Global Calibration Model,DM,,
-FIFO,First In First Out,Gen,,
-FITS,\gls{Flexible Image Transport System},Gen,,
-FIU,Florida International University,Gen,,
-FK5,Fifth Fundamental Catalogue,Gen,,
-FoM,Figure of Merit,Gen,,
-FoV,Field of View (also denoted FOV),Gen,,
-FPA,Focal Plane Array, LSST,,
-FPA,Focal Plane Assembly, Gaia,,
-FPGA,Field-Programmable Gate Array,Gen,,
-FS,File System,Gen,,
-FTE,Full Time Equivalent,Gen,,
-FUSE,a user space filesystem framework,IT,,
-FWHM,Full Width at Half-Maximum,Gen,,
-GAVO,German Astronomical Virtual Observatory,Gen,,
-Gb,Gigabit,Gen,,
-GB,Gigabyte,Gen,,
-gcc,The GNU Compiler Collection; a C and C++ compiler,Gen,,
-GCN,GRB Coordinates Network,Gen,,
-GLONASS,GLObal NAvigation Satellite System,Gen,,
-GPFS,General Parallel File System (now IBM Spectrum Scale),Gen,,
-GPL,GNU Public License,Gen,,
-GPS,Global Positioning System,Gen,,
-GRB,Gamma-Ray Burst,Gen,,
-GST,Greenwich Sidereal Time,Gen,,
-GUI,Graphical User Interface,Gen,,
-HEASARC,NASA's Archive of Data on Energetic Phenomena,Gen,,
-HEALPix,Hierarchical Equal-Area iso-Latitude Pixelisation,Gen,,
-HEP, High Energy Physics,Gen,,
-HIPS,Hierarchical Progressive Survey,Gen,,
-HSC,Hyper Suprime-Cam,Gen,,
-HST,Hubble Space Telescope,Gen,,
-HPC,High Performance Computing,DM,,
-HTC,High Throughput Computing,DM,,
-HTM,\gls{Hierarchical Triangular Mesh},Gen,,
-HTML,HyperText Markup Language,Gen,,
-HTTP,HyperText Transfer Protocol,Gen,,
-HW,HardWare,Gen,,
-I&T,Integration and Test,Gen,,
-IAU,International Astronomical Union,Gen,,
-IBM,International Business Machines,Gen,,
-IDL,Interactive Data Language,Gen,,
-IoA,Institute of Astronomy (Cambridge; also denoted IOA),Gen,,
-IRAF,Image Reduction and Analysis Facility,Hist,,
-IPAC,No longer an acronym; science and data center at Caltech,Gen,,
-IRSA,Infrared Science Archive,Gen,,
-IT,Information Technology,Gen,,
-ITIL,Information Technology Infrastructure Library,Gen,,
-IVOA,International Virtual-Observatory Alliance,Gen,,
-JD,\gls{Julian Date},Gen,,
-JDBC,Java DataBase Connectivity,Gen,,
-JHU,Johns Hopkins University,Gen,,
-JIRA,issue tracking product (not an acronym but a truncation of Gojira the Japanese name for Godzilla),Gen,,
-JPL,Jet Propulsion Laboratory (DE ephemerides),Gen,,
-JRE,Java Runtime Environment,Gen,,
-JSON,JavaScript Object Notation,Gen,,
-JVM,Java Virtual Machine,Gen,,
-JWST,James Webb Space Telescope (formerly known as NGST),Gen,,
-KBO,Kuiper-Belt Object,Gen,,
-kbps,kilobits per second,Gen,,
-LAN,Local Area Network,Gen,,
-LAPACK,Linear Algebra PACKage,Gen,,
-LASER,Light Amplification by Stimulated Emission of Radiation,Gen,,
-LaTeX,(Leslie) Lamport TeX (document markup language and document preparation system),Gen,,
-LATISS,LSST Atmospheric Transmission Imager and Slitless Spectrograph,TS, ,
-LCO,Las Cumbres Observatories,Gen,,
-LED,Light-Emitting Diode,Gen,,
-LHC,Large Hadron Collider (at CERN),Gen,,
-LPGL,Lesser Public GNU general License,Gen,,
-LUT,Look-Up Table,Gen,,
-MAST,Mikulski Archive for Space Telescopes,Gen,,
-Mb,Megabit (1000000 bit),Gen,,
-MB,MegaByte,Gen,,
-MBps,Megabits per second,Gen,,
-MC,Monte-Carlo (simulation/process),Gen,,
-MCMC,Monte Carlo Markov Chain,Gen,,
-MERRA,Modern-Era Retrospective analysis for Research and Applications,NASA,,
-MIDAS,Munich Image Data Analysis System (ESO),Gen,,
-MJD,Modified \gls{Julian Date} (to be avoided; see also \gls{JD}),Gen,,
-MOC,Multi Ordered Catalogue,VO DM,,
-MOSFET,Metal-Oxide Semiconductor Field-Electric Transistor,Gen,,
-MPA,Max Planck Institute for Astrophysics,Gen,,
-MPP,Massively Parallel Process,DM, ,
-MREFC,\gls{Major Research Equipment and Facility Construction},Gen,,NSF
-MREN,Montenegrin Research and Education Network,Gen,,
-MSB,Most Significant Bit,Gen,,
-MYDB,"My Database, the notion of having a local storage beside the queriable database to store either temporary tables or uploaded catalogs",DM Gen, ,
-NAOJ,National Astronomical Observatory of Japan,Gen,,
-NASA,National Aeronautics and Space Administration,Gen,,
-NED,NASA/IPAC Extragalactic Database,Gen,,
-NCOA,National Center for Optical-Infrared Astronomy,Gen,,
-NCSA,National Center for Supercomputing Applications,Gen,,
-NEO,Near-Earth Object,Gen,,
-NFS,Network File System,Gen,,
-NIST,National Institute of Standards and Technology (USA),Gen,,
-NOAO,National Optical Astronomy Observatories (USA),Gen,,
-NSF,\gls{National Science Foundation},Gen,,
-OBS,Organisation Breakdown Structure,Gen,,
-OS,Operating System,Gen,,
-OSX,Macintosh Operating System (obsolete; now macOS),Gen,,
-Pan-STARRS,Panoramic Survey Telescope and Rapid Response System,Gen,,
-Parsl,Parallel Scripting Library \url{http://parsl-project.org/},DM,,
-PB,PetaByte,Gen,,
-PCA,Principal Component Analysis,Gen,,
-PDF,Portable Document Format,Gen,,
-PDF,Probability Density Function,Gen,,
-PFS,Prime Focus Spectrograph,Gen,,
-PLL,Phase-Locked Loop,Gen,,
-POSIX,Portable Operating System Interface,Gen,,
-PR,Pull Request,Gen,,
-PSF,Point Spread Function,Gen,,
-QA,Quality Assurance,Gen,,
-QC,Quality Control,Gen,,
-Qserv,Proprietary Database built by SLAC for LSST,DM,,
-RA,Right Ascension,Gen,,
-RAID,Redundant Array of Inexpensive Disks,Gen,,
-RAL,Rutherford Appleton Laboratory (UK),Gen,,
-RAM,Random Access Memory,Gen,,
-RC,Release Candidate,Gen,,
-REUNA,Red Universitaria Nacional,Gen,,
-RMS,Root-Mean-Square,Gen,,
-ROOT,Object-oriented data analysis framework developed at CERN,Gen,,
-RS232C,Standard 25-pin serial connection between computers and modems,Gen,,
-SaaS,Software as a Service,Gen,,
-SAMP,Simple Application Messaging Protocol,Gen,,
-SAO,Smithsonian Astrophysical Observatory,Gen,,
-SDSS,\gls{Sloan Digital Sky Survey},Gen,,
-SI,Syst\`eme International (International System of units defined by ISO),Gen,,
-SLA,Service Level Agreement,Gen,,
-SOAP,Simple Object Access Protocol,Gen,,
-SODA,Server-side Operations for Data Access,Gen,,
-SPI,Schedule Performance Index,Gen,,
-SPIE,The international society for optics and photonics,Gen,,
-SQL,Structured Query Language,Gen,,
-SSD,Solid-State Disk,Gen,,
-SSH,Secure SHell,Gen,,
-stdin,standard input,Gen,,
-stdout,standard output,Gen,,
-SW,Software (also denoted S/W),Gen,,
-TACC,Texas Advanced Computing Center,Gen,,
-TAI,International Atomic Time,Gen,,
-TAP,Table Access Protocol,Gen,,
-TB,TeraByte,Gen,,
-TBA,To Be Announced,Gen,,
-TBA,To Be Assigned,Gen,,
-TBC,To Be Confirmed,Gen,,
-TBD,To Be Defined (Determined),Gen,,
-TBR,To Be Resolved,Gen,,
-TCAM,Technical Control (or Cost) Account Manager,DM,,
-TFLOP,Tera FLOP,Gen,,
-TOPCAT,Tool for OPerations on Catalogues And Tables,Gen,,
-TSS,Telescope and Site Software,LSST,,
-UCL,University College London (UK),Gen,,
-UDP,User Datagram Protocol,Gen,,
-UI,User Interface,Gen,,
-US,United States,Gen,,
-USNO,United States Naval Observatory,Gen,,
-UT,Universal Time,Gen,,
-UT1,Universal Time 1,Gen,,
-UTC,Coordinated Universal Time,Gen,,
-UW,University of Washington,Gen,,
-UX,User Experience,Gen,,
-VLA,Very Large Array (NRAO),Gen,,
-VLBA,Very Long Baseline Array,Gen,,
-VLBI,Very Long Baseline Interferometry,Gen,,
-VLT,Very Large Telescope (ESO),Gen,,
-VLTI,Very Large Telescope Interferometer (ESO),Gen,,
-VM,Virtual Machine,Gen,,
-VNOC,Virtual Network Operations Center,NET ,,
-VO,Virtual Observatory,Gen,,
-VOIP,Voice Over Internet Protocol,IT DM,,
-WAN,Wide Area Network,Gen,,
-WBS,\gls{Work Breakdown Structure},Gen,,
-WCS,\gls{World Coordinate System},Gen,,
-WISE,Wide-field Survey Explorer,Gen,,
-WSDL,Web Services Description Language,Gen,,
-XHTML,eXtensible HyperText Markup Language,Gen,,
-XML,eXtensible Markup Language,Gen,,
-XMM,X-ray Multi-mirror Mission (ESA; officially known as XMM-Newton),Gen,,
-XSD,XML Schema Definition,Gen,,
-XSL,eXtensible Stylesheet Language,Gen,,
-XSLT,eXtensible Stylesheet Language Transformation,Gen,,
-YAML,Yet Another Markup Language,Gen,,
-AOS,Active Optics System,LSST DM,,
-ACCS,Auxiliary Camera Control System,LSST DM,,
-AP,Alert Production,LSST DM,,
-ATM,Adaptavist Test Management,LSST DM,,
-CAM,CAMera,LSST DM,,
-CB,Configuration Baseline,LSST DM,,
-CCB,\gls{Change Control Board},LSST DM,,
-CCOB,Camera Calibration Optical Bench,LSST DM,,
-CM,Configuration Management,LSST DM,,
-CMDB,Configuration Management Database,LSST DM,,
-CPP,Calibration Production Processing,LSST DM,,
-CR,Change Request,LSST DM,,
-DAC,\gls{Data Access Center},LSST DM,,
-DAQ,Data Acquisition System,LSST DM,,
-DAX,Data Access Services,LSST DM,,
-DBB,Data Back Bone,LSST DM,,
-DC,Data Center,LSST DM,,
-DDMPM,Data Management Deputy Project Manager,LSST DM,,
-DM,\gls{Data Management},LSST DM,,
-DMCCB,DM Change Control Board,LSST DM,,
-DMCS,Data Management Control System,LSST DM,,
-DMIS,DM Interface Scientist,LSST DM,,
-DMLT,DM Leadership Team,LSST DM,,
-DMO,Data Management Organization,LSST DM,,
-DMPM,Data Management Project Manager,LSST DM,,
-DMQA,Data Management Quality Assurance,LSST DM,,
-DMS,Data Management Subsystem,LSST DM,,
-DMSE,Data Management System Engineer,LSST DM,,
-DMSR,DM System Requirements; LSE-61,LSST DM,,
-DMSS,DM Subsystem Scientist,LSST DM,,
-DMSST,DM System Science Team,LSST DM,,
-DMTN,DM Technical Note,LSST DM,,
-DMTR,DM Test Report,LSST DM,,
-DPDD,Data Product Definition Document,LSST DM,,
-DR,Data Release,LSST DM,,
-DRP,Data Release Production,LSST DM,,
-DTN,Data Transfer Node,LSST DM,,
-DWDM,Dense Wave Division Multiplex,LSST DM,,
-EAC,Estimate At Completion,LSST DM,,
-EFD,Engineering Facilities Database,LSST DM,,
-EIE,European Industrial Engineering - Italian engineering company (Dome),LSST DM,,
-EPO,Education and Public Outreach,LSST DM,,
-ETC,Estimate To Complete,LSST DM,,
-ETU,Engineering Test Unit,LSST DM,,
-EUPS,Extended Unix Product System,LSST DM,,
-FSAAS,Filesystem as a Service, IT,,
-FDR,Final Design Review,LSST DM,,
-FLOP,FLoating point Operation,IT,,
-ICBS,International Communications and Base Site,LSST DM,,
-IS,Interface Scientist,LSST DM,,
-ISR,Instrument Signal Removal,LSST DM,,
-IT,Integration Test,LSST DM,,
-ITC,Information Technology Center,LSST DM,,
-JTM,Joint Technical Meeting,LSST DM,,
-JSR,Joint Status Review,LSST DM,,
-KPM,Key Performance Metric,LSST DM,,
-LCR,\gls{LSST Change Request},LSST DM,,
-LDF,LSST Data Facility,LSST DM,,
-LDM,LSST Data Management (Document Handle),LSST DM,,
-LOVE,LSST Operations Visualization Environment,LSST DM,,
-LPM,LSST Project Management (Document Handle),LSST DM,,
-LSE,LSST Systems Engineering (Document Handle),LSST DM,,
-LSP,LSST Science Platform,LSST DM,,
-LSR,LSST System Requirements; LSE-29,LSST DM,,
-LSST,Large Synoptic Survey Telescope,LSST DM,,
-MOPS,Moving Object Processing System,LSST DM,,
-NET,Network Engineering Team,LSST DM,,
-OCS,Observatory Control System,LSST DM,,
-OODS,Observatory Operations Data Service,DM,,
-OPS,Operations,LSST DM,,
-OSS,Observatory System Specifications; LSE-30,LSST DM,,
-PCW,Project Community Workshop,LSST DM,,
-PDAC,Prototype Data Access Center,LSST DM,,
-PDR,Preliminary Design Review,LSST DM,,
-PDU,Power Distribution Unit,LSST DM,,
-PM,Project Manager,LSST DM,,
-PMCS,\gls{Project Management Controls System},LSST DM,,
-PMP,(DM) Project Management Plan; LDM-294,LSST DM,,
-PS,Project Scientist,LSST DM,,
-PST,\gls{Project Science Team},LSST DM,,
-PSTN,Project Science Technical Note,LSST DM,,
-Qserv,Proprietary LSST Database system,LSST DM,,
-REB,Readout Electronics Board,LSST DM,,
-RFC,Request For Comment,LSST DM,,
-RM,Release Manager,LSST DM,,
-SAC,Science Advisory Committee,LSST DM,,
-SEMP,Systems Engineering Management Plan,LSST DM,,
-SLAC,No longer an acronym; formerly Stanford Linear Accelerator Center,LSST DM,,
-SQuaRE,Science Quality and Reliability Engineering,LSST DM,LDM-204,
-SQuaSH,\gls{Science Quality Analysis Harness},DM,https://squash.lsst.codes/,
-SQR,SQuARE document handle,LSST DM,,
-SRD,LSST Science Requirements; LPM-17,LSST DM,,
-SS,Subsystem Scientist,LSST DM,,
-SST,Subsystem Science Team,LSST DM,,
-SUI,Science User Interface,LSST DM,,
-SUIT,Science User Interface and Tools,LSST DM,,
-SV,Science Validation,LSST DM,,
-T&S,Telescope and Site,LSST DM,,
-T/CAM,Technical/Control (or Cost) Account Manager,LSST DM,,
-TCT,Technical Control Team (obsolete; now DMCCB),LSST DM,,
-TS,Test Specification,LSST DM,,
-VCD,Verification Control Document,LSST DM,,
-WG,Working Group,LSST DM,,
-Accident,"An undesired event that results in harm to people, damage to property, or loss to process.  Accidents result from contact with a substance or source of energy above the threshold limit of the body structure.",Adm,,
-Accruals,"Accounts on a balance sheet that represent liabilities and non-cash-based assets used in accrual-based accounting; these accounts include, among many others, accounts payable, accounts receivable, goodwill, future tax liability, and future interest expense",Adm,,
-Archive,"The repository for documents required by the NSF to be kept. These include documents related to design and development, construction, integration, test, and operations of the LSST observatory system. The archive is maintained using the enterprise content management system DocuShare, which is accessible through a link on the project website www.project.lsst.org.",Adm,,
-Association of Universities for Research in Astronomy," consortium of US institutions and international affiliates that operates world-class astronomical observatories, AURA is the legal entity responsible for managing what it calls independent operating Centers, including LSST, under respective cooperative agreements with the National Science Foundation. AURA assumes fiducial responsibility for the funds provided through those cooperative agreements. AURA also is the legal owner of the AURA Observatory properties in Chile.",Adm,,
-AURA Management Council for LSST,",  group reporting to the AURA Board of Directors that oversees the activities of the LSST Project Office and advocates the mission of the LSST",Adm,,
-Base Year Cost,"The cost of a particular project element as of a year chosen to represent an arbitrary cost level of 100, usually the year the project plan was created or refreshed. New, up-to-date base years are periodically introduced to keep data current.",Adm,,
-Baseline,The point at which project designs or requirements are considered to be 'frozen' and after which all changes must be traced and approved,Adm,,
-"Baseline, Cost","The 'frozen' total costs required for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed",Adm,,
-"Baseline, Design",The baseline defining the site specific preliminary design of the LSST subsystems and their associated hardware and software deliverables required to meet the requirements and definitions of the System Baseline,Adm,,
-"Baseline, Functional","The baseline defining at the highest level the scientific, functional, and performance requirements for what the LSST Observatory is and what it must do as a whole",Adm,,
-"Baseline, Schedule","The 'frozen' amount of time required for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed",Adm,,
-"Baseline, System","The baseline defining the high level set of functional and performance requirements for the LSST system and each of the LSST subsystems (Camera, Telescope and Site, and Data Management), the Observatory Control System, and Education and Public Outreach",Adm,,
-"Baseline, Technical","The 'frozen' requirements, specifications, designs, and allocations needed for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed",Adm,,
-Basis of Estimate,"justification for arriving at a particular cost estimate, including estimating methods, approach taken, prices used, assumptions made; an analyzed and carefully calculated number",Adm,,
-Builder,Individuals who have accumulated 2 FTE years worth of employment/contributions to the LSST Project.,Adm,,
-Business Manager,"The person responsible for all business activities of the LSST Project and the LSST Corporation; he or she serves as liaison to AURA \gls{CAS}, develops and monitors contracts, and serves as the LSST Corporation Secretary",Adm,,
-Buyer,"Includes the terms 'Buyer' 'subcontract administrator or officer' 'contracts administrator or officer' sub-award administrator, or any other LSSTC authorized procurement official as used herein are inter-changeable.",Adm,,
-CASNET,AURA's financial reporting database,Adm,,
-Center,An entity managed by AURA that is responsible for execution of a federally funded project,Adm,,
-CAS,\gls{Central Administrative Services},Adm,,
-Central Administrative Services,"AURA corporate division responsible for providing accounting, procurement, and business IT support services to AURA centers",Adm,,
-Change Control,"The systematic approach to managing all changes to the LSST system, including technical data and policy documentation. The purpose is to ensure that no unnecessary changes are made, all changes are documented, and resources are used efficiently and appropriately.",Adm,,
-Change Control Board, "advisory board to the Project Manager; composed of technical and management representatives who recommend approval or disapproval of proposed changes to, deviations from, and waivers to a configuration item's current approved configuration documentation",Adm,,
-Change Control Board Chair,"The person responsible for CCB administration and implementation of approved changes to the project technical, cost, and schedule baselines; the CCB Chair is also the Systems Engineering Manager (SEM)",Adm,,
-CCP,\gls{Change Control Process},Adm,,
-Change Control Process,"collection of formal documented procedures used to apply technical and administrative direction and monitoring processes to the Project. Proposed changes to items under change control must undergo impact analysis to assess their effect(s) on project cost, schedule and performance capabilities. All changes to items under change control must be approved by the Project Manager, or if certain thresholds apply, by the LSST Director and/or the NSF. See LPM-19.",Adm,,
-Change Controlled Documents,Those documents which have been designated by the project as under formal configuration control,Adm,,
-LSST Change Request,"document that proposes a change to a configuration item; after evaluation by the CCB and decision by the Project Manager, the change request is updated with the outcome, action items, and necessary notification",Adm,,
-Chief Scientist,The principal scientific advisor  to the LSST Director; he or she acts as an interface to the science community in order to ensure that the LSST program is scientifically and technologically well founded and that the specifications are appropriate for achieving the scientific goals of the project.,Adm,,
-COBRA,The trade name for an integrated suite of project management software programs that work together to track all aspects of an ongoing construction job,Adm,,
-Commissioning,"A two-year phase at the end of the Construction project during which a technical team a) integrates the various technical components of the three subsystems; b) shows their compliance with ICDs and system-level requirements as detailed in the LSST Observatory System Specifications document (OSS, LSE-30); and c) performs science verification to show compliance with the survey performance specifications as detailed in the LSST Science Requirements Document (SRD, LPM-17).",Adm,,
-Compliance,"Adherence to the laws, regulations, award terms and conditions, specifications, and internal policies applicable to the LSST Project",Adm,,
-CQA,\gls{Compliance and Quality Administrator},,,
-Compliance and Quality Administrator,"The person who directs activities designed to ensure the LSST Project's compliance with all applicable laws, regulations and internal policies. The CQA reports directly to the LSST Project Manager. However, if appropriate and applicable, s/he also may directly report significant compliance issues and matters to the LSST Director and the NSF.",Adm,,
-Configuration Item,"Any component of the LSST system, such as requirements, specifications, designs, characteristics, and/or documents describing the aforementioned, that has reached a baseline point and is under change control",Adm,,
-Construction,"The period during which LSST observatory facilities, components, hardware, and software are built, tested, integrated, and commissioned. Construction follows design and development and precedes operations. The LSST construction phase is funded through the \gls{NSF} \gls{MREFC} account.",Adm,,
-Contingency,"The project's overall reserves in excess of the documented baselines for budget, schedule, and technical scope. Held in order to accommodate unexpected events or circumstances that represent potential risk to the project.",Adm,,
-Contingency Management,"The formal process that provides the ability and flexibility to solve unforeseen issues that may impact the project's budget, schedule, and technical performance. The process incorporates activity-based uncertainties and high impact event-based uncertainties.",Adm,,
-Contract,"A binding legal agreement between parties obligating the one (typically the  'seller') to furnish certain supplies or services and the other (typically, the buyer) to compensate the seller for the supplies or services with some form of consideration, (typically money). The term, 'contract' is used interchangeably with 'sub-award' 'agreement' 'memorandum of understanding and/or agreement' and 'purchase order' Each is a term used to differentiate between a purchase-order-format type document and a complex purchase in a subcontract/sub-award-format type document. These also include awards and notices of awards; job orders or task letters issued under basic ordering agreements; letter contracts; orders, such as purchase orders and subcontracts under which the order becomes effective by written acceptance or performance; and bilateral contract modifications.",Adm,,
-Cost Estimate,"An approximation of total costs required for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed",Adm,,
-Department of Energy,"cabinet department of the United States federal government; the DOE has assumed technical and financial responsibility for providing the LSST camera. The DOE's responsibilities are executed by a collaboration led by SLAC National Accelerator Laboratory.",Adm,,DOE
-Deputy Director,"The person who supports the Director in the execution of the overall LSST project and assumes his or her duties and authority during any short term or extended absence, planned or unplanned",Adm,,
-Descope,A strategic downward revision to project objectives,Adm,,
-Director,"The person responsible for the overall conduct of the project; the LSST director is charged with ensuring that both the scientific goals and management constraints on the project are met. S/he is the principal public spokesperson for the project in all matters and represents the project to the scientific community, AURA, the member institutions of LSSTC, and the funding agencies.",Adm,,
-Document,Any object (in any application supported by DocuShare or design archives such as PDMWorks or GIT) that supports project management or records milestones and deliverables of the LSST Project,Adm,,
-Document Specialist,The person responsible for maintaining the Project's document archive (DocuShare) as well as providing editing and technical writing services. He or she also coordinates administrative support to the Project Management Office and the distributed Project team.,Adm,,
-DocuShare,The trade name for the enterprise management software used by LSST to archive and manage documents,Adm,,
-Earned Value,A measurement of how much work has been completed compared to how much was expected to have been completed at a given point in the project,Adm,,
-EVM,"Earned Value Management,  project management technique for objectively measuring project performance and progress in terms of budget and schedule",Adm,,
-EVMS,"Earned Value Management System, suite of tools used to perform earned value management",Adm,,
-Encumbrances,"A contingent liability, contract, purchase order, payroll commitment, tax payable, or legal penalty that is chargeable to an account; it ceases to be an encumbrance when paid out or when the actual liability amount is determined and recorded as an expense",Adm,,
-Escalation,Change in the cost or price of specific goods and services in a given economy over a period,Adm,,
-FTE,"Full-Time Equivalent, unit equivalent to one person working full time for one year with normal holidays, vacations, and sick time. No paid overtime is assumed.",Adm,,
-Handle,The unique identifier assigned to a document uploaded to DocuShare,Adm,,
-Head of Safety,See Safety Manager,Adm,,
-Incident,"An undesired event, which under slightly different circumstances, could have resulted in harm to people, damage to property, or loss to process.",Adm,,
-ITSC,"Information Technology Services Committee , internal LSST Project Office committee charged with managing project IT services, including advising management on which services LSST should use. The ITSC's goals are 1) to ensure interoperability exists among products, 2) to combine, reuse and/or, recycle existing services when possible, 3) to prevent applications from becoming stagnant or security hazards, 4) to make recommendations on whether a particular tool remains 5) to keep the project informed of what is going on at all spectrums, and 6) to make recommendations for how the Project Office will transition into commissioning and operations.",Adm,,
-Information Technology Systems Administrator,"The person responsible for maintaining the Project Office's servers, networks, and computing hardware; he or she also provides technical support to the Project Management Office and the distributed Project team.",Adm,,
-Institutional Member,"An organization such as an institute, observatory, university, or company committed to making an intellectual, financial, or other significant contribution to LSST operations or to preparing the scientific community to use the LSST dataset. They are members of the LSST Corporation and pay an annual membership fee in an amount established by the LSSTC Board of Directors.",Adm,,
-IPS,"Integrated Project Schedule, complete picture of the entire project life cycle. By incorporating all project phases into the same model, the IPS allows the project team to plan the critical interfaces not only among project work elements but also among the design, construction, commissioning, and operations phases.",Adm,,
-ICD,"Interface Control Document, describes, defines, and controls the interface(s) of a system, thereby bounding its requirements. The description includes the inputs and outputs of a single system or element. An ICD may also describe the interface between two systems or subsystems. The purpose of the ICD is to communicate all possible inputs to and all potential outputs from a system for some potential or actual user of the system in operations. The internal interfaces of a system or subsystem are typically not documented in an ICD, but rather in a system design document.",Adm,,
-ISD,"Interface Support Document,  constrains an \gls{ICD} through such things as dictionaries, protocols, or definitions of system-wide architectural frameworks by which the subsystem teams must abide. However, ISDs do NOT contain requirements. ISDs are written by the subsystem teams with a stake in the subject matter; they are change controlled documents.",Adm,,
-International Affiliate,"An organization outside of the United States or Chile such as an institute, university, consortium, or government agency that has agreed to share in the annual operating costs of the LSST in exchange for data rights for a specified list of principal investigators during LSST operations and commissioning. These data rights may include access to specified project resources prior to operations. Rights also come with responsibilities, similar to those required of U.S.-based scientists, regarding unauthorized redistribution of data.",Adm,,
-JOG,\gls{Joint Oversight Group},Adm,,
-Joint Oversight Group,"oversight body comprised of representatives from the \gls{NSF} and \gls{DOE}; the JOG meets regularly with LSST senior management to coordinate the Project's activities",Adm,,
-LSSTC,"\gls{LSST} Corporation. an Arizona 501(c)3 not-for-profit corporation formed in 2003 for the purpose of designing, constructing, and operating the LSST System. During design and development, the Corporation stewarded private funding used for such essential contributions as early site preparation, mirror construction, and early data management system development. During construction, LSSTC will secure private operations funding from international affiliates and play a key role in preparing the scientific community to use the LSST dataset.",Adm,,
-PMO,\gls{Project Management Office},Adm,,
-Project Management Office,"the work element responsible for achieving the project's objectives",Adm,,
-LSSTPO,"\gls{LSST} Project Office,  official name of the stand-alone AURA operating center responsible for execution of the LSST construction project under the NSF \gls{MREFC} account.",Adm,,
-Major Research Equipment and Facility Construction,"the NSF account through which large facilities construction projects such as LSST are funded",Adm,,
-Manifest,Various files (and file formats) which define sets of build products having some shared attribute. There are release manifests which enumerate the eups-tags of all eups build products a the validated suite.,Adm,,
-National Science Foundation,"primary federal agency supporting research in all fields of fundamental science and engineering; NSF selects and funds projects through competitive, merit-based review",Adm,,
-Offer,"A response to a solicitation that, if accepted, would bind the offeror to perform the work described in resultant contract. Responses to sealed bidding are offers that are often referred to as 'bids' or 'sealed bids;' responses to a request for proposals (RFP, negotiated-type procurements) are offers often referred to as 'proposals' responses to a request for quotations (RFQ) are not offers and are generally called 'quotes'",Adm,,
-Operations,The 10-year period following construction and commissioning during which the LSST Observatory conducts its survey,Adm,,
-Opportunity,"The degree of exposure to an event that might happen to the benefit of a program, project, or other activity. It is described by a combination of the probability that the opportunity event will occur and the consequence of the extent of gain from the occurrence, or impact. There are two levels of opportunities. At the macro level, a project itself is the manifestation of the pursuit of an opportunity. At the element level, tactical opportunities exist, whereby certain events, if realized, provide a cost or schedule savings to the project or increase technical performance.",Adm,,
-Opportunity Management,"The proactive art and science of planning, assessing, and handling future events to seek favorable impacts on project, cost, schedule, or performance to the extent possible.  Opportunity management is a structured, formal, and disciplined activity focused on the necessary steps and planning actions to determine and exploit opportunities to the extent possible.",Adm,,
-Policy file,A structured ASCII file that contains set of attributes for input to a pipeline. Deprecated.,Adm,,
-Preferred Version,"The default version of a document served to a DocuShare user. For change controlled documents, the preferred version represents the document's current, approved baseline. For other documents, the preferred version represents the most current iteration.",Adm,,
-Primavera,The trade name for the project management software suite used by LSST to maintain its program plan and schedule,Adm,,
-Procurement,"The activities involved with or the actual purchase, subcontract, lease, rent, or otherwise acquire supplies or services, and actions associated therewith",Adm,,
-PEP,\gls{Project Execution Plan},Adm,,
-Project Execution Plan,"primary document defining how the LSST Project will be undertaken; it details the project's scope, activities, quality and technical specifications, resources, schedule, and organization",Adm,,
-Project Management Controls Specialist,The person responsible for maintaining the Project Management Control System (PCMS); he or she works closely with the Project Manager and each of the Subsystem Managers.,Adm,,
-Project Management Controls System,"suite of tools used to organize and manage a project, including cost and schedule databases, a qualified accounting system, and change control",Adm,,
-Project Manager,"The person responsible for exercising leadership and oversight over the entire LSST project; he or she controls schedule, budget, and all contingency funds",Adm,,
-Project Science Team,"an operational unit within LSST that carries out specific scientific performance investigations as prioritized by the Director, the Project Manager, and the Project Scientist. Its membership includes key scientists on the Project who provide specific necessary expertise. The Project Science Team provides required scientific input on critical technical decisions as the project construction proceeds",Adm,,
-Project Scientist,The principal scientific advisor  to the LSST Project Manager to ensure that LSST system specifications are appropriate for achieving the scientific goals of the project; the Project Scientist also works closely with the Systems Engineering group and chairs the LSST Science Council,Adm,,
-Release,"Publication of a new iteration of an existing document following approval of changes through the change control process. Upon release, the new iteration becomes the current baseline and the preferred version in the archive.",Adm,,
-Requirement,"A declaration of a specified function or quantitative performance that the delivered system or subsystem must meet.  It is a statement that identifies a necessary attribute, capability, characteristic, or quality of a system in order for the delivered system or subsystem to meet a derived or higher requirement, constraint, or function.",Adm,,
-Retarget,"In the context of task construction, a task may substitute a class sub-task to change the behavior of a particular step in the processing.",Adm,,
-Review,"Programmatic and/or technical audits of a given component of the project, where a preferably independent committee advises further project decisions, based on the current status and their evaluation of it. The reviews assess technical performance and maturity, as well as the compliance of the design and end product with the stated requirements and interfaces.",Adm,,
-Review Committee,"A panel of independent reviewers performing a programmatic and/or technical audit of a given component of the project; committees consist of subject matter experts external to the reviewed team and preferably external to the LSST project. The committee submits a post-review report including findings (observations), comments (concerns), and recommendations (requests for action)",Adm,,
-Review Data Package,"The set of documents and data to be made available to Review Committee members during a review of a project component; the package has two parts: management data and product data. Management data includes appropriately mature and detailed versions of management plans, budgets and/or cost estimates, schedule, and procurement plans. Product data includes appropriately mature and detailed versions of the product technical documentation such as requirements, ICDs, models and analysis reports, and integration and verification plans.",Adm,,
-Review Decision Making Authority,"The person responsible for a project component who calls a review and consequently makes programmatic and/or technical decisions based on the Review Committee's findings, comments, and recommendations",Adm,,
-Review Hub,An LSST website that acts as a clearinghouse for information about external reviews of all LSST components planned to occur in the next six months. The site links to review-specific websites for both planned reviews and reviews that have been conducted already.,Adm,,
-Review Plan,"An enumeration of the necessary components for a proposed review of a project component; the review plan defines the Review Committee chair and members, the charge to the Review Committee, the Review Data Package, and the expected/required participants, including key team members presenting review material.",Adm,,
-Risk,"The degree of exposure to an event that might happen to the detriment of a program, project, or other activity. It is described by a combination of the probability that the risk event will occur and the consequence of the extent of loss from the occurrence, or impact. Risk is an inherent part of all activities, whether the activity is simple and small, or large and complex.",Adm,,
-Risk Management,"The art and science of planning, assessing, and handling future events to avoid unfavorable impacts on project cost, schedule, or performance to the extent possible. Risk management is a structured, formal, and disciplined activity focused on the necessary steps and planning actions to determine and control risks to an acceptable level. Risk Management is an event-based management approach to managing uncertainty.",Adm,,
-"Risk, Cost","The possibility that available budget will be exceeded. Cost risk exists if a) the project must devote more resources than planned to achieve technical requirements, b) the project must add resources to support slipped schedules due to any reason, c) if changes must be made to the number of items to be produced, or d) if changes occur in the organization or national economy. Cost risk can be predicted at the total project level or for a system element. The collective effects of element-level cost risk can produce cost risk for the total project.",Adm,,
-"Risk, Programmatic","Produced by events that are beyond the control of the project manager. These events often are produced by decisions made by personnel at higher levels of authority, such as reductions in project priority, delays in receiving authorization to proceed with a project, reduced or delayed funding, changes in organization or national objectives, etc. Programmatic risk can be a source of risk in any of the other three risk categories.",Adm,,
-"Risk, Schedule","The possibility that the project will fail to meet scheduled milestones. Schedule risk exists if there is inadequate allowance for acquisition delays or if difficulty is experienced in achieving scheduled technical accomplishments, such as the development of software. Schedule risk can be incurred at the total project level for milestones such as deployment of the first system element. The cascading effects of element-level schedule risks can produce schedule risk for the total project.",Adm,,
-"Risk, Technical","The possibility that a technical requirement of the system may not be achieved in the system life cycle. Technical risk exists if the system may fail to achieve performance requirements; to meet operability, producibility, testability, or integration requirements; or to meet environmental protection requirements. A potential failure to meet any requirement that can be expressed in technical terms is a source of technical risk.",Adm,,
-Safety,The control of accidental loss.,Adm,,
-Safety Council,A consulting body providing policy advice and evaluation of safety program effectiveness; the council is composed of independent safety professionals and representatives of LSST institutional members,Adm,,
-Safety Manager,"The person who manages, executes, and verifies compliance with the LSST Safety Policy (LPM-18); the Safety Manager is also chair of the Safety Council",Adm,,
-SHE,"Safety, Health, and Environmental",,,
-SHE Plans,"\gls{SHE} plans are site-specific guidelines for safe working conditions. LSST expects that each collaborating organization and contractor has established safety programs to govern the specific activities at that location. LSST has a minimum expectation for the criteria established in these plans and expects all staff, permanent to the location or visiting, to follow these local procedures. When LSST specific sites are established the project will issue specific SHE plans for those locations.",Adm,,
-SAC,"Science Advisory Committee, advisory body, providing a formal and two-way connection to the external science community served by LSST; comprised of scientists familiar with but external to the LSST Project, the SAC advises the LSST Director on both policy questions and technical topics of interest to the Project and the science community.",Adm,,
-Science Collaboration,"An autonomous body of scientists interested in a particular area of science enabled by the LSST dataset, which through precursor studies, simulations, and algorithm development lays the groundwork for the large-scale science projects the LSST will enable.  In addition to preparing their members to take full advantage of LSST early in its operations phase, the science collaborations have helped to define the system's science requirements, refine and promote the science case, and quality check design and development work.",Adm,,
-Science Collaboration Chair,The leader of and spokesperson for a Science Collaboration,Adm,,
-Scope,"The work needed to be accomplished in order to deliver the product, service, or result with the specified features and functions",Adm,,
-Signature Authority,The individual designated by the LSSTC policy as authorized to approve the use of funds from a specific account; he or she must approve each Purchase Requisition for the account listed on the Purchase Requisition,Adm,,
-Site Manager,"The LSST-delegated representative at the Cerro Pachón, Chile Summit site who is authorized to approve and accept work, provide technical liaison, monitor safety, and interpret LSST plans and specifications on behalf of AURA/LSST",Adm,,
-SLAC,"SLAC National Accelerator Laboratory,  national laboratory funded by the US Department of Energy (DOE); SLAC leads a consortium of DOE laboratories that has assumed responsibility for providing the LSST camera. Although the Camera project manages its own schedule and budget, including contingency, the Camera team's schedule and requirements are integrated with the larger Project.  The camera effort is accountable to the LSSTPO.",Adm,,
-Sole Source,"A purchase of a commodity or a service that is noncompetitive in price, specifications, or use; or is 'only source' and must be accompanied by a sole source justification",Adm,,
-Sole Source Justification,A document accompanying a Purchase Requisition that provides the justification(s) for procuring the items must be from the single vendor listed on the Purchase Requisition,Adm,,
-Speakers Bureau,"A volunteer body promoting LSST's visibility by identifying, initiating, and coordinating opportunities for LSST-related talks, especially at large conferences",Adm,,
-Speakers Bureau Website,"An LSST website used by the LPO as a tool for screening and approving participation of LSST project personnel at various externally hosted meetings; the site also provides a mechanism for the Speakers Bureau to accept speaker requests, coordinate speakers, and maintain a record of requests received and talks given.  With this tool the Director and Project Manager can review and approve/deny requests for LSST financial support for travel before such meetings occur.  Project personnel use the site to report their intended participation in a meeting even if they are requesting neither a speaker nor LSST funding.",Adm,,
-Specification,One or more performance parameter(s) being established by a requirement that the delivered system or subsystem must meet,Adm,,
-stack,"a grouping, usually in layers (hence stack), of software packages and services to achieve a common goal. Often providing a higher level set of end user oriented services and tools",DM,,
-stack,A record of all versions of a document uploaded to a particular DocuShare handle,Adm,,
-Stop Work Authority,"The authority of any individual to stop work if unanticipated/unsafe conditions are identified or non-compliant practices are observed at the site. Workers shall be instructed stop the work immediately and notify their supervisor(s), safety and health representative(s), and the LSST site manager of this action. Disagreements or differences of opinion about the need to terminate an activity shall occur only after the activity is stopped and people are removed from the hazard. All workers at the site have the authority to stop work. Work may not proceed until the circumstances are investigated and deficiencies corrected.",Adm,,
-Subcontract,An agreement under which another entity will perform part or all of the project's contract obligations,Adm,,
-Subsystem,A set of elements comprising a system within the larger LSST system that is responsible for a key technical deliverable of the project.,Adm,,
-SSM,\gls{Subsystem Manager},Adm,,
-Subsystem Manager,"responsible manager for an LSST subsystem; he or she exercises authority, within prescribed limits and under scrutiny of the Project Manager, over the relevant subsystem's cost, schedule, and work plans",Adm,,
-Subsystem Scientist,The principal science advisor  to a Subsystem Manager; he or she ensures that the subsystem specifications are appropriated for achieving the project's goals,Adm,,
-Subsystem Systems Engineer,A subsystem team member who works closely with the Subsystem Manager and the project Systems Engineering group on internal integration of the subsystem's component parts and the subsystem's integration with the larger LSST system,Adm,,
-Summit,"The site on the Cerro Pachón, Chile mountaintop where the LSST observatory, support facilities, and infrastructure will be built.",Adm,,
-Systems Engineer,A member of the Systems Engineering group who works closely with the Systems Engineering Manager and the Systems Scientist on the integrated LSST system's various technical issues spanning the full life cycle of the entire project,Adm,,
-SEM,\gls{Systems Engineering Manager},Adm,,
-Systems Engineering Manager,"individual responsible for the oversight and coordination of the LSST systems engineering efforts as well as the management of the Systems Engineering group and work package. The SEM is also the CCB Chair and as such is responsible for the execution, technical oversight, and coordination of configuration control activities.",Adm,,
-Systems Scientist,A member of the Systems Engineering group and chief liaison to all project scientists; the Systems Scientist works closely with the Systems Engineering Manager and is responsible for the flow-down of science requirements. The Systems Scientist ensures that acceptance testing and commissioning address the science requirements.,Adm,,
-Technical Baseline Classified Index (LSE-90),"An index linking to the various requirements documents, specifications documents, ICDs, design documents, budgets and allocations, and \gls{WBS} dictionaries defining the current baseline of the LSST project's technical scope",Adm,,
-Telescope and Site,"The LSST subsystem responsible for design and construction of the telescope structure, telescope mirrors, optical wavefront measurement and control system, telescope and observatory control systems software, and the summit and base facilities. The Telescope technical team is hosted by NOAO.",Adm,,
-Then-Year Cost,An extrapolation from the base year cost of a project element out to the year the cost actually will be incurred that accounts for escalation rates.,Adm,,
-Travel Administrator,The person responsible ensuring compliance with the LSST Travel Policy. S/he makes all travel arrangements for all individuals whose travel is paid by LSST. S/he also reviews all Travel Expense Reports (TER) to vet claimed expenses as allowable before submitting them for approval by the LSST Business Manager.,Adm,,
-Validation,"A process of confirming that the delivered system will provide its desired functionality; overall, a validation process includes the evaluation, integration, and test activities carried out at the system level to ensure that the final developed system satisfies the intent and performance of that system in operations",Adm,,
-Verification,"The process of evaluating the design, including hardware and software - to ensure the requirements have been met;  verification (of requirements) is performed by test, analysis, inspection, and/or demonstration",Adm,,
-Work Breakdown Structure,"a tool that defines and organizes the LSST project's total work scope through the enumeration and grouping of the project's discrete work elements",Adm,,
-Work Elements,The critical tasks of the LSST Project as represented in the WBS,Adm,,
-Constraint,An external limitation imposed on a delivered item under which it must meet its requirements (e.g. the survey performance must be met under the constraint of the historical weather pattern of the chosen site).  A constraint is not a characteristic possessed by the system or subsystem itself.,Adm TS Cam DM SE,,
-MJD,"The Modified Julian Day is shorthand for the Julian Day: MJD = JD - 2400000.5, which makes MJD=0 correspond to UT midnight in 1858-Nov-17. The half-day offset from JD aligns the start of the day with modern civil timekeeping.",Adm TS Cam DM SE Sci,,
-Amplifier,"An electronic component of a CCD that is used to recover the signal during read-out. For LSST, multiple amplifiers on each CCD will enable simultaneous read-out of adjacent regions of each detector. Often this term is used, not quite correctly, as a synonym for a read-out channel.",Cam,,
-Camcol,"In the SDSS survey, a camera column is the range (in declination) covered by a single sensor in the camera.",Cam,,
-Camera,"The LSST subsystem responsible for the 3.2-gigapixel LSST camera, which will take more than 800 panoramic images of the sky every night. SLAC leads a consortium of Department of Energy laboratories to design and build the camera sensors, optics, electronics, cryostat, filters and filter exchange mechanism, and camera control system.",Cam,,
-Channel,"An amplifier on an LSST camera CCD (see sensor). For LSST there are 16 amplifiers for each science sensor, resulting in 16 parallel data channels from each device. The 16 channels comprising a sensor are numbered from ""0,0"" through '1,7'.  This term may also refer to the raw data from a read-out amplifier of a sensor.",Cam,,
-Filter,"A filter in astronomy is an optical element used to restrict the passband of light reaching the focal plane, it transmits a selected range of wavelengths. Filters elements are often named after standard photometric passbands, such as those used in the SDSS survey: u, g, r, i, z.",Cam,,
-Focal plane array,"A focal plane array (\gls{FPA}) is the arrangement of multiple sensors in the focal plane of a camera. For LSST, the FPA is divided into an array of contiguous rafts, upon which 9 science sensors are mounted 3x3. Additional engineering sensors are mounted on rafts near the periphery to support wavefront sensing and telescope guiding.",Cam,,
-Overscan,"Refers to the portion of the channel read-out of either a) non photo-active pixels, or b) additional read-out of the serial register after all science pixels have been accumulated (sometimes called virtual overscan). The overscan is often appended to the science pixels in the assembled amplifier image as a separate region. This region is useful to science processing software for estimating the stability of the DC offset in the read-out electronics.",Cam,,
-Raft,"The sensors in the LSST camera are packaged into replaceable electronic assemblies, called rafts, consisting of 9 butted sensors (CCDs) in a 3x3 mosaic. Each raft is a replaceable unit in the LSST camera. There are 21 science rafts in the camera plus 4 additional corner rafts with specialized, non-science sensors, making for a total of 189 CCDs per focal plane image. The 21 science rafts are numbered from ""0,1"" through ""0,3"", ""1,0"" through ""3,4"", and ""4,1"" through ""4,3"". (In other words, the 25 combinations from ""0,0"" through ""4,4"" minus the four corners which are non-science.)",Cam,,
-Sensor,"A sensor is a generic term for a light-sensitive detector, such as a CCD. For LSST, sensors consist of a 2-D array of roughly 4K x 4K pixels, which are mounted on a raft in a 3x3 mosaic. Each sensor is divided into 16 channels or amplifiers. The 9 sensors that make up a raft are numbered from ""0,0"" through ""2,2"".",Cam,,
-Charge-Coupled Device,"a particular kind of solid-state sensor for detecting optical-band photons. It is composed of a 2-D array of pixels, and one or more read-out amplifiers.",Cam Sci,,
-afw,LSST's pipeline library code and primitives including images and tables.,DM,https://github.com/lsst/afw,
-Alert,"A packet of information for each source detected with signal-to-noise ratio > 5 in a difference image during Prompt Processing, containing measurement and characterization parameters based on the past 12 months of LSST observations plus small cutouts of the single-visit, template, and difference images, distributed via the internet.",DM,LSE-163,
-Alert Production,"The principal component of Prompt Processing that processes and calibrates incoming images, performs Difference Image Analysis to identify DIASources and DIAObjects, packages and distributes the resulting Alerts, and runs the Moving Object Processing System.",DM,LDM-151,AP
-Alternative Standard Visit,A single observation of an LSST field comprised of one 30 second exposure.,DM,,
-aperture correction,"A correction that is applied to fluxes of sources that were measured within a finite aperture, to account for the source flux that lies outside the aperture. This correction is usually based upon a model of the PSF as derived from bright, isolated stars. From the model one can derive the magnitude of the correction with aperture size and its variation with position in the image, which asymptotically approaches 1.0 at infinite aperture. Fluxes of sources in crowded fields are often measured with small apertures to avoid contamination, and then corrected with this approach.",DM,LDM-151,
-Archive Center,"Part of the LSST Data Management System, the LSST archive center is a data center at NCSA that hosts the LSST Archive, which includes released science data and metadata, observatory and engineering data, and supporting software such as the LSST Software Stack.",DM,,
-Association Pipeline,"An application that matches detected Sources or DIASources or generated Objects to an existing catalog of Objects, producing a (possibly many-to-many) set of associations and a list of unassociated inputs. Association Pipelines are used in Prompt Processing after DIASource generation and in the final stages of Data Release processing to ensure continuity of Object identifiers.",DM,LDM-151,
-background,"In an image, the background consists of contributions from the sky (e.g., clouds or scattered moonlight), and from the telescope and camera optics, which must be distinguished from the astrophysical background. The sky and instrumental backgrounds are characterized and removed by the LSST processing software using a low-order spatial function whose coefficients are recorded in the image metadata.",DM,,
-Base Facility,"The data center located at the Base Site in La Serena, Chile. The Base Facility is composed of the Base portion of the Prompt Enclave directly supporting Observatory operations, the Commissioning Cluster, an Archive Enclave holding data products, and the Chilean Data Access Center.",DM,LDM-148,
-Batch Production,"Computational processing that is executed as inputs become available, in a distributed way across multiple enclaves when needed, while tracking status and outputs. Examples of Batch Production include offline processing for Prompt data products, calibration products, template images, and Special Programs data products. Prioritization protocols for the various types of batch production are given in LDM-148.",DM,LDM-148,
-brighter-fatter effect,The common term used to refer to one of the photometric qualities of the LSST camera: sources with a higher flux have a broader PSF. This is accounted for during calibration.,DM,"LDM-151, https://arxiv.org/pdf/1402.0725v1.pdf",
-Broker,"Software which receives and redistributes Alerts, and may also perform processing such as filtering for certain characteristics, cross-matching with non-LSST catalogs, and/or light-curve classification, in order to identify and prioritize targets for follow-up and/or make scientific analyses. ",DM,LDM-612,
-Butler,"A middleware component for persisting and retrieving image datasets (raw or processed), calibration reference data, and catalogs.",DM,"LDM-152, https://ldm-463.lsst.io/v/draft/index.html#id1",
-CalExp,"A particular type of Butler dataset that consists of an image corresponding to a single CCD, which has been characterized and calibrated. (A Butler term.)",DM,LDM-151,Calexp
-Calibrated Science Image,Deprecated term; see Processed Visit Image.,DM,,"CSI, Processed Visit Image, PVI"
-calibration,"The process of translating signals produced by a measuring instrument such as a telescope and camera into physical units such as flux, which are used for scientific analysis. Calibration removes most of the contributions to the signal from environmental and instrumental factors, such that only the astronomical component remains.",DM,LDM-151,
-Calibration Image,"Any of a set of images used in the Instrument Signature Removal pipeline to remove distortions caused by the telescope, detector, or other sources, from the raw images. Includes darks, flats, tunable-laser dome flats, etc.",DM,LDM-151,
-Calibration Scientist,"The person responsible for the system calibration plan who establishes the requirements for the constituent elements of the calibration hardware, software, and operational data. The Calibration Scientist works under the direction of the Systems Engineering group.",DM,,
-Camera Crosstalk-Corrected Image,An image from the Camera system that has had crosstalk removed but has not been processed by the Instrument Signature Removal pipeline.,DM,,"C3 Image, Raw Image"
-Chi-squared Coadd Image,"A Coadd Image that is the weighted sum of multiple input images, where for each input:
+"Term","Description","Subsystem Tags","Documentation Tags","Associated Acronyms and Alternative Terms"
+"1D","One-dimensional","Gen","",""
+"2D","Two-dimensional","Gen","",""
+"2MASS","Two-Micron All Sky Survey","Gen","",""
+"3D","Three-dimensional","Gen","",""
+"A/D","Analogue-to-Digital (converter)","Gen","",""
+"AAS","American Astronomical Society","Gen","",""
+"ABI","Application Binary Interface","Gen","",""
+"AC","Alternating Current","Gen","",""
+"ACWP","Actual Cost of Work Performed","Gen","",""
+"ADASS","Astronomical Data Analysis Software and Systems","Gen","",""
+"ADC","Analogue-to-Digital Converter","Gen","",""
+"ADQL","Astronomical Data Query Language","Gen","",""
+"ADU","Analogue-to-Digital Unit","Gen","",""
+"AIT","Assembly Integration and Test","Gen","",""
+"AIV","Assembly Integration and Verification","Gen","",""
+"ALMA","Atacama Large Millimeter Array (ESO)","Gen","",""
+"AMCL","\gls{AURA Management Council for LSST}","LSST","",""
+"AWS","Amazon Web Services","Gen","",""
+"AOB","Any Other Business","Gen","",""
+"API","Application Programming Interface","Gen","",""
+"arcmin","arcminute minute of arc (unit of angle)","Gen","",""
+"arcsec","arcsecond second of arc (unit of angle)","Gen","",""
+"ASAP","As Soon As Possible","Gen","",""
+"ASCII","American Standard Code for Information Interchange","Gen","",""
+"au","astronomical unit","Gen","",""
+"AU","deprecated acronym for astronomical unit; use au instead","Gen","",""
+"AURA","\gls{Association of Universities for Research in Astronomy}","Gen","",""
+"b","bit","Gen","",""
+"B","Byte (8 bit)","Gen","",""
+"BAC","Budget At Complete","Gen","",""
+"BCWP","Budgeted Cost of Work Performed","Gen","",""
+"BCWS","Budgeted Cost of Work Scheduled","Gen","",""
+"BDC"," Base Data Center"," DM IT","",""
+"BNF","Backus-Naur Form","Gen","",""
+"BOE","\gls{Basis of Estimate}","Gen","",""
+"BPS","Batch Production Service","LDF DM","",""
+"bps","bit(s) per second","Gen","",""
+"Bps","Bytes per second","Gen","",""
+"CADC","Canadian Astronomy Data Centre","Gen","",""
+"CAOM","Common Archive Observation Model","DM Gen","",""
+"CAM","Control (or Cost) Account Manager","Gen","",""
+"CC","Change Control","Gen","",""
+"CCD","\gls{Charge-Coupled Device}","Gen","",""
+"CDS","Centre de Donnes astronomiques de Strasbourg","Gen","",""
+"CfA","(Harvard-Smithsonian) Center for Astrophysics","Gen","",""
+"CI","Cyber Infrastructure","Petabytes","",""
+"CI","Continuous Integration","Gen","",""
+"COMPASS","Catalogues of Objects and Measured Parameters from All Sky Surveys","Gen","",""
+"CORBA","Common Object Request Broker Architecture","Gen","",""
+"COTS","Commercial-Off-The-Shelf","Gen","",""
+"CPI","Cost Performance Index","Gen","",""
+"CPU","Central Processing Unit","Gen","",""
+"CR","Cosmic Ray","Gen","",""
+"CSV","Comma Separated Values","Gen","",""
+"CTIO","Cerro Tololo Inter-American Observatory","Gen","",""
+"CV","Curriculum Vitae","Gen","",""
+"DB","DataBase","Gen","",""
+"Db","Decibel","Gen","",""
+"DBMS","DataBase Management System","Gen","",""
+"DCR","Differential Chromatic Refraction","Gen","",""
+"DEC","Declination","Gen","",""
+"deg","degree; unit of angle","Gen","",""
+"DIA","Difference Image Analysis","DM","",""
+"DIMM","Differential Image Motion Monitor","Gen","",""
+"DOE","\gls{Department of Energy}","Gen","",""
+"DoF","Degree(s) of Freedom (also known as DOF)","Gen","",""
+"DOM","Document Object Model","Gen","",""
+"DoNM","Date of Next Meeting","Gen","",""
+"DPAC","Data Processing and Analysis Consortium (Gaia)","Gen","",""
+"DS9","Deep Space 9 (specific astronomical data visualisation application; SAOImage)","Gen","",""
+"DWDM","Dense Wave Division Multiplex","Gen","",""
+"EEPROM","Electrically Erasable Programmable Read-Only Memory","Gen","",""
+"ESA","European Space Agency","Gen","",""
+"ESAC","European Space Astronomy Centre","Gen","",""
+"ESNET","Energy Sciences Network","Gen","",""
+"ETC","Estimate To Complete","Gen","",""
+"eV","electron-Volt","Gen","",""
+"EVM","Earned Value Management","Gen","",""
+"EVMS","Earned Value Management System","Gen","",""
+"FAQ","Frequently Asked Question","Gen","",""
+"FFT","Fast Fourier Transform","Gen","",""
+"FGCM"," Forward Global Calibration Model","DM","",""
+"FIFO","First In First Out","Gen","",""
+"FITS","\gls{Flexible Image Transport System}","Gen","",""
+"FIU","Florida International University","Gen","",""
+"FK5","Fifth Fundamental Catalogue","Gen","",""
+"FoM","Figure of Merit","Gen","",""
+"FoV","Field of View (also denoted FOV)","Gen","",""
+"FPA","Focal Plane Array"," LSST","",""
+"FPA","Focal Plane Assembly"," Gaia","",""
+"FPGA","Field-Programmable Gate Array","Gen","",""
+"FS","File System","Gen","",""
+"FTE","Full Time Equivalent","Gen","",""
+"FUSE","a user space filesystem framework","IT","",""
+"FWHM","Full Width at Half-Maximum","Gen","",""
+"GAVO","German Astronomical Virtual Observatory","Gen","",""
+"Gb","Gigabit","Gen","",""
+"GB","Gigabyte","Gen","",""
+"gcc","The GNU Compiler Collection; a C and C++ compiler","Gen","",""
+"GCN","GRB Coordinates Network","Gen","",""
+"GLONASS","GLObal NAvigation Satellite System","Gen","",""
+"GPFS","General Parallel File System (now IBM Spectrum Scale)","Gen","",""
+"GPL","GNU Public License","Gen","",""
+"GPS","Global Positioning System","Gen","",""
+"GRB","Gamma-Ray Burst","Gen","",""
+"GST","Greenwich Sidereal Time","Gen","",""
+"GUI","Graphical User Interface","Gen","",""
+"HEASARC","NASA's Archive of Data on Energetic Phenomena","Gen","",""
+"HEALPix","Hierarchical Equal-Area iso-Latitude Pixelisation","Gen","",""
+"HEP"," High Energy Physics","Gen","",""
+"HIPS","Hierarchical Progressive Survey","Gen","",""
+"HSC","Hyper Suprime-Cam","Gen","",""
+"HST","Hubble Space Telescope","Gen","",""
+"HPC","High Performance Computing","DM","",""
+"HTC","High Throughput Computing","DM","",""
+"HTM","\gls{Hierarchical Triangular Mesh}","Gen","",""
+"HTML","HyperText Markup Language","Gen","",""
+"HTTP","HyperText Transfer Protocol","Gen","",""
+"HW","HardWare","Gen","",""
+"I&T","Integration and Test","Gen","",""
+"IAU","International Astronomical Union","Gen","",""
+"IBM","International Business Machines","Gen","",""
+"IDL","Interactive Data Language","Gen","",""
+"IoA","Institute of Astronomy (Cambridge; also denoted IOA)","Gen","",""
+"IRAF","Image Reduction and Analysis Facility","Hist","",""
+"IPAC","No longer an acronym; science and data center at Caltech","Gen","",""
+"IRSA","Infrared Science Archive","Gen","",""
+"IT","Information Technology","Gen","",""
+"ITIL","Information Technology Infrastructure Library","Gen","",""
+"IVOA","International Virtual-Observatory Alliance","Gen","",""
+"JD","\gls{Julian Date}","Gen","",""
+"JDBC","Java DataBase Connectivity","Gen","",""
+"JHU","Johns Hopkins University","Gen","",""
+"JIRA","issue tracking product (not an acronym but a truncation of Gojira the Japanese name for Godzilla)","Gen","",""
+"JPL","Jet Propulsion Laboratory (DE ephemerides)","Gen","",""
+"JRE","Java Runtime Environment","Gen","",""
+"JSON","JavaScript Object Notation","Gen","",""
+"JVM","Java Virtual Machine","Gen","",""
+"JWST","James Webb Space Telescope (formerly known as NGST)","Gen","",""
+"KBO","Kuiper-Belt Object","Gen","",""
+"kbps","kilobits per second","Gen","",""
+"LAN","Local Area Network","Gen","",""
+"LAPACK","Linear Algebra PACKage","Gen","",""
+"LASER","Light Amplification by Stimulated Emission of Radiation","Gen","",""
+"LaTeX","(Leslie) Lamport TeX (document markup language and document preparation system)","Gen","",""
+"LATISS","LSST Atmospheric Transmission Imager and Slitless Spectrograph","TS"," ",""
+"LCO","Las Cumbres Observatories","Gen","",""
+"LED","Light-Emitting Diode","Gen","",""
+"LHC","Large Hadron Collider (at CERN)","Gen","",""
+"LPGL","Lesser Public GNU general License","Gen","",""
+"LUT","Look-Up Table","Gen","",""
+"MAST","Mikulski Archive for Space Telescopes","Gen","",""
+"Mb","Megabit (1000000 bit)","Gen","",""
+"MB","MegaByte","Gen","",""
+"MBps","Megabits per second","Gen","",""
+"MC","Monte-Carlo (simulation/process)","Gen","",""
+"MCMC","Monte Carlo Markov Chain","Gen","",""
+"MERRA","Modern-Era Retrospective analysis for Research and Applications","NASA","",""
+"MIDAS","Munich Image Data Analysis System (ESO)","Gen","",""
+"MJD","Modified \gls{Julian Date} (to be avoided; see also \gls{JD})","Gen","",""
+"MOC","Multi Ordered Catalogue","VO DM","",""
+"MOSFET","Metal-Oxide Semiconductor Field-Electric Transistor","Gen","",""
+"MPA","Max Planck Institute for Astrophysics","Gen","",""
+"MPP","Massively Parallel Process","DM"," ",""
+"MREFC","\gls{Major Research Equipment and Facility Construction}","Gen","","NSF"
+"MREN","Montenegrin Research and Education Network","Gen","",""
+"MSB","Most Significant Bit","Gen","",""
+"MYDB","My Database, the notion of having a local storage beside the queriable database to store either temporary tables or uploaded catalogs","DM Gen"," ",""
+"NAOJ","National Astronomical Observatory of Japan","Gen","",""
+"NASA","National Aeronautics and Space Administration","Gen","",""
+"NED","NASA/IPAC Extragalactic Database","Gen","",""
+"NCOA","National Center for Optical-Infrared Astronomy","Gen","",""
+"NCSA","National Center for Supercomputing Applications","Gen","",""
+"NEO","Near-Earth Object","Gen","",""
+"NFS","Network File System","Gen","",""
+"NIST","National Institute of Standards and Technology (USA)","Gen","",""
+"NOAO","National Optical Astronomy Observatories (USA)","Gen","",""
+"NSF","\gls{National Science Foundation}","Gen","",""
+"OBS","Organisation Breakdown Structure","Gen","",""
+"OS","Operating System","Gen","",""
+"OSX","Macintosh Operating System (obsolete; now macOS)","Gen","",""
+"Pan-STARRS","Panoramic Survey Telescope and Rapid Response System","Gen","",""
+"Parsl","Parallel Scripting Library \url{http://parsl-project.org/}","DM","",""
+"PB","PetaByte","Gen","",""
+"PCA","Principal Component Analysis","Gen","",""
+"PDF","Portable Document Format","Gen","",""
+"PDF","Probability Density Function","Gen","",""
+"PFS","Prime Focus Spectrograph","Gen","",""
+"PLL","Phase-Locked Loop","Gen","",""
+"POSIX","Portable Operating System Interface","Gen","",""
+"PR","Pull Request","Gen","",""
+"PSF","Point Spread Function","Gen","",""
+"QA","Quality Assurance","Gen","",""
+"QC","Quality Control","Gen","",""
+"Qserv","Proprietary Database built by SLAC for LSST","DM","",""
+"RA","Right Ascension","Gen","",""
+"RAID","Redundant Array of Inexpensive Disks","Gen","",""
+"RAL","Rutherford Appleton Laboratory (UK)","Gen","",""
+"RAM","Random Access Memory","Gen","",""
+"RC","Release Candidate","Gen","",""
+"REUNA","Red Universitaria Nacional","Gen","",""
+"RMS","Root-Mean-Square","Gen","",""
+"ROOT","Object-oriented data analysis framework developed at CERN","Gen","",""
+"RS232C","Standard 25-pin serial connection between computers and modems","Gen","",""
+"SaaS","Software as a Service","Gen","",""
+"SAMP","Simple Application Messaging Protocol","Gen","",""
+"SAO","Smithsonian Astrophysical Observatory","Gen","",""
+"SDSS","\gls{Sloan Digital Sky Survey}","Gen","",""
+"SI","Syst\`eme International (International System of units defined by ISO)","Gen","",""
+"SLA","Service Level Agreement","Gen","",""
+"SOAP","Simple Object Access Protocol","Gen","",""
+"SODA","Server-side Operations for Data Access","Gen","",""
+"SPI","Schedule Performance Index","Gen","",""
+"SPIE","The international society for optics and photonics","Gen","",""
+"SQL","Structured Query Language","Gen","",""
+"SSD","Solid-State Disk","Gen","",""
+"SSH","Secure SHell","Gen","",""
+"stdin","standard input","Gen","",""
+"stdout","standard output","Gen","",""
+"SW","Software (also denoted S/W)","Gen","",""
+"TACC","Texas Advanced Computing Center","Gen","",""
+"TAI","International Atomic Time","Gen","",""
+"TAP","Table Access Protocol","Gen","",""
+"TB","TeraByte","Gen","",""
+"TBA","To Be Announced","Gen","",""
+"TBA","To Be Assigned","Gen","",""
+"TBC","To Be Confirmed","Gen","",""
+"TBD","To Be Defined (Determined)","Gen","",""
+"TBR","To Be Resolved","Gen","",""
+"TCAM","Technical Control (or Cost) Account Manager","DM","",""
+"TFLOP","Tera FLOP","Gen","",""
+"TOPCAT","Tool for OPerations on Catalogues And Tables","Gen","",""
+"TSS","Telescope and Site Software","LSST","",""
+"UCL","University College London (UK)","Gen","",""
+"UDP","User Datagram Protocol","Gen","",""
+"UI","User Interface","Gen","",""
+"US","United States","Gen","",""
+"USNO","United States Naval Observatory","Gen","",""
+"UT","Universal Time","Gen","",""
+"UT1","Universal Time 1","Gen","",""
+"UTC","Coordinated Universal Time","Gen","",""
+"UW","University of Washington","Gen","",""
+"UX","User Experience","Gen","",""
+"VLA","Very Large Array (NRAO)","Gen","",""
+"VLBA","Very Long Baseline Array","Gen","",""
+"VLBI","Very Long Baseline Interferometry","Gen","",""
+"VLT","Very Large Telescope (ESO)","Gen","",""
+"VLTI","Very Large Telescope Interferometer (ESO)","Gen","",""
+"VM","Virtual Machine","Gen","",""
+"VNOC","Virtual Network Operations Center","NET ","",""
+"VO","Virtual Observatory","Gen","",""
+"VOIP","Voice Over Internet Protocol","IT DM","",""
+"WAN","Wide Area Network","Gen","",""
+"WBS","\gls{Work Breakdown Structure}","Gen","",""
+"WCS","\gls{World Coordinate System}","Gen","",""
+"WISE","Wide-field Survey Explorer","Gen","",""
+"WSDL","Web Services Description Language","Gen","",""
+"XHTML","eXtensible HyperText Markup Language","Gen","",""
+"XML","eXtensible Markup Language","Gen","",""
+"XMM","X-ray Multi-mirror Mission (ESA; officially known as XMM-Newton)","Gen","",""
+"XSD","XML Schema Definition","Gen","",""
+"XSL","eXtensible Stylesheet Language","Gen","",""
+"XSLT","eXtensible Stylesheet Language Transformation","Gen","",""
+"YAML","Yet Another Markup Language","Gen","",""
+"AOS","Active Optics System","LSST DM","",""
+"ACCS","Auxiliary Camera Control System","LSST DM","",""
+"AP","Alert Production","LSST DM","",""
+"ATM","Adaptavist Test Management","LSST DM","",""
+"CAM","CAMera","LSST DM","",""
+"CB","Configuration Baseline","LSST DM","",""
+"CCB","\gls{Change Control Board}","LSST DM","",""
+"CCOB","Camera Calibration Optical Bench","LSST DM","",""
+"CM","Configuration Management","LSST DM","",""
+"CMDB","Configuration Management Database","LSST DM","",""
+"CPP","Calibration Production Processing","LSST DM","",""
+"CR","Change Request","LSST DM","",""
+"DAC","\gls{Data Access Center}","LSST DM","",""
+"DAQ","Data Acquisition System","LSST DM","",""
+"DAX","Data Access Services","LSST DM","",""
+"DBB","Data Back Bone","LSST DM","",""
+"DC","Data Center","LSST DM","",""
+"DDMPM","Data Management Deputy Project Manager","LSST DM","",""
+"DM","\gls{Data Management}","LSST DM","",""
+"DMCCB","DM Change Control Board","LSST DM","",""
+"DMCS","Data Management Control System","LSST DM","",""
+"DMIS","DM Interface Scientist","LSST DM","",""
+"DMLT","DM Leadership Team","LSST DM","",""
+"DMO","Data Management Organization","LSST DM","",""
+"DMPM","Data Management Project Manager","LSST DM","",""
+"DMQA","Data Management Quality Assurance","LSST DM","",""
+"DMS","Data Management Subsystem","LSST DM","",""
+"DMSE","Data Management System Engineer","LSST DM","",""
+"DMSR","DM System Requirements; LSE-61","LSST DM","",""
+"DMSS","DM Subsystem Scientist","LSST DM","",""
+"DMSST","DM System Science Team","LSST DM","",""
+"DMTN","DM Technical Note","LSST DM","",""
+"DMTR","DM Test Report","LSST DM","",""
+"DPDD","Data Product Definition Document","LSST DM","",""
+"DR","Data Release","LSST DM","",""
+"DRP","Data Release Production","LSST DM","",""
+"DTN","Data Transfer Node","LSST DM","",""
+"DWDM","Dense Wave Division Multiplex","LSST DM","",""
+"EAC","Estimate At Completion","LSST DM","",""
+"EFD","Engineering Facilities Database","LSST DM","",""
+"EIE","European Industrial Engineering - Italian engineering company (Dome)","LSST DM","",""
+"EPO","Education and Public Outreach","LSST DM","",""
+"ETC","Estimate To Complete","LSST DM","",""
+"ETU","Engineering Test Unit","LSST DM","",""
+"EUPS","Extended Unix Product System","LSST DM","",""
+"FSAAS","Filesystem as a Service"," IT","",""
+"FDR","Final Design Review","LSST DM","",""
+"FLOP","FLoating point Operation","IT","",""
+"ICBS","International Communications and Base Site","LSST DM","",""
+"IS","Interface Scientist","LSST DM","",""
+"ISR","Instrument Signal Removal","LSST DM","",""
+"IT","Integration Test","LSST DM","",""
+"ITC","Information Technology Center","LSST DM","",""
+"JTM","Joint Technical Meeting","LSST DM","",""
+"JSR","Joint Status Review","LSST DM","",""
+"KPM","Key Performance Metric","LSST DM","",""
+"LCR","\gls{LSST Change Request}","LSST DM","",""
+"LDF","LSST Data Facility","LSST DM","",""
+"LDM","LSST Data Management (Document Handle)","LSST DM","",""
+"LOVE","LSST Operations Visualization Environment","LSST DM","",""
+"LPM","LSST Project Management (Document Handle)","LSST DM","",""
+"LSE","LSST Systems Engineering (Document Handle)","LSST DM","",""
+"LSP","LSST Science Platform","LSST DM","",""
+"LSR","LSST System Requirements; LSE-29","LSST DM","",""
+"LSST","Large Synoptic Survey Telescope","LSST DM","",""
+"MOPS","Moving Object Processing System","LSST DM","",""
+"NET","Network Engineering Team","LSST DM","",""
+"OCS","Observatory Control System","LSST DM","",""
+"OODS","Observatory Operations Data Service","DM","",""
+"OPS","Operations","LSST DM","",""
+"OSS","Observatory System Specifications; LSE-30","LSST DM","",""
+"PCW","Project Community Workshop","LSST DM","",""
+"PDAC","Prototype Data Access Center","LSST DM","",""
+"PDR","Preliminary Design Review","LSST DM","",""
+"PDU","Power Distribution Unit","LSST DM","",""
+"PM","Project Manager","LSST DM","",""
+"PMCS","\gls{Project Management Controls System}","LSST DM","",""
+"PMP","(DM) Project Management Plan; LDM-294","LSST DM","",""
+"PS","Project Scientist","LSST DM","",""
+"PST","\gls{Project Science Team}","LSST DM","",""
+"PSTN","Project Science Technical Note","LSST DM","",""
+"Qserv","Proprietary LSST Database system","LSST DM","",""
+"REB","Readout Electronics Board","LSST DM","",""
+"RFC","Request For Comment","LSST DM","",""
+"RM","Release Manager","LSST DM","",""
+"SAC","Science Advisory Committee","LSST DM","",""
+"SEMP","Systems Engineering Management Plan","LSST DM","",""
+"SLAC","No longer an acronym; formerly Stanford Linear Accelerator Center","LSST DM","",""
+"SQuaRE","Science Quality and Reliability Engineering","LSST DM","LDM-204",""
+"SQuaSH","\gls{Science Quality Analysis Harness}","DM","https://squash.lsst.codes/",""
+"SQR","SQuARE document handle","LSST DM","",""
+"SRD","LSST Science Requirements; LPM-17","LSST DM","",""
+"SS","Subsystem Scientist","LSST DM","",""
+"SST","Subsystem Science Team","LSST DM","",""
+"SUI","Science User Interface","LSST DM","",""
+"SUIT","Science User Interface and Tools","LSST DM","",""
+"SV","Science Validation","LSST DM","",""
+"T&S","Telescope and Site","LSST DM","",""
+"T/CAM","Technical/Control (or Cost) Account Manager","LSST DM","",""
+"TCT","Technical Control Team (obsolete; now DMCCB)","LSST DM","",""
+"TS","Test Specification","LSST DM","",""
+"VCD","Verification Control Document","LSST DM","",""
+"WG","Working Group","LSST DM","",""
+"Accident","An undesired event that results in harm to people, damage to property, or loss to process.  Accidents result from contact with a substance or source of energy above the threshold limit of the body structure","Adm","",""
+"Accruals","Accounts on a balance sheet that represent liabilities and non-cash-based assets used in accrual-based accounting; these accounts include, among many others, accounts payable, accounts receivable, goodwill, future tax liability, and future interest expense","Adm","",""
+"Archive","The repository for documents required by the NSF to be kept. These include documents related to design and development, construction, integration, test, and operations of the LSST observatory system. The archive is maintained using the enterprise content management system DocuShare, which is accessible through a link on the project website www.project.lsst.org","Adm","",""
+"Association of Universities for Research in Astronomy"," consortium of US institutions and international affiliates that operates world-class astronomical observatories, AURA is the legal entity responsible for managing what it calls independent operating Centers, including LSST, under respective cooperative agreements with the National Science Foundation. AURA assumes fiducial responsibility for the funds provided through those cooperative agreements. AURA also is the legal owner of the AURA Observatory properties in Chile","Adm","",""
+"AURA Management Council for LSST",",  group reporting to the AURA Board of Directors that oversees the activities of the LSST Project Office and advocates the mission of the LSST","Adm","",""
+"Base Year Cost","The cost of a particular project element as of a year chosen to represent an arbitrary cost level of 100, usually the year the project plan was created or refreshed. New, up-to-date base years are periodically introduced to keep data current","Adm","",""
+"Baseline","The point at which project designs or requirements are considered to be 'frozen' and after which all changes must be traced and approved","Adm","",""
+"Baseline, Cost","The 'frozen' total costs required for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed","Adm","",""
+"Baseline, Design","The baseline defining the site specific preliminary design of the LSST subsystems and their associated hardware and software deliverables required to meet the requirements and definitions of the System Baseline","Adm","",""
+"Baseline, Functional","The baseline defining at the highest level the scientific, functional, and performance requirements for what the LSST Observatory is and what it must do as a whole","Adm","",""
+"Baseline, Schedule","The 'frozen' amount of time required for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed","Adm","",""
+"Baseline, System","The baseline defining the high level set of functional and performance requirements for the LSST system and each of the LSST subsystems (Camera, Telescope and Site, and Data Management), the Observatory Control System, and Education and Public Outreach","Adm","",""
+"Baseline, Technical","The 'frozen' requirements, specifications, designs, and allocations needed for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed","Adm","",""
+"Basis of Estimate","justification for arriving at a particular cost estimate, including estimating methods, approach taken, prices used, assumptions made; an analyzed and carefully calculated number","Adm","",""
+"Builder","Individuals who have accumulated 2 FTE years worth of employment/contributions to the LSST Project","Adm","",""
+"Business Manager","The person responsible for all business activities of the LSST Project and the LSST Corporation; he or she serves as liaison to AURA \gls{CAS}, develops and monitors contracts, and serves as the LSST Corporation Secretary","Adm","",""
+"Buyer","Includes the terms 'Buyer' 'subcontract administrator or officer' 'contracts administrator or officer' sub-award administrator, or any other LSSTC authorized procurement official as used herein are inter-changeable","Adm","",""
+"CASNET","AURA's financial reporting database","Adm","",""
+"Center","An entity managed by AURA that is responsible for execution of a federally funded project","Adm","",""
+"CAS","\gls{Central Administrative Services}","Adm","",""
+"Central Administrative Services","AURA corporate division responsible for providing accounting, procurement, and business IT support services to AURA centers","Adm","",""
+"Change Control","The systematic approach to managing all changes to the LSST system, including technical data and policy documentation. The purpose is to ensure that no unnecessary changes are made, all changes are documented, and resources are used efficiently and appropriately","Adm","",""
+"Change Control Board Chair","The person responsible for CCB administration and implementation of approved changes to the project technical, cost, and schedule baselines; the CCB Chair is also the Systems Engineering Manager (SEM)","Adm","",""
+"CCP","\gls{Change Control Process}","Adm","",""
+"Change Control Process","collection of formal documented procedures used to apply technical and administrative direction and monitoring processes to the Project. Proposed changes to items under change control must undergo impact analysis to assess their effect(s) on project cost, schedule and performance capabilities. All changes to items under change control must be approved by the Project Manager, or if certain thresholds apply, by the LSST Director and/or the NSF. See LPM-19","Adm","",""
+"Change Controlled Documents","Those documents which have been designated by the project as under formal configuration control","Adm","",""
+"LSST Change Request","document that proposes a change to a configuration item; after evaluation by the CCB and decision by the Project Manager, the change request is updated with the outcome, action items, and necessary notification","Adm","",""
+"Chief Scientist","The principal scientific advisor  to the LSST Director; he or she acts as an interface to the science community in order to ensure that the LSST program is scientifically and technologically well founded and that the specifications are appropriate for achieving the scientific goals of the project","Adm","",""
+"COBRA","The trade name for an integrated suite of project management software programs that work together to track all aspects of an ongoing construction job","Adm","",""
+"Commissioning","A two-year phase at the end of the Construction project during which a technical team a) integrates the various technical components of the three subsystems; b) shows their compliance with ICDs and system-level requirements as detailed in the LSST Observatory System Specifications document (OSS, LSE-30); and c) performs science verification to show compliance with the survey performance specifications as detailed in the LSST Science Requirements Document (SRD, LPM-17)","Adm","",""
+"Compliance","Adherence to the laws, regulations, award terms and conditions, specifications, and internal policies applicable to the LSST Project","Adm","",""
+"CQA","\gls{Compliance and Quality Administrator}","","",""
+"Compliance and Quality Administrator","The person who directs activities designed to ensure the LSST Project's compliance with all applicable laws, regulations and internal policies. The CQA reports directly to the LSST Project Manager. However, if appropriate and applicable, s/he also may directly report significant compliance issues and matters to the LSST Director and the NSF","Adm","",""
+"Configuration Item","Any component of the LSST system, such as requirements, specifications, designs, characteristics, and/or documents describing the aforementioned, that has reached a baseline point and is under change control","Adm","",""
+"Construction","The period during which LSST observatory facilities, components, hardware, and software are built, tested, integrated, and commissioned. Construction follows design and development and precedes operations. The LSST construction phase is funded through the \gls{NSF} \gls{MREFC} account","Adm","",""
+"Contingency","The project's overall reserves in excess of the documented baselines for budget, schedule, and technical scope. Held in order to accommodate unexpected events or circumstances that represent potential risk to the project","Adm","",""
+"Contingency Management","The formal process that provides the ability and flexibility to solve unforeseen issues that may impact the project's budget, schedule, and technical performance. The process incorporates activity-based uncertainties and high impact event-based uncertainties","Adm","",""
+"Contract","A binding legal agreement between parties obligating the one (typically the  'seller') to furnish certain supplies or services and the other (typically, the buyer) to compensate the seller for the supplies or services with some form of consideration, (typically money). The term, 'contract' is used interchangeably with 'sub-award' 'agreement' 'memorandum of understanding and/or agreement' and 'purchase order' Each is a term used to differentiate between a purchase-order-format type document and a complex purchase in a subcontract/sub-award-format type document. These also include awards and notices of awards; job orders or task letters issued under basic ordering agreements; letter contracts; orders, such as purchase orders and subcontracts under which the order becomes effective by written acceptance or performance; and bilateral contract modifications","Adm","",""
+"Cost Estimate","An approximation of total costs required for completion of the project based on known resources (staff, physical assets, knowledge, etc.) that will be needed","Adm","",""
+"Department of Energy","cabinet department of the United States federal government; the DOE has assumed technical and financial responsibility for providing the LSST camera. The DOE's responsibilities are executed by a collaboration led by SLAC National Accelerator Laboratory","Adm","","DOE"
+"Deputy Director","The person who supports the Director in the execution of the overall LSST project and assumes his or her duties and authority during any short term or extended absence, planned or unplanned","Adm","",""
+"Descope","A strategic downward revision to project objectives","Adm","",""
+"Director","The person responsible for the overall conduct of the project; the LSST director is charged with ensuring that both the scientific goals and management constraints on the project are met. S/he is the principal public spokesperson for the project in all matters and represents the project to the scientific community, AURA, the member institutions of LSSTC, and the funding agencies","Adm","",""
+"Document","Any object (in any application supported by DocuShare or design archives such as PDMWorks or GIT) that supports project management or records milestones and deliverables of the LSST Project","Adm","",""
+"Document Specialist","The person responsible for maintaining the Project's document archive (DocuShare) as well as providing editing and technical writing services. He or she also coordinates administrative support to the Project Management Office and the distributed Project team","Adm","",""
+"DocuShare","The trade name for the enterprise management software used by LSST to archive and manage documents","Adm","",""
+"Earned Value","A measurement of how much work has been completed compared to how much was expected to have been completed at a given point in the project","Adm","",""
+"EVM","Earned Value Management,  project management technique for objectively measuring project performance and progress in terms of budget and schedule","Adm","",""
+"EVMS","Earned Value Management System, suite of tools used to perform earned value management","Adm","",""
+"Encumbrances","A contingent liability, contract, purchase order, payroll commitment, tax payable, or legal penalty that is chargeable to an account; it ceases to be an encumbrance when paid out or when the actual liability amount is determined and recorded as an expense","Adm","",""
+"Escalation","Change in the cost or price of specific goods and services in a given economy over a period","Adm","",""
+"FTE","Full-Time Equivalent, unit equivalent to one person working full time for one year with normal holidays, vacations, and sick time. No paid overtime is assumed","Adm","",""
+"Handle","The unique identifier assigned to a document uploaded to DocuShare","Adm","",""
+"Head of Safety","See Safety Manager","Adm","",""
+"Incident","An undesired event, which under slightly different circumstances, could have resulted in harm to people, damage to property, or loss to process","Adm","",""
+"ITSC","Information Technology Services Committee , internal LSST Project Office committee charged with managing project IT services, including advising management on which services LSST should use. The ITSC's goals are 1) to ensure interoperability exists among products, 2) to combine, reuse and/or, recycle existing services when possible, 3) to prevent applications from becoming stagnant or security hazards, 4) to make recommendations on whether a particular tool remains 5) to keep the project informed of what is going on at all spectrums, and 6) to make recommendations for how the Project Office will transition into commissioning and operations","Adm","",""
+"Information Technology Systems Administrator","The person responsible for maintaining the Project Office's servers, networks, and computing hardware; he or she also provides technical support to the Project Management Office and the distributed Project team","Adm","",""
+"Institutional Member","An organization such as an institute, observatory, university, or company committed to making an intellectual, financial, or other significant contribution to LSST operations or to preparing the scientific community to use the LSST dataset. They are members of the LSST Corporation and pay an annual membership fee in an amount established by the LSSTC Board of Directors","Adm","",""
+"IPS","Integrated Project Schedule, complete picture of the entire project life cycle. By incorporating all project phases into the same model, the IPS allows the project team to plan the critical interfaces not only among project work elements but also among the design, construction, commissioning, and operations phases","Adm","",""
+"ICD","Interface Control Document, describes, defines, and controls the interface(s) of a system, thereby bounding its requirements. The description includes the inputs and outputs of a single system or element. An ICD may also describe the interface between two systems or subsystems. The purpose of the ICD is to communicate all possible inputs to and all potential outputs from a system for some potential or actual user of the system in operations. The internal interfaces of a system or subsystem are typically not documented in an ICD, but rather in a system design document","Adm","",""
+"ISD","Interface Support Document,  constrains an \gls{ICD} through such things as dictionaries, protocols, or definitions of system-wide architectural frameworks by which the subsystem teams must abide. However, ISDs do NOT contain requirements. ISDs are written by the subsystem teams with a stake in the subject matter; they are change controlled documents","Adm","",""
+"International Affiliate","An organization outside of the United States or Chile such as an institute, university, consortium, or government agency that has agreed to share in the annual operating costs of the LSST in exchange for data rights for a specified list of principal investigators during LSST operations and commissioning. These data rights may include access to specified project resources prior to operations. Rights also come with responsibilities, similar to those required of U.S.-based scientists, regarding unauthorized redistribution of data","Adm","",""
+"JOG","\gls{Joint Oversight Group}","Adm","",""
+"Joint Oversight Group","oversight body comprised of representatives from the \gls{NSF} and \gls{DOE}; the JOG meets regularly with LSST senior management to coordinate the Project's activities","Adm","",""
+"LSSTC","\gls{LSST} Corporation. an Arizona 501(c)3 not-for-profit corporation formed in 2003 for the purpose of designing, constructing, and operating the LSST System. During design and development, the Corporation stewarded private funding used for such essential contributions as early site preparation, mirror construction, and early data management system development. During construction, LSSTC will secure private operations funding from international affiliates and play a key role in preparing the scientific community to use the LSST dataset","Adm","",""
+"PMO","\gls{Project Management Office}","Adm","",""
+"Project Management Office","the work element responsible for achieving the project's objectives","Adm","",""
+"LSSTPO","\gls{LSST} Project Office,  official name of the stand-alone AURA operating center responsible for execution of the LSST construction project under the NSF \gls{MREFC} account","Adm","",""
+"Major Research Equipment and Facility Construction","the NSF account through which large facilities construction projects such as LSST are funded","Adm","",""
+"Manifest","Various files (and file formats) which define sets of build products having some shared attribute. There are release manifests which enumerate the eups-tags of all eups build products a the validated suite","Adm","",""
+"National Science Foundation","primary federal agency supporting research in all fields of fundamental science and engineering; NSF selects and funds projects through competitive, merit-based review","Adm","",""
+"Offer","A response to a solicitation that, if accepted, would bind the offeror to perform the work described in resultant contract. Responses to sealed bidding are offers that are often referred to as 'bids' or 'sealed bids;' responses to a request for proposals (RFP, negotiated-type procurements) are offers often referred to as 'proposals' responses to a request for quotations (RFQ) are not offers and are generally called 'quotes'","Adm","",""
+"Operations","The 10-year period following construction and commissioning during which the LSST Observatory conducts its survey","Adm","",""
+"Opportunity","The degree of exposure to an event that might happen to the benefit of a program, project, or other activity. It is described by a combination of the probability that the opportunity event will occur and the consequence of the extent of gain from the occurrence, or impact. There are two levels of opportunities. At the macro level, a project itself is the manifestation of the pursuit of an opportunity. At the element level, tactical opportunities exist, whereby certain events, if realized, provide a cost or schedule savings to the project or increase technical performance","Adm","",""
+"Opportunity Management","The proactive art and science of planning, assessing, and handling future events to seek favorable impacts on project, cost, schedule, or performance to the extent possible.  Opportunity management is a structured, formal, and disciplined activity focused on the necessary steps and planning actions to determine and exploit opportunities to the extent possible","Adm","",""
+"Policy file","A structured ASCII file that contains set of attributes for input to a pipeline. Deprecated","Adm","",""
+"Preferred Version","The default version of a document served to a DocuShare user. For change controlled documents, the preferred version represents the document's current, approved baseline. For other documents, the preferred version represents the most current iteration","Adm","",""
+"Primavera","The trade name for the project management software suite used by LSST to maintain its program plan and schedule","Adm","",""
+"Procurement","The activities involved with or the actual purchase, subcontract, lease, rent, or otherwise acquire supplies or services, and actions associated therewith","Adm","",""
+"PEP","\gls{Project Execution Plan}","Adm","",""
+"Project Execution Plan","primary document defining how the LSST Project will be undertaken; it details the project's scope, activities, quality and technical specifications, resources, schedule, and organization","Adm","",""
+"Project Management Controls Specialist","The person responsible for maintaining the Project Management Control System (PCMS); he or she works closely with the Project Manager and each of the Subsystem Managers","Adm","",""
+"Project Management Controls System","suite of tools used to organize and manage a project, including cost and schedule databases, a qualified accounting system, and change control","Adm","",""
+"Project Manager","The person responsible for exercising leadership and oversight over the entire LSST project; he or she controls schedule, budget, and all contingency funds","Adm","",""
+"Project Science Team","an operational unit within LSST that carries out specific scientific performance investigations as prioritized by the Director, the Project Manager, and the Project Scientist. Its membership includes key scientists on the Project who provide specific necessary expertise. The Project Science Team provides required scientific input on critical technical decisions as the project construction proceeds","Adm","",""
+"Project Scientist","The principal scientific advisor  to the LSST Project Manager to ensure that LSST system specifications are appropriate for achieving the scientific goals of the project; the Project Scientist also works closely with the Systems Engineering group and chairs the LSST Science Council","Adm","",""
+"Release","Publication of a new iteration of an existing document following approval of changes through the change control process. Upon release, the new iteration becomes the current baseline and the preferred version in the archive","Adm","",""
+"Requirement","A declaration of a specified function or quantitative performance that the delivered system or subsystem must meet.  It is a statement that identifies a necessary attribute, capability, characteristic, or quality of a system in order for the delivered system or subsystem to meet a derived or higher requirement, constraint, or function","Adm","",""
+"Retarget","In the context of task construction, a task may substitute a class sub-task to change the behavior of a particular step in the processing","Adm","",""
+"Review","Programmatic and/or technical audits of a given component of the project, where a preferably independent committee advises further project decisions, based on the current status and their evaluation of it. The reviews assess technical performance and maturity, as well as the compliance of the design and end product with the stated requirements and interfaces","Adm","",""
+"Review Committee","A panel of independent reviewers performing a programmatic and/or technical audit of a given component of the project; committees consist of subject matter experts external to the reviewed team and preferably external to the LSST project. The committee submits a post-review report including findings (observations), comments (concerns), and recommendations (requests for action)","Adm","",""
+"Review Data Package","The set of documents and data to be made available to Review Committee members during a review of a project component; the package has two parts: management data and product data. Management data includes appropriately mature and detailed versions of management plans, budgets and/or cost estimates, schedule, and procurement plans. Product data includes appropriately mature and detailed versions of the product technical documentation such as requirements, ICDs, models and analysis reports, and integration and verification plans","Adm","",""
+"Review Decision Making Authority","The person responsible for a project component who calls a review and consequently makes programmatic and/or technical decisions based on the Review Committee's findings, comments, and recommendations","Adm","",""
+"Review Hub","An LSST website that acts as a clearinghouse for information about external reviews of all LSST components planned to occur in the next six months. The site links to review-specific websites for both planned reviews and reviews that have been conducted already","Adm","",""
+"Review Plan","An enumeration of the necessary components for a proposed review of a project component; the review plan defines the Review Committee chair and members, the charge to the Review Committee, the Review Data Package, and the expected/required participants, including key team members presenting review material","Adm","",""
+"Risk","The degree of exposure to an event that might happen to the detriment of a program, project, or other activity. It is described by a combination of the probability that the risk event will occur and the consequence of the extent of loss from the occurrence, or impact. Risk is an inherent part of all activities, whether the activity is simple and small, or large and complex","Adm","",""
+"Risk Management","The art and science of planning, assessing, and handling future events to avoid unfavorable impacts on project cost, schedule, or performance to the extent possible. Risk management is a structured, formal, and disciplined activity focused on the necessary steps and planning actions to determine and control risks to an acceptable level. Risk Management is an event-based management approach to managing uncertainty","Adm","",""
+"Risk, Cost","The possibility that available budget will be exceeded. Cost risk exists if a) the project must devote more resources than planned to achieve technical requirements, b) the project must add resources to support slipped schedules due to any reason, c) if changes must be made to the number of items to be produced, or d) if changes occur in the organization or national economy. Cost risk can be predicted at the total project level or for a system element. The collective effects of element-level cost risk can produce cost risk for the total project","Adm","",""
+"Risk, Programmatic","Produced by events that are beyond the control of the project manager. These events often are produced by decisions made by personnel at higher levels of authority, such as reductions in project priority, delays in receiving authorization to proceed with a project, reduced or delayed funding, changes in organization or national objectives, etc. Programmatic risk can be a source of risk in any of the other three risk categories","Adm","",""
+"Risk, Schedule","The possibility that the project will fail to meet scheduled milestones. Schedule risk exists if there is inadequate allowance for acquisition delays or if difficulty is experienced in achieving scheduled technical accomplishments, such as the development of software. Schedule risk can be incurred at the total project level for milestones such as deployment of the first system element. The cascading effects of element-level schedule risks can produce schedule risk for the total project","Adm","",""
+"Risk, Technical","The possibility that a technical requirement of the system may not be achieved in the system life cycle. Technical risk exists if the system may fail to achieve performance requirements; to meet operability, producibility, testability, or integration requirements; or to meet environmental protection requirements. A potential failure to meet any requirement that can be expressed in technical terms is a source of technical risk","Adm","",""
+"Safety","The control of accidental loss","Adm","",""
+"Safety Council","A consulting body providing policy advice and evaluation of safety program effectiveness; the council is composed of independent safety professionals and representatives of LSST institutional members","Adm","",""
+"Safety Manager","The person who manages, executes, and verifies compliance with the LSST Safety Policy (LPM-18); the Safety Manager is also chair of the Safety Council","Adm","",""
+"SHE","Safety, Health, and Environmental","","",""
+"SHE Plans","\gls{SHE} plans are site-specific guidelines for safe working conditions. LSST expects that each collaborating organization and contractor has established safety programs to govern the specific activities at that location. LSST has a minimum expectation for the criteria established in these plans and expects all staff, permanent to the location or visiting, to follow these local procedures. When LSST specific sites are established the project will issue specific SHE plans for those locations","Adm","",""
+"SAC","Science Advisory Committee, advisory body, providing a formal and two-way connection to the external science community served by LSST; comprised of scientists familiar with but external to the LSST Project, the SAC advises the LSST Director on both policy questions and technical topics of interest to the Project and the science community","Adm","",""
+"Science Collaboration","An autonomous body of scientists interested in a particular area of science enabled by the LSST dataset, which through precursor studies, simulations, and algorithm development lays the groundwork for the large-scale science projects the LSST will enable.  In addition to preparing their members to take full advantage of LSST early in its operations phase, the science collaborations have helped to define the system's science requirements, refine and promote the science case, and quality check design and development work","Adm","",""
+"Science Collaboration Chair","The leader of and spokesperson for a Science Collaboration","Adm","",""
+"Scope","The work needed to be accomplished in order to deliver the product, service, or result with the specified features and functions","Adm","",""
+"Signature Authority","The individual designated by the LSSTC policy as authorized to approve the use of funds from a specific account; he or she must approve each Purchase Requisition for the account listed on the Purchase Requisition","Adm","",""
+"Site Manager","The LSST-delegated representative at the Cerro Pachón, Chile Summit site who is authorized to approve and accept work, provide technical liaison, monitor safety, and interpret LSST plans and specifications on behalf of AURA/LSST","Adm","",""
+"SLAC","SLAC National Accelerator Laboratory,  national laboratory funded by the US Department of Energy (DOE); SLAC leads a consortium of DOE laboratories that has assumed responsibility for providing the LSST camera. Although the Camera project manages its own schedule and budget, including contingency, the Camera team's schedule and requirements are integrated with the larger Project.  The camera effort is accountable to the LSSTPO","Adm","",""
+"Sole Source","A purchase of a commodity or a service that is noncompetitive in price, specifications, or use; or is 'only source' and must be accompanied by a sole source justification","Adm","",""
+"Sole Source Justification","A document accompanying a Purchase Requisition that provides the justification(s) for procuring the items must be from the single vendor listed on the Purchase Requisition","Adm","",""
+"Speakers Bureau","A volunteer body promoting LSST's visibility by identifying, initiating, and coordinating opportunities for LSST-related talks, especially at large conferences","Adm","",""
+"Speakers Bureau Website","An LSST website used by the LPO as a tool for screening and approving participation of LSST project personnel at various externally hosted meetings; the site also provides a mechanism for the Speakers Bureau to accept speaker requests, coordinate speakers, and maintain a record of requests received and talks given.  With this tool the Director and Project Manager can review and approve/deny requests for LSST financial support for travel before such meetings occur.  Project personnel use the site to report their intended participation in a meeting even if they are requesting neither a speaker nor LSST funding","Adm","",""
+"Specification","One or more performance parameter(s) being established by a requirement that the delivered system or subsystem must meet","Adm","",""
+"stack","a grouping, usually in layers (hence stack), of software packages and services to achieve a common goal. Often providing a higher level set of end user oriented services and tools","DM","",""
+"stack","A record of all versions of a document uploaded to a particular DocuShare handle","Adm","",""
+"Stop Work Authority","The authority of any individual to stop work if unanticipated/unsafe conditions are identified or non-compliant practices are observed at the site. Workers shall be instructed stop the work immediately and notify their supervisor(s), safety and health representative(s), and the LSST site manager of this action. Disagreements or differences of opinion about the need to terminate an activity shall occur only after the activity is stopped and people are removed from the hazard. All workers at the site have the authority to stop work. Work may not proceed until the circumstances are investigated and deficiencies corrected","Adm","",""
+"Subcontract","An agreement under which another entity will perform part or all of the project's contract obligations","Adm","",""
+"Subsystem","A set of elements comprising a system within the larger LSST system that is responsible for a key technical deliverable of the project","Adm","",""
+"SSM","\gls{Subsystem Manager}","Adm","",""
+"Subsystem Manager","responsible manager for an LSST subsystem; he or she exercises authority, within prescribed limits and under scrutiny of the Project Manager, over the relevant subsystem's cost, schedule, and work plans","Adm","",""
+"Subsystem Scientist","The principal science advisor  to a Subsystem Manager; he or she ensures that the subsystem specifications are appropriated for achieving the project's goals","Adm","",""
+"Subsystem Systems Engineer","A subsystem team member who works closely with the Subsystem Manager and the project Systems Engineering group on internal integration of the subsystem's component parts and the subsystem's integration with the larger LSST system","Adm","",""
+"Summit","The site on the Cerro Pachón, Chile mountaintop where the LSST observatory, support facilities, and infrastructure will be built","Adm","",""
+"Systems Engineer","A member of the Systems Engineering group who works closely with the Systems Engineering Manager and the Systems Scientist on the integrated LSST system's various technical issues spanning the full life cycle of the entire project","Adm","",""
+"SEM","\gls{Systems Engineering Manager}","Adm","",""
+"Systems Engineering Manager","individual responsible for the oversight and coordination of the LSST systems engineering efforts as well as the management of the Systems Engineering group and work package. The SEM is also the CCB Chair and as such is responsible for the execution, technical oversight, and coordination of configuration control activities","Adm","",""
+"Systems Scientist","A member of the Systems Engineering group and chief liaison to all project scientists; the Systems Scientist works closely with the Systems Engineering Manager and is responsible for the flow-down of science requirements. The Systems Scientist ensures that acceptance testing and commissioning address the science requirements","Adm","",""
+"Technical Baseline Classified Index (LSE-90)","An index linking to the various requirements documents, specifications documents, ICDs, design documents, budgets and allocations, and \gls{WBS} dictionaries defining the current baseline of the LSST project's technical scope","Adm","",""
+"Telescope and Site","The LSST subsystem responsible for design and construction of the telescope structure, telescope mirrors, optical wavefront measurement and control system, telescope and observatory control systems software, and the summit and base facilities. The Telescope technical team is hosted by NOAO","Adm","",""
+"Then-Year Cost","An extrapolation from the base year cost of a project element out to the year the cost actually will be incurred that accounts for escalation rates","Adm","",""
+"Travel Administrator","The person responsible ensuring compliance with the LSST Travel Policy. S/he makes all travel arrangements for all individuals whose travel is paid by LSST. S/he also reviews all Travel Expense Reports (TER) to vet claimed expenses as allowable before submitting them for approval by the LSST Business Manager","Adm","",""
+"Validation","A process of confirming that the delivered system will provide its desired functionality; overall, a validation process includes the evaluation, integration, and test activities carried out at the system level to ensure that the final developed system satisfies the intent and performance of that system in operations","Adm","",""
+"Verification","The process of evaluating the design, including hardware and software - to ensure the requirements have been met;  verification (of requirements) is performed by test, analysis, inspection, and/or demonstration","Adm","",""
+"Work Breakdown Structure","a tool that defines and organizes the LSST project's total work scope through the enumeration and grouping of the project's discrete work elements","Adm","",""
+"Work Elements","The critical tasks of the LSST Project as represented in the WBS","Adm","",""
+"Constraint","An external limitation imposed on a delivered item under which it must meet its requirements (e.g. the survey performance must be met under the constraint of the historical weather pattern of the chosen site).  A constraint is not a characteristic possessed by the system or subsystem itself","Adm TS Cam DM SE","",""
+"MJD","The Modified Julian Day is shorthand for the Julian Day: MJD = JD - 2400000.5, which makes MJD=0 correspond to UT midnight in 1858-Nov-17. The half-day offset from JD aligns the start of the day with modern civil timekeeping","Adm TS Cam DM SE Sci","",""
+"Amplifier","An electronic component of a CCD that is used to recover the signal during read-out. For LSST, multiple amplifiers on each CCD will enable simultaneous read-out of adjacent regions of each detector. Often this term is used, not quite correctly, as a synonym for a read-out channel","Cam","",""
+"Camcol","In the SDSS survey, a camera column is the range (in declination) covered by a single sensor in the camera","Cam","",""
+"Camera","The LSST subsystem responsible for the 3.2-gigapixel LSST camera, which will take more than 800 panoramic images of the sky every night. SLAC leads a consortium of Department of Energy laboratories to design and build the camera sensors, optics, electronics, cryostat, filters and filter exchange mechanism, and camera control system","Cam","",""
+"Channel","An amplifier on an LSST camera CCD (see sensor). For LSST there are 16 amplifiers for each science sensor, resulting in 16 parallel data channels from each device. The 16 channels comprising a sensor are numbered from ""0,0"" through '1,7'.  This term may also refer to the raw data from a read-out amplifier of a sensor","Cam","",""
+"Filter","A filter in astronomy is an optical element used to restrict the passband of light reaching the focal plane, it transmits a selected range of wavelengths. Filters elements are often named after standard photometric passbands, such as those used in the SDSS survey: u, g, r, i, z","Cam","",""
+"Focal plane array","A focal plane array (\gls{FPA}) is the arrangement of multiple sensors in the focal plane of a camera. For LSST, the FPA is divided into an array of contiguous rafts, upon which 9 science sensors are mounted 3x3. Additional engineering sensors are mounted on rafts near the periphery to support wavefront sensing and telescope guiding","Cam","",""
+"Overscan","Refers to the portion of the channel read-out of either a) non photo-active pixels, or b) additional read-out of the serial register after all science pixels have been accumulated (sometimes called virtual overscan). The overscan is often appended to the science pixels in the assembled amplifier image as a separate region. This region is useful to science processing software for estimating the stability of the DC offset in the read-out electronics","Cam","",""
+"Raft","The sensors in the LSST camera are packaged into replaceable electronic assemblies, called rafts, consisting of 9 butted sensors (CCDs) in a 3x3 mosaic. Each raft is a replaceable unit in the LSST camera. There are 21 science rafts in the camera plus 4 additional corner rafts with specialized, non-science sensors, making for a total of 189 CCDs per focal plane image. The 21 science rafts are numbered from ""0,1"" through ""0,3"", ""1,0"" through ""3,4"", and ""4,1"" through ""4,3"". (In other words, the 25 combinations from ""0,0"" through ""4,4"" minus the four corners which are non-science.)","Cam","",""
+"Sensor","A sensor is a generic term for a light-sensitive detector, such as a CCD. For LSST, sensors consist of a 2-D array of roughly 4K x 4K pixels, which are mounted on a raft in a 3x3 mosaic. Each sensor is divided into 16 channels or amplifiers. The 9 sensors that make up a raft are numbered from ""0,0"" through ""2,2""","Cam","",""
+"Charge-Coupled Device","a particular kind of solid-state sensor for detecting optical-band photons. It is composed of a 2-D array of pixels, and one or more read-out amplifiers","Cam Sci","",""
+"afw","LSST's pipeline library code and primitives including images and tables","DM","https://github.com/lsst/afw",""
+"Alert","A packet of information for each source detected with signal-to-noise ratio > 5 in a difference image during Prompt Processing, containing measurement and characterization parameters based on the past 12 months of LSST observations plus small cutouts of the single-visit, template, and difference images, distributed via the internet","DM","LSE-163",""
+"Alert Production","The principal component of Prompt Processing that processes and calibrates incoming images, performs Difference Image Analysis to identify DIASources and DIAObjects, packages and distributes the resulting Alerts, and runs the Moving Object Processing System","DM","LDM-151","AP"
+"Alternative Standard Visit","A single observation of an LSST field comprised of one 30 second exposure","DM","",""
+"aperture correction","A correction that is applied to fluxes of sources that were measured within a finite aperture, to account for the source flux that lies outside the aperture. This correction is usually based upon a model of the PSF as derived from bright, isolated stars. From the model one can derive the magnitude of the correction with aperture size and its variation with position in the image, which asymptotically approaches 1.0 at infinite aperture. Fluxes of sources in crowded fields are often measured with small apertures to avoid contamination, and then corrected with this approach","DM","LDM-151",""
+"Archive Center","Part of the LSST Data Management System, the LSST archive center is a data center at NCSA that hosts the LSST Archive, which includes released science data and metadata, observatory and engineering data, and supporting software such as the LSST Software Stack","DM","",""
+"Association Pipeline","An application that matches detected Sources or DIASources or generated Objects to an existing catalog of Objects, producing a (possibly many-to-many) set of associations and a list of unassociated inputs. Association Pipelines are used in Prompt Processing after DIASource generation and in the final stages of Data Release processing to ensure continuity of Object identifiers","DM","LDM-151",""
+"background","In an image, the background consists of contributions from the sky (e.g., clouds or scattered moonlight), and from the telescope and camera optics, which must be distinguished from the astrophysical background. The sky and instrumental backgrounds are characterized and removed by the LSST processing software using a low-order spatial function whose coefficients are recorded in the image metadata","DM","",""
+"Base Facility","The data center located at the Base Site in La Serena, Chile. The Base Facility is composed of the Base portion of the Prompt Enclave directly supporting Observatory operations, the Commissioning Cluster, an Archive Enclave holding data products, and the Chilean Data Access Center","DM","LDM-148",""
+"Batch Production","Computational processing that is executed as inputs become available, in a distributed way across multiple enclaves when needed, while tracking status and outputs. Examples of Batch Production include offline processing for Prompt data products, calibration products, template images, and Special Programs data products. Prioritization protocols for the various types of batch production are given in LDM-148","DM","LDM-148",""
+"brighter-fatter effect","The common term used to refer to one of the photometric qualities of the LSST camera: sources with a higher flux have a broader PSF. This is accounted for during calibration","DM","LDM-151, https://arxiv.org/pdf/1402.0725v1.pdf",""
+"Broker","Software which receives and redistributes Alerts, and may also perform processing such as filtering for certain characteristics, cross-matching with non-LSST catalogs, and/or light-curve classification, in order to identify and prioritize targets for follow-up and/or make scientific analyses. ","DM","LDM-612",""
+"Butler","A middleware component for persisting and retrieving image datasets (raw or processed), calibration reference data, and catalogs","DM","LDM-152, https://ldm-463.lsst.io/v/draft/index.html#id1",""
+"CalExp","A particular type of Butler dataset that consists of an image corresponding to a single CCD, which has been characterized and calibrated. (A Butler term.)","DM","LDM-151","Calexp"
+"Calibrated Science Image","Deprecated term; see Processed Visit Image","DM","","CSI, Processed Visit Image, PVI"
+"calibration","The process of translating signals produced by a measuring instrument such as a telescope and camera into physical units such as flux, which are used for scientific analysis. Calibration removes most of the contributions to the signal from environmental and instrumental factors, such that only the astronomical component remains","DM","LDM-151",""
+"Calibration Image","Any of a set of images used in the Instrument Signature Removal pipeline to remove distortions caused by the telescope, detector, or other sources, from the raw images. Includes darks, flats, tunable-laser dome flats, etc","DM","LDM-151",""
+"Calibration Scientist","The person responsible for the system calibration plan who establishes the requirements for the constituent elements of the calibration hardware, software, and operational data. The Calibration Scientist works under the direction of the Systems Engineering group","DM","",""
+"Camera Crosstalk-Corrected Image","An image from the Camera system that has had crosstalk removed but has not been processed by the Instrument Signature Removal pipeline","DM","","C3 Image, Raw Image"
+"Chi-squared Coadd Image","A Coadd Image that is the weighted sum of multiple input images, where for each input:
 
 coadd.image += image.image**2 / image.variance
 coadd.mask |= image.weightMap += weight
 
-For bad pixels, coadd and weightMap are not altered. Note that the inputs must be aligned to a common projection and pixel grid and corrected to the same photometric scale and zero-point.",DM,,Coadd Image
-CmdLineTask,"A special kind of Task that can read its inputs and write its outputs using a Butler, and can run easily from the command-line. CmdLineTask is a specific implementation of the concept of a command-line task. CmdLineTasks are being phased out in favor of PipelineTasks. ",DM,,PipelineTask
-Coadd Image,"An image that is the combination of multiple input images. The inputs are aligned to a common projection and pixel grid, corrected to the same photometric scale and zero-point, with bad pixels and artifacts rejected. (Image PSFs may also be matched prior to co-addition.) Coadd Images have had non-astrophysical background removed.",DM,,"Co-Add, CoAdd, co-add, coadd"
-Collimated Beam Projector,"The hardware to project a field of sources onto discrete sections of the telescope optics in order to characterize spatial variations in the telescope and instrument transmission function, and to monitor filter throughput evolution during the survey. Images obtained using the CBP will be used in calibration.",DM,LDM-151,CBP
-command-line task,"An enhancement of a Task in the LSST Stack context, it is the equivalent of a data processing pipeline and may be run directly from the shell command-line. A command-line task minimally consists of: a configuration and metadata, an argument parser, and a run method and a runner script.",DM,,Task
-configuration,"A task-specific set of configuration parameters, also called a 'config'. The config is read-only; once a task is constructed, the same configuration will be used to process all data. This makes the data processing more predictable: it does not depend on the order in which items of data are processed. This is distinct from arguments or options, which are allowed to vary from one task invocation to the next.",DM,,config
-Data Access Center,"Part of the LSST Data Management System, the US and Chilean DACs will provide authorized access to the released LSST data products, software such as the Science Platform, and computational resources for data analysis. The US DAC also includes a service for distributing bulk data on daily and annual (Data Release) timescales to partner institutions, collaborations, and LSST Education and Public Outreach (EPO). ",DM,LDM-148,DAC
-Data Backbone,"The software that provides for data registration, retrieval, storage, transport, replication, and provenance capabilities that are compatible with the Data Butler. It allows data products to move between Facilities, Enclaves, and DACs by managing caches of files at each endpoint, including persistence to long-term archival storage (e.g. tape).",DM,LDM-148,DBB
-data collection,"A data collection in the second-generation (Gen2) Butler (referred to as a data repository in earlier generations) consists of hierarchically organized data files, an inventory or registry of the contents (i.e., metadata from the data files) stored in an sqlite3 file, and a Mapper file that specifies to the LSST Stack software the camera model to apply when accessing the data in the data repository.",DM,,"repository, collection"
-Data Identifier,"A specification of one or more specific metadata that allow the selection of data from a collection. The specific metadata vary, depending on the origin of the data, but often include some sort of visit identifier, a sensor or CCD, and a filter. For details of syntax, see the Data Identifiers page.",DM,https://confluence.lsstcorp.org/display/LSWUG/Data+Identifiers,
-Data Management,"The LSST Subsystem responsible for the Data Management System (DMS), which will capture, store, catalog, and serve the LSST dataset to the scientific community and public. The DM team is responsible for the DMS architecture, applications, middleware, infrastructure, algorithms, and Observatory Network Design. DM is a distributed team working at LSST and partner institutions, with the DM Subsystem Manager located at LSST headquarters in Tucson.",DM,LDM-294,DM
-Data Management Subsystem,"The subsystems within Data Management may contain a defined combination of hardware, a software stack, a set of running processes, and the people who manage them: they are a major component of the DM System operations. Examples include the "'Archive Operations Subsystem' and the 'Data Processing Subsystem'".",DM,,
-Data Management System,"The computing infrastructure, middleware, and applications that process, store, and enable information extraction from the LSST dataset; the DMS will process peta-scale data volume, convert raw images into a faithful representation of the universe, and archive the results in a useful form. The infrastructure layer consists of the computing, storage, networking hardware, and system software. The middleware layer handles distributed processing, data access, user interface, and system operations services. The applications layer includes the data pipelines and the science data archives' products and services.",DM,LSE-61,DMS
-Data Product,"The LSST survey will produce three categories of Data Products. Prompt, Data Release, User Generated. Previously referred to as Levels 1, 2, and 3.",DM,LPM-231,
-Data Release,"The approximately annual reprocessing of all LSST data, and the installation of the resulting data products in the LSST Data Access Centers, which marks the start of the two-year proprietary period.",DM,,DR
-Data Release Data Product,"These products will be made available annually as the result of coherent processing of the entire science data set to date. These will include calibrated images; measurements of positions, fluxes, and shapes; variability information such as orbital parameters for moving objects; and an appropriate compact description of light curves. The Data Release data products will include a uniform reprocessing of the difference-imaging-based Prompt data products.",DM,"LDM-151, LSE-163, LPM-231",Level 2 Data Product
-Data Release Processing,Deprecated term; see Data Release Production.,DM,,"DRP, Level 2 Processing, Data Release Production"
-Data Release Production,"An episode of (re)processing all of the accumulated LSST images, during which all output DR data products are generated. These episodes are planned to occur annually during the LSST survey, and the processing will be executed at the Archive Center. This includes Difference Imaging Analysis, generating deep Coadd Images, Source detection and association, creating Object and Solar System Object catalogs, and related metadata.",DM,"LDM-151, LSE-163","DRP, Level 2 Processing"
-data repository,"A data repository consists of hierarchically organized data files, an inventory or registry of the contents (i.e., metadata from the data files) stored in an sqlite3 file, and a Mapper file that specifies to the LSST Stack software the camera model to apply when accessing the data in the repository. With the second-generation (Gen2) Butler, the term repository will be replaced by data collection.",DM, https://ldm-463.lsst.io/v/draft/index.html#repository,collection
-database schema,"A database schema defines how content is structured, as described in a formal language supported by the database management system. It refers to a mapping of the data model to the database structure, as realized in the partitioning of information into fields within tables of related information.",DM,,
-deblend,"Deblending is the act of inferring the intensity profiles of two or more overlapping sources from a single footprint within an image. Source footprints may overlap in crowded fields, or where the astrophysical phenomena intrinsically overlap (e.g., a supernova embedded in an external galaxy), or by spatial co-incidence (e.g., an asteroid passing in front of a star). Deblending may make use of a priori information from images (e.g., deep CoAdds or visit images obtained in good seeing), from catalogs, or from models. A 'deblend' is commonly referred to in terms of 'parent' (total) and 'child' (component) objects.",DM,LDM-151,
-deepCoadd,A Coadd Image designed to produce detections as maximum depth. Produced by AssembleCoaddTask.,DM,,Coadd
-deepDiff,A Difference Image that results from subtracting a template from a CalExp.,DM,,DiffIm
-DIAObject,"A DIAObject is the association of DIASources, by coordinate, that have been detected with signal-to-noise ratio greater than 5 in at least one difference image. It is distinguished from a regular Object in that its brightness varies in time, and from a SSObject in that it is stationary (non-moving).",DM,LSE-163,DIA Object
-DIASource,A DIASource is a detection with signal-to-noise ratio greater than 5 in a difference image.,DM,LSE-163,DIA Source
-Difference Image,"Refers to the result formed from the pixel-by-pixel difference of two images of the sky, after warping to the same pixel grid, scaling to the same photometric response, matching to the same PSF shape, and applying a correction for Differential Chromatic Refraction. The pixels in a difference thus formed should be zero (apart from noise) except for sources that are new, or have changed in brightness or position. In the LSST context, the difference is generally taken between a visit image and template. ",DM,"LDM-151, LSE-163",DiffIm
-Difference Image Analysis,"The detection and characterization of sources in the Difference Image that are above a configurable threshold, done as part of Alert Generation Pipeline.",DM,"LDM-151, LSE-163","DIA, Difference Image Processing"
-Differential Chromatic Refraction,"The refraction of incident light by Earth's atmosphere causes the apparent position of objects to be shifted, and the size of this shift depends on both the wavelength of the source and its airmass at the time of observation. DCR corrections are done as a part of DIA.",DM,DMTN-017,DCR
-Enclave,"Individually defined portions of the computational resources at the Summit, Base, NCSA, and Satellite Facilities, such as the Prompt Enclave, the Archive Enclave, etc. ",DM,LDM-148,
-eups,"ExtUPS (usually abbreviated as eups) is the software component management system that is used for the LSST Stack. It enables a choice of which versions of components should be used for a software build, and ensures that a consistent set is chosen. See the Eups Tutorial for details.",DM,https://developer.lsst.io/stack/eups-tutorial.html,ExtUPS
-eups-tag,A versioned tag for eups that identifies a build product with its git-source SHA-1 identifier.,DM,https://developer.lsst.io/stack/eups-tutorial.html,
-Firefly,"A framework of software components written by IPAC for building web-based user interfaces to astronomical archives, through which data may be searched and retrieved, and viewed as \gls{FITS} images, catalogs, and/or plots. Firefly tools will be integrated into the Science Platform.",DM,https://github.com/Caltech-IPAC/firefly,
-Flexible Image Transport System,"an international standard in astronomy for storing images, tables, and metadata in disk files. See the IAU FITS Standard for details.",DM,,
-footprint,"See 'source footprint', 'instrumental footprint', or 'survey footprint', `Footprint` is a Python class representing a source footprint.",DM,LDM-151,
-forced photometry,"A measurement of the photometric properties of a source, or expected source, with one or more parameters held fixed. Most often this means fixing the location of the center of the brightness profile (which may be known or predicted in advance), and measuring other properties such as total brightness, shape, and orientation. Forced photometry will be done for all Objects in the Data Release Production.",DM,"LDM-151, LSE-163",
-ForcedSource,DRP table resulting from forced photometry.,DM,"LDM-151, LSE-163",
-git,"A distributed revision control system, often used for software source code. See the Git User Manual for details. Not developed by LSST DM.",DM,https://git-scm.com/,
-git-tag,The tag assigned to a particular SHA-1 identifier which associates the git source with an eups-tag of the build product.,DM,https://git-scm.com/,git
-Image Decorrelation,"A method of improving the noise properties of the Difference Image in cases where the Template Image has a significant amount of noise, in order to use the same detection thresholds for defining DIASources.",DM,"LDM-151, DMTN-021",
-Independent Data Access Center,"Externally supported and administered versions of the DAC to serve the full, or a limited subset of, the LSST data products and/or software to authorized users. ",DM,LPM-251,iDAC
-Instrument Signature Removal,"Instrument Signature Removal is a pipeline that applies calibration reference data in the course of raw data processing, to remove artifacts of the instrument or detector electronics, such as removal of overscan pixels, bias correction, and the application of a flat-field to correct for pixel-to-pixel variations in sensitivity.",DM,LDM-151,ISR
-instrumental footprint,"The size and shape of a region on the sky that is covered by the field of view of an instrument, or part of an instrument, e.g., the LSST Camera, or ComCam, or a single LSST CCD.  Often represented by a geometric region defined in field-angle space.",DM,,
-jointcal,"The jointcal package optimizes the astrometric and photometric calibrations of a set of astronomical images that cover a sky tract and were obtained as a series of visits, which may be spread out in time. The jointcal algorithms incorporates object matching both between visits and to reference star catalogs, and produces more accurate distortion and throughput models than if the astrometry and photometry were fit independently. Jointcal is a part of the Science Pipelines.",DM,"DMTN-036, LDM-151",
-Level 1 Data Product,Deprecated term; see Prompt Data Product.,DM,LPM-231,Prompt Data Product
-Level 1 Processing,Deprecated term; see Prompt Processing.,DM,LPM-231,Prompt Processing
-Level 2 Data Product,Deprecated term; see Data Release Data Product.,DM,LPM-231,Data Release Data Product
-Level 2 Processing,Deprecated term; see Data Release Production.,DM,LPM-231,Data Release Production
-Level 3 Data Product,Deprecated term; see User Generated Data Product.,DM,LPM-231,User Generated Data Product
-Level 3 Processing,Deprecated term; see User Generated Processing.,DM,LPM-231,User Generated Processing
-Mapper,"A piece of software that abstracts persisting and unpersisting data; specifically, it knows how to navigate a data repository to locate data that match selection criteria that are relevant for data obtained with a particular camera. Used by the Butler.",DM,,
-metadata,"General term for data about data, e.g., attributes of astronomical objects (e.g. images, sources, astroObjects, etc.) that are characteristics of the objects themselves, and facilitate the organization, preservation, and query of data sets. (E.g., a FITS header contains metadata).",DM,,
-Mini-Broker,A tool provided by the LSST Science Platform that provides a limited amount of alert filtering capabilities.,DM,LDM-612,
-Moving Object Processing System,The Moving Object Processing System (MOPS) identifies new SSObjects using unassociated DIASources. MOPS is part of the Science Pipelines.,DM,"Jones et al. (2016), IAUS,318, 282.",MOPS
-NCSA Facility,"The data center at the National Center for Supercomputing Applications (NCSA) in Urbana, Illinois, USA. The NCSA Facility is composed of the NCSA portion of the Prompt Enclave, the Offline Production Enclave hosting all offline Data Release and calibration activities, an Archive Enclave holding data products, and the US Data Access Center.",DM,LDM-148,
-Nightly Alert Processing,Deprecated term; see 'Alert Production'.,DM,,Alert Production
-Nightly Archive Processing,Deprecated term; see 'Prompt Processing'.,DM,,Prompt Processing
-Non-Standard Visit,"Any single observation of a LSST field that is not comprised of either two 15 second 'Snap' exposures (a standard visit) or one 30 second exposure (an alternative standard visit). For example, exposure times for Special Programs might be significantly shorter or longer than a standard visit (or of random length).",DM,DMTN-065,
-Object,"In LSST nomenclature this refers to an astronomical object, such as a star, galaxy, or other physical entity. E.g., comets, asteroids are also Objects but typically called a Moving Object or a Solar System Object (SSObject). One of the DRP data products is a table of Objects detected by LSST which can be static, or change brightness or position with time.",DM,"LDM-151, LSE-163",
-Operations Rehearsal,"A data management system prototype project employing the same methods, tools, personnel, and technologies as the real system in order to introduce and validate new algorithms, functionality, and infrastructure. Previously referred to as a data challenge.",DM,,
-patch,"An quadrilateral sub-region of a sky tract, with a size in pixels chosen to fit easily into memory on desktop computers.",DM,LDM-151,sky patch
-pipeline,A configured sequence of software tasks (Stages) to process data and generate data products. Example: Association Pipeline.,DM,,
-PipelineTask,"A special kind of Task that can read its inputs and write its outputs using a Butler, in addition to being able to have them passed in and out directly as Python objects. PipelineTasks may be connected together dynamically and executed by a generic workflow system. PipelineTasks typically (but not always) delegate most of their work to nested regular Tasks.",DM,"LDM-556, DMTN-055",supertask
-postage stamp,"Image cutouts that are ~30x30 arcseconds, centered on an Object, and included in every Alert.",DM,"LDM-151, LSE-163",
-precovery,"The process of finding, or putting upper limits on, detections of a newly discovered DIAObject in previously obtained images, typically using forced photometry. Alert Packets will contain precovery data derived from the past 30 days of images that include the location of a new DIAObject.",DM,LSE-163,
-Processed Visit Image,"A fully-qualified LSST image from a single visit that includes the science pixel array and concomitant data including a quality mask and a variance array, in addition to a PSF characterization and metadata (including calibration metadata) about the image. It is stored with the background already subtracted.",DM,"LDM-151, LSE-163",PVI
-Prompt Data Product,"These products are generated continuously every observing night by Prompt Processing. They include both Alerts to Objects that have changed brightness or position, which are released with 60-second latency, and other catalog and image data products that are release with 24-hour latency.",DM,"LDM-151, LSE-163, LPM-231",Level 1 Data Product
-Prompt Processing,"The processing that occurs at the Archive Center on the nightly stream of raw images coming from the telescope, including Difference Imaging Analysis, Alert Production, and the Moving Object Processing System. This processing generates Prompt Data Products.",DM,"LDM-151, LSE-163, LPM-231",Level 1 Processing
-provenance,"Information about how LSST images, Sources, and Objects were created (e.g., versions of pipelines, algorithmic components, or templates) and how to recreate them.",DM,,
-PSF match,"To convolve an image to obtain a desired point spread function (PSF), typically in order to match it to another image. For example, Template Images are PSF matched to the new image before image subtraction when Difference Images are created.",DM,LDM-151,PSFMatch
-Qserv,"LSST's distributed parallel database. This database server is used for collecting, storing, and serving LSST Data Release Catalogs and Project metadata, and is part of the Software Stack.",DM,LDM-135,QSERV
-Raw Image,"The output from a camera, consisting of a set of image sections from each amplifier on each sensor on the focal plane array, including overscan.",DM,LDM-151,"C3 Image, Raw Camera Image, Raw Exposure"
-Release,"With regard to data pipelines or data products, a version that is cleared for distribution (i.e., has met QA specifications), is assigned a version identifier (e.g., 2.1), and does not evolve in the future to enable provenance.",DM,,
-release-tag,Refers to a tag which groups an entire stack of packages that are verified as unit and package-integration tested; this is also an eups-tag.,DM,https://developer.lsst.io/stack/eups-tutorial.html,eups-tag
-Satellite Facility,"The data center at CC-IN2P3 in Lyon, France.",DM,LDM-148,
-SDQA,\gls{Science Data Quality Assessment},DM LSST,,
-Science Data Quality Assessment,"An analysis system that examines and reports on the quality of LSST data and data products from a scientific perspective, and determines whether the data meets the science requirements in LPM-17.",DM,LPM-17,SDQA
-Science Pipelines,"The library of software components and the algorithms and processing pipelines assembled from them that are being developed by DM to generate science-ready data products from LSST images. The Pipelines may be executed at scale as part of LSST Prompt or Data Release processing, or pieces of them may be used in a standalone mode or executed through the LSST Science Platform. The Science Pipelines are one component of the LSST Software Stack.",DM,https://pipelines.lsst.io,Software Stack
-Science Platform,"A set of integrated web applications and services deployed at the LSST Data Access Centers (DACs) through which the scientific community will access, visualize, and perform next-to-the-data analysis of the LSST data products.",DM,LSE-319,
-Science Verification,"The second phase of Commissioning for the LSST Construction Project, Science Verification demonstrates the system's compliance with the survey performance specifications detailed in the LSST Science Requirements Document (SRD, LPM-17). These activities are based solely on the measured 'on-sky' performance of the LSST system.",DM,LPM-17,
-SCons,A piece of software developed externally to LSST. An automated build tool used for DM software development. See the SCons website for details.,DM,https://scons.org,
-SDQA Metric,"The name of a quantity that is calculated for image data by SDQA-related pipeline processes (e.g., mean, standard deviation, number of saturated pixels, mean PSF width, etc.). Associated with the metric name are the physical units of the calculated quantity and whether the quantity's data type is integer or floating-point.",DM,,
-SDQA Rating,The value and error associated with an SDQA metric. An image can have a set of different SDQA ratings.,DM,,
-SDQA Status,"The status assigned to an image by the SDQA subsystem (e.g., pass, fail, unknown, etc.). Database tables that store image metadata will include a field containing an ID number that corresponds to an SDQA status.",DM,,
-SDQA Threshold,"The set of lower and upper thresholds associated with an SDQA Metric. Some metrics have only either a lower or upper threshold. In general, the thresholds depend on observing conditions (e.g., atmospheric seeing, filter, etc.).",DM,,
-shape,"In reference to a Source or Object, the shape is a functional characterization of its spatial intensity distribution, and the integral of the shape is the flux. Shape characterizations are a data product in the DIASource, DIAObject, Source, and Object catalogs.",DM,,
-Single Visit Image,See CalExp.,DM,,"SVI, CalExp"
-sky map,"A sky tessellation for LSST. The Stack includes software to define a geometric mapping from the representation of World Coordinates in input images to the LSST sky map. This tessellation is comprised of individual tracts which are, in turn, comprised of patches.",DM,LDM-151,
-Snap,One 15 second exposure within a Standard Visit in the LSST cadence.,DM,,
-Software Stack,"Often referred to as the LSST Stack, or just The Stack, it is the collection of software written by the LSST Data Management Team to process, generate, and serve LSST images, transient alerts, and catalogs. The Stack includes the LSST Science Pipelines, as well as packages upon which the DM software depends. It is open source and publicly available.",DM,https://pipelines.lsst.io,"The Stack, Science Pipelines"
-Solar System Object,"A solar system object is an astrophysical object that is identified as part of the Solar System: planets and their satellites, asteroids, comets, etc. This class of object had historically been referred to within the LSST Project as Moving Objects.",DM,LSE-163,SSObject
-Source,"A single detection of an astrophysical object in an image, the characteristics for which are stored in the Source Catalog of the DRP database. The association of Sources that are non-moving lead to Objects; the association of moving Sources leads to Solar System Objects. (Note that in non-LSST usage ""source"" is often used for what LSST calls an Object.)",DM,"LSE-163, LDM-151",
-Source Association,"The process of associating source detections on multiple images taken at different epochs, or in multiple passbands, with a single astronomical Object.",DM,LDM-151,
-source footprint,"A set of pixels that are determined to be part of a Source (or DIASource). It is implemented as a list of spans. A span contains coordinates of a stripe of pixels: row (y) given span belongs to, and a section of a column (xStart, xEnd). In DM code, the term 'footprint' refers to a 'source footprint'.",DM,LDM-151,
-Special Program,Any LSST mini-survey or deep drilling field that is observed independently of the Wide-Fast-Deep (WFD) main survey.,DM,DMTN-065,
-sqlite3,"A software package external to DM, sqlite3 provides a SQL interface compliant with the DB-API 2.0 specification for SQLite, a self-contained public-domain SQL database engine.",DM,"https://www.sqlite.org/index.html, https://docs.python.org/3.4/library/sqlite3.html",
-Science Quality Analysis Harness,provides a minimal infrastructure for monitoring the LSST verification metrics. It can be used and extended to preserve the code and knowledge developed during LSST construction \url{https://squash.lsst.codes/}.,DM,https://squash.lsst.codes/,
-Standard Visit,A single observation of a LSST field comprised of two 15 second 'Snap' exposures that are immediately combined. An 'Alternative Standard Visit' is a single observation of a LSST field comprised of one 30 second exposure.,DM,LSE-30,
-Summit Facility,"The main Observatory and Auxiliary Telescope buildings at the Summit Site on Cerro Pachon, Chile.",DM,LDM-148,
-supertask,Deprecated term; see PipelineTask.,DM,,PipelineTask
-survey footprint,"The portion of the sky covered by data from an astronomical survey, e.g., the main wide-fast-deep LSST 10-year survey, the LSST deep drilling fields, or the Science Validation data taken during commissioning.  Sometimes represented by Boolean maps or other summary statistics in an all-sky representation, e.g., the \gls{IVOA} \gls{MOC} standard.",DM,,
-Template,"A co-added, single-band image of the sky that is deep, and created in a manner to remove transient or fast moving objects from the final image. Constituent images for templates may be selected from a limited range of quality parameters, such as PSF size or airmass. Such images are used to perform Difference Image Analysis in order to detect variable, transient, and Solar System astrophysical objects.",DM,"LDM-151, LSE-163",Template Image
-tile,"Obsolete form of sky tessellation, superseded by tracts/patches.",DM,,sky tile
-Task,"Tasks are the basic unit of code re-use in the LSST Stack. They perform a well defined, logically contained piece of functionality. Tasks come standard with configuration, logging, processing metadata, and debugging features. For further details, see How to Write a Task in the source code documentation.  Tasks can be nested, providing a natural way to structure - and configure - high level algorithms that delegate work to lower-level algorithms.",DM,"http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/pipe_tasks_write_task.html","command-line task, PipelineTask"
-tracklet,Links between unassociated DIASources within one night to identify moving objects.,DM,LDM-151,
-tract,"A portion of sky, a spherical convex polygon, within the LSST all-sky tessellation (sky map). Each tract is subdivided into sky patches.",DM,LDM-151,sky tract
-User Generated Data Product,"The products of User Generated Processing pipelines; these products will originate from the community, including project teams.",DM,LPM-231,Level 3 Data Product
-User Generated Processing,"Any (re)processing of LSST data performed by a user, with either custom pipelines or reconfigured LSST software, to create User Generated Data Products. This processing will originate from the community, including project teams.",DM,LPM-231,Level 3 Processing
-warp,"(noun) The pixels from a single CCD Exposure that overlap a given coadd patch, trimmed and resampled into the patch's coordinate system; in other words, an image that has been astrometrically registered to the common coordinate system of a tract.",DM,LDM-151,
-Hierarchical Triangular Mesh, is a partitioning scheme to divide the surface of the unit sphere into spherical triangles. It is a hierarchical scheme and the subdivisions have roughly equal areas. HTM is used to index the coordinates in the object databases for faster querying speeds.,DM Sci,"http://www.skyserver.org/htm/,  https://www.microsoft.com/en-us/research/wp-content/uploads/2005/09/tr-2005-123.pdf",
-Wide-Fast-Deep,The main survey of the LSST to cover at least 18000 square degrees of the southern sky.,DM TS,,WFD
-Visit,"A sequence of one or more consecutive exposures at a given position, orientation, and filter within the LSST cadence. See \gls{Standard Visit}, \gls{Alternative Standard Visit}, and \gls{Non-Standard Visit},DM TS Sims,,
-Education and Public Outreach (EPO),"The LSST subsystem responsible for the cyberinfrastructure, user interfaces, and outreach programs necessary to connect educators, planetaria, citizen scientists, amateur astronomers, and the general public to the transformative LSST dataset",EPO,,EPO
-adaptive moments,"The second moments of the source intensity distribution, which are used for measuring source shapes. This approach is close to optimal for measuring the shapes of faint galaxies.",Sci,,
-airmass,"The pathlength of light from an astrophysical source through the Earth's atmosphere. It is given approximately by sec z, where z is the angular distance from the zenith (the point directly overhead, where airmass = 1.0) to the source.",Sci,,
-algorithm,A computational implementation of a calculation or some method of processing.,Sci,,
-astrometry,"In astronomy, the sub-discipline of astrometry concerns precision measurement of positions (at a reference epoch), and real and apparent motions of astrophysical objects. Real motion means 3-D motions of the object with respect to an inertial reference frame; apparent motions are an artifact of the motion of the Earth. Astrometry per se is sometimes confused with the act of determining a World Coordinate System (WCS), which is a functional characterization of the mapping from pixels in an image or spectrum to world coordinate such as (RA, Dec) or wavelength.",Sci,,
-astronomical object,"A star, galaxy, asteroid, or other physical object of astronomical interest. Beware: in non-LSST usage, these are often known as sources.",Sci,,
-camera,"An imaging device mounted at a telescope focal plane, composed of optics, a shutter, a set of filters, and one or more sensors arranged in a focal plane array.",Sci,,
-CFHT-LS,A 5-passband legacy imaging survey conducted at the Canada-France-Hawaii Telescope from 2003-2008.,Sci,,
-declination,"Often abbreviated Dec, it is a part of an equatorial coordinate pair that expresses the angular distance (usually expressed in degrees) from the Celestial Equator, measured along great circles that intersect the Equatorial poles. Positions south of the equator are given negative sign.",Sci,,
-ephemeris,"An ephemeris (pl: ephemerides) gives the predicted positions of astronomical objects or artificial satellites in the sky with time. The ephemerides are computed from mathematical models of motion of the object and the Earth. In the LSST Moving Object Processing System, it refers to a predicted position (RA/Dec/time/etc) of a MovingObject",Sci,,
-epoch,"Sky coordinate reference frame, e.g., J2000. Alternatively refers to a single observation (usually photometric, can be multi-band) of a variable source.",Sci,,
-exponential profile,"The radial distribution of flux of an astronomical source that is characterized: I(r)=I0exp(.68(r/re)) The normalization 1.68 is chosen so that the model radius is a half-light radius. An 2-dimensional elliptical version of this profile is fit to every detected source.",Sci,,
-flux,"Shorthand for radiative flux, it is a measure of the transport of radiant energy per unit area per unit time. In astronomy this is usually expressed in cgs units: erg/cm2/s.",Sci,,
-Julian Date,"The Julian Date (JD) of any instant is the Julian day number for the preceding noon (UTC), plus the fraction of the day elapsed since that instant. The Julian day number is a running sequence of integral days, starting at noon, since the beginning of the Julian Period; JD 0.0 corresponds to noon on 1 January 4713 BCE. Various Julian Date converters are available on the Web. For example, 18h 00m 00.0s UT on 2014-July-01 (near the start of LSST construction) corresponds to JD 2456840.25.",Sci,,
-"magnitude, Petrosian","A magnitude determined from a fit to a Petrosian brightness profile: Rp(r) = stuf f Appropriate for galaxies.",Sci,,
-"magnitude, Petrosian","A magnitude determined from a fit to a Petrosian brightness profile: Rp(r) = stuf f Appropriate for galaxies.",Sci,,
+For bad pixels, coadd and weightMap are not altered. Note that the inputs must be aligned to a common projection and pixel grid and corrected to the same photometric scale and zero-point","DM","","Coadd Image"
+"CmdLineTask","A special kind of Task that can read its inputs and write its outputs using a Butler, and can run easily from the command-line. CmdLineTask is a specific implementation of the concept of a command-line task. CmdLineTasks are being phased out in favor of PipelineTasks. ","DM","","PipelineTask"
+"Coadd Image","An image that is the combination of multiple input images. The inputs are aligned to a common projection and pixel grid, corrected to the same photometric scale and zero-point, with bad pixels and artifacts rejected. (Image PSFs may also be matched prior to co-addition.) Coadd Images have had non-astrophysical background removed","DM","","Co-Add, CoAdd, co-add, coadd"
+"Collimated Beam Projector","The hardware to project a field of sources onto discrete sections of the telescope optics in order to characterize spatial variations in the telescope and instrument transmission function, and to monitor filter throughput evolution during the survey. Images obtained using the CBP will be used in calibration","DM","LDM-151","CBP"
+"command-line task","An enhancement of a Task in the LSST Stack context, it is the equivalent of a data processing pipeline and may be run directly from the shell command-line. A command-line task minimally consists of: a configuration and metadata, an argument parser, and a run method and a runner script","DM","","Task"
+"configuration","A task-specific set of configuration parameters, also called a 'config'. The config is read-only; once a task is constructed, the same configuration will be used to process all data. This makes the data processing more predictable: it does not depend on the order in which items of data are processed. This is distinct from arguments or options, which are allowed to vary from one task invocation to the next","DM","","config"
+"Data Access Center","Part of the LSST Data Management System, the US and Chilean DACs will provide authorized access to the released LSST data products, software such as the Science Platform, and computational resources for data analysis. The US DAC also includes a service for distributing bulk data on daily and annual (Data Release) timescales to partner institutions, collaborations, and LSST Education and Public Outreach (EPO). ","DM","LDM-148","DAC"
+"Data Backbone","The software that provides for data registration, retrieval, storage, transport, replication, and provenance capabilities that are compatible with the Data Butler. It allows data products to move between Facilities, Enclaves, and DACs by managing caches of files at each endpoint, including persistence to long-term archival storage (e.g. tape)","DM","LDM-148","DBB"
+"data collection","A data collection in the second-generation (Gen2) Butler (referred to as a data repository in earlier generations) consists of hierarchically organized data files, an inventory or registry of the contents (i.e., metadata from the data files) stored in an sqlite3 file, and a Mapper file that specifies to the LSST Stack software the camera model to apply when accessing the data in the data repository","DM","","repository, collection"
+"Data Identifier","A specification of one or more specific metadata that allow the selection of data from a collection. The specific metadata vary, depending on the origin of the data, but often include some sort of visit identifier, a sensor or CCD, and a filter. For details of syntax, see the Data Identifiers page","DM","https://confluence.lsstcorp.org/display/LSWUG/Data+Identifiers",""
+"Data Management","The LSST Subsystem responsible for the Data Management System (DMS), which will capture, store, catalog, and serve the LSST dataset to the scientific community and public. The DM team is responsible for the DMS architecture, applications, middleware, infrastructure, algorithms, and Observatory Network Design. DM is a distributed team working at LSST and partner institutions, with the DM Subsystem Manager located at LSST headquarters in Tucson","DM","LDM-294","DM"
+"Data Management Subsystem","The subsystems within Data Management may contain a defined combination of hardware, a software stack, a set of running processes, and the people who manage them: they are a major component of the DM System operations. Examples include the 'Archive Operations Subsystem' and the 'Data Processing Subsystem'"".""","DM","",""
+"Data Management System","The computing infrastructure, middleware, and applications that process, store, and enable information extraction from the LSST dataset; the DMS will process peta-scale data volume, convert raw images into a faithful representation of the universe, and archive the results in a useful form. The infrastructure layer consists of the computing, storage, networking hardware, and system software. The middleware layer handles distributed processing, data access, user interface, and system operations services. The applications layer includes the data pipelines and the science data archives' products and services","DM","LSE-61","DMS"
+"Data Product","The LSST survey will produce three categories of Data Products. Prompt, Data Release, User Generated. Previously referred to as Levels 1, 2, and 3","DM","LPM-231",""
+"Data Release","The approximately annual reprocessing of all LSST data, and the installation of the resulting data products in the LSST Data Access Centers, which marks the start of the two-year proprietary period","DM","","DR"
+"Data Release Data Product","These products will be made available annually as the result of coherent processing of the entire science data set to date. These will include calibrated images; measurements of positions, fluxes, and shapes; variability information such as orbital parameters for moving objects; and an appropriate compact description of light curves. The Data Release data products will include a uniform reprocessing of the difference-imaging-based Prompt data products","DM","LDM-151, LSE-163, LPM-231","Level 2 Data Product"
+"Data Release Processing","Deprecated term; see Data Release Production","DM","","DRP, Level 2 Processing, Data Release Production"
+"Data Release Production","An episode of (re)processing all of the accumulated LSST images, during which all output DR data products are generated. These episodes are planned to occur annually during the LSST survey, and the processing will be executed at the Archive Center. This includes Difference Imaging Analysis, generating deep Coadd Images, Source detection and association, creating Object and Solar System Object catalogs, and related metadata","DM","LDM-151, LSE-163","DRP, Level 2 Processing"
+"data repository","A data repository consists of hierarchically organized data files, an inventory or registry of the contents (i.e., metadata from the data files) stored in an sqlite3 file, and a Mapper file that specifies to the LSST Stack software the camera model to apply when accessing the data in the repository. With the second-generation (Gen2) Butler, the term repository will be replaced by data collection","DM"," https://ldm-463.lsst.io/v/draft/index.html#repository","collection"
+"database schema","A database schema defines how content is structured, as described in a formal language supported by the database management system. It refers to a mapping of the data model to the database structure, as realized in the partitioning of information into fields within tables of related information","DM","",""
+"deblend","Deblending is the act of inferring the intensity profiles of two or more overlapping sources from a single footprint within an image. Source footprints may overlap in crowded fields, or where the astrophysical phenomena intrinsically overlap (e.g., a supernova embedded in an external galaxy), or by spatial co-incidence (e.g., an asteroid passing in front of a star). Deblending may make use of a priori information from images (e.g., deep CoAdds or visit images obtained in good seeing), from catalogs, or from models. A 'deblend' is commonly referred to in terms of 'parent' (total) and 'child' (component) objects","DM","LDM-151",""
+"deepCoadd","A Coadd Image designed to produce detections as maximum depth. Produced by AssembleCoaddTask","DM","","Coadd"
+"deepDiff","A Difference Image that results from subtracting a template from a CalExp","DM","","DiffIm"
+"DIAObject","A DIAObject is the association of DIASources, by coordinate, that have been detected with signal-to-noise ratio greater than 5 in at least one difference image. It is distinguished from a regular Object in that its brightness varies in time, and from a SSObject in that it is stationary (non-moving)","DM","LSE-163","DIA Object"
+"DIASource","A DIASource is a detection with signal-to-noise ratio greater than 5 in a difference image","DM","LSE-163","DIA Source"
+"Difference Image","Refers to the result formed from the pixel-by-pixel difference of two images of the sky, after warping to the same pixel grid, scaling to the same photometric response, matching to the same PSF shape, and applying a correction for Differential Chromatic Refraction. The pixels in a difference thus formed should be zero (apart from noise) except for sources that are new, or have changed in brightness or position. In the LSST context, the difference is generally taken between a visit image and template. ","DM","LDM-151, LSE-163","DiffIm"
+"Difference Image Analysis","The detection and characterization of sources in the Difference Image that are above a configurable threshold, done as part of Alert Generation Pipeline","DM","LDM-151, LSE-163","DIA, Difference Image Processing"
+"Differential Chromatic Refraction","The refraction of incident light by Earth's atmosphere causes the apparent position of objects to be shifted, and the size of this shift depends on both the wavelength of the source and its airmass at the time of observation. DCR corrections are done as a part of DIA","DM","DMTN-017","DCR"
+"Enclave","Individually defined portions of the computational resources at the Summit, Base, NCSA, and Satellite Facilities, such as the Prompt Enclave, the Archive Enclave, etc. ","DM","LDM-148",""
+"eups","ExtUPS (usually abbreviated as eups) is the software component management system that is used for the LSST Stack. It enables a choice of which versions of components should be used for a software build, and ensures that a consistent set is chosen. See the Eups Tutorial for details","DM","https://developer.lsst.io/stack/eups-tutorial.html","ExtUPS"
+"eups-tag","A versioned tag for eups that identifies a build product with its git-source SHA-1 identifier","DM","https://developer.lsst.io/stack/eups-tutorial.html",""
+"Firefly","A framework of software components written by IPAC for building web-based user interfaces to astronomical archives, through which data may be searched and retrieved, and viewed as \gls{FITS} images, catalogs, and/or plots. Firefly tools will be integrated into the Science Platform","DM","https://github.com/Caltech-IPAC/firefly",""
+"Flexible Image Transport System","an international standard in astronomy for storing images, tables, and metadata in disk files. See the IAU FITS Standard for details","DM","",""
+"footprint","See 'source footprint', 'instrumental footprint', or 'survey footprint', `Footprint` is a Python class representing a source footprint","DM","LDM-151",""
+"forced photometry","A measurement of the photometric properties of a source, or expected source, with one or more parameters held fixed. Most often this means fixing the location of the center of the brightness profile (which may be known or predicted in advance), and measuring other properties such as total brightness, shape, and orientation. Forced photometry will be done for all Objects in the Data Release Production","DM","LDM-151, LSE-163",""
+"ForcedSource","DRP table resulting from forced photometry","DM","LDM-151, LSE-163",""
+"git","A distributed revision control system, often used for software source code. See the Git User Manual for details. Not developed by LSST DM","DM","https://git-scm.com/",""
+"git-tag","The tag assigned to a particular SHA-1 identifier which associates the git source with an eups-tag of the build product","DM","https://git-scm.com/","git"
+"Image Decorrelation","A method of improving the noise properties of the Difference Image in cases where the Template Image has a significant amount of noise, in order to use the same detection thresholds for defining DIASources","DM","LDM-151, DMTN-021",""
+"Independent Data Access Center","Externally supported and administered versions of the DAC to serve the full, or a limited subset of, the LSST data products and/or software to authorized users. ","DM","LPM-251","iDAC"
+"Instrument Signature Removal","Instrument Signature Removal is a pipeline that applies calibration reference data in the course of raw data processing, to remove artifacts of the instrument or detector electronics, such as removal of overscan pixels, bias correction, and the application of a flat-field to correct for pixel-to-pixel variations in sensitivity","DM","LDM-151","ISR"
+"instrumental footprint","The size and shape of a region on the sky that is covered by the field of view of an instrument, or part of an instrument, e.g., the LSST Camera, or ComCam, or a single LSST CCD.  Often represented by a geometric region defined in field-angle space","DM","",""
+"jointcal","The jointcal package optimizes the astrometric and photometric calibrations of a set of astronomical images that cover a sky tract and were obtained as a series of visits, which may be spread out in time. The jointcal algorithms incorporates object matching both between visits and to reference star catalogs, and produces more accurate distortion and throughput models than if the astrometry and photometry were fit independently. Jointcal is a part of the Science Pipelines","DM","DMTN-036, LDM-151",""
+"Level 1 Data Product","Deprecated term; see Prompt Data Product","DM","LPM-231","Prompt Data Product"
+"Level 1 Processing","Deprecated term; see Prompt Processing","DM","LPM-231","Prompt Processing"
+"Level 2 Data Product","Deprecated term; see Data Release Data Product","DM","LPM-231","Data Release Data Product"
+"Level 2 Processing","Deprecated term; see Data Release Production","DM","LPM-231","Data Release Production"
+"Level 3 Data Product","Deprecated term; see User Generated Data Product","DM","LPM-231","User Generated Data Product"
+"Level 3 Processing","Deprecated term; see User Generated Processing","DM","LPM-231","User Generated Processing"
+"Mapper","A piece of software that abstracts persisting and unpersisting data; specifically, it knows how to navigate a data repository to locate data that match selection criteria that are relevant for data obtained with a particular camera. Used by the Butler","DM","",""
+"metadata","General term for data about data, e.g., attributes of astronomical objects (e.g. images, sources, astroObjects, etc.) that are characteristics of the objects themselves, and facilitate the organization, preservation, and query of data sets. (E.g., a FITS header contains metadata)","DM","",""
+"Mini-Broker","A tool provided by the LSST Science Platform that provides a limited amount of alert filtering capabilities","DM","LDM-612",""
+"Moving Object Processing System","The Moving Object Processing System (MOPS) identifies new SSObjects using unassociated DIASources. MOPS is part of the Science Pipelines","DM","Jones et al. (2016), IAUS,318, 282.","MOPS"
+"NCSA Facility","The data center at the National Center for Supercomputing Applications (NCSA) in Urbana, Illinois, USA. The NCSA Facility is composed of the NCSA portion of the Prompt Enclave, the Offline Production Enclave hosting all offline Data Release and calibration activities, an Archive Enclave holding data products, and the US Data Access Center","DM","LDM-148",""
+"Nightly Alert Processing","Deprecated term; see 'Alert Production'","DM","","Alert Production"
+"Nightly Archive Processing","Deprecated term; see 'Prompt Processing'","DM","","Prompt Processing"
+"Non-Standard Visit","Any single observation of a LSST field that is not comprised of either two 15 second 'Snap' exposures (a standard visit) or one 30 second exposure (an alternative standard visit). For example, exposure times for Special Programs might be significantly shorter or longer than a standard visit (or of random length)","DM","DMTN-065",""
+"Object","In LSST nomenclature this refers to an astronomical object, such as a star, galaxy, or other physical entity. E.g., comets, asteroids are also Objects but typically called a Moving Object or a Solar System Object (SSObject). One of the DRP data products is a table of Objects detected by LSST which can be static, or change brightness or position with time","DM","LDM-151, LSE-163",""
+"Operations Rehearsal","A data management system prototype project employing the same methods, tools, personnel, and technologies as the real system in order to introduce and validate new algorithms, functionality, and infrastructure. Previously referred to as a data challenge","DM","",""
+"patch","An quadrilateral sub-region of a sky tract, with a size in pixels chosen to fit easily into memory on desktop computers","DM","LDM-151","sky patch"
+"pipeline","A configured sequence of software tasks (Stages) to process data and generate data products. Example: Association Pipeline","DM","",""
+"PipelineTask","A special kind of Task that can read its inputs and write its outputs using a Butler, in addition to being able to have them passed in and out directly as Python objects. PipelineTasks may be connected together dynamically and executed by a generic workflow system. PipelineTasks typically (but not always) delegate most of their work to nested regular Tasks","DM","LDM-556, DMTN-055","supertask"
+"postage stamp","Image cutouts that are ~30x30 arcseconds, centered on an Object, and included in every Alert","DM","LDM-151, LSE-163",""
+"precovery","The process of finding, or putting upper limits on, detections of a newly discovered DIAObject in previously obtained images, typically using forced photometry. Alert Packets will contain precovery data derived from the past 30 days of images that include the location of a new DIAObject","DM","LSE-163",""
+"Processed Visit Image","A fully-qualified LSST image from a single visit that includes the science pixel array and concomitant data including a quality mask and a variance array, in addition to a PSF characterization and metadata (including calibration metadata) about the image. It is stored with the background already subtracted","DM","LDM-151, LSE-163","PVI"
+"Prompt Data Product","These products are generated continuously every observing night by Prompt Processing. They include both Alerts to Objects that have changed brightness or position, which are released with 60-second latency, and other catalog and image data products that are release with 24-hour latency","DM","LDM-151, LSE-163, LPM-231","Level 1 Data Product"
+"Prompt Processing","The processing that occurs at the Archive Center on the nightly stream of raw images coming from the telescope, including Difference Imaging Analysis, Alert Production, and the Moving Object Processing System. This processing generates Prompt Data Products","DM","LDM-151, LSE-163, LPM-231","Level 1 Processing"
+"provenance","Information about how LSST images, Sources, and Objects were created (e.g., versions of pipelines, algorithmic components, or templates) and how to recreate them","DM","",""
+"PSF match","To convolve an image to obtain a desired point spread function (PSF), typically in order to match it to another image. For example, Template Images are PSF matched to the new image before image subtraction when Difference Images are created","DM","LDM-151","PSFMatch"
+"Qserv","LSST's distributed parallel database. This database server is used for collecting, storing, and serving LSST Data Release Catalogs and Project metadata, and is part of the Software Stack","DM","LDM-135","QSERV"
+"Raw Image","The output from a camera, consisting of a set of image sections from each amplifier on each sensor on the focal plane array, including overscan","DM","LDM-151","C3 Image, Raw Camera Image, Raw Exposure"
+"Release","With regard to data pipelines or data products, a version that is cleared for distribution (i.e., has met QA specifications), is assigned a version identifier (e.g., 2.1), and does not evolve in the future to enable provenance","DM","",""
+"release-tag","Refers to a tag which groups an entire stack of packages that are verified as unit and package-integration tested; this is also an eups-tag","DM","https://developer.lsst.io/stack/eups-tutorial.html","eups-tag"
+"Satellite Facility","The data center at CC-IN2P3 in Lyon, France","DM","LDM-148",""
+"SDQA","\gls{Science Data Quality Assessment}","DM LSST","",""
+"Science Data Quality Assessment","An analysis system that examines and reports on the quality of LSST data and data products from a scientific perspective, and determines whether the data meets the science requirements in LPM-17","DM","LPM-17","SDQA"
+"Science Pipelines","The library of software components and the algorithms and processing pipelines assembled from them that are being developed by DM to generate science-ready data products from LSST images. The Pipelines may be executed at scale as part of LSST Prompt or Data Release processing, or pieces of them may be used in a standalone mode or executed through the LSST Science Platform. The Science Pipelines are one component of the LSST Software Stack","DM","https://pipelines.lsst.io","Software Stack"
+"Science Platform","A set of integrated web applications and services deployed at the LSST Data Access Centers (DACs) through which the scientific community will access, visualize, and perform next-to-the-data analysis of the LSST data products","DM","LSE-319",""
+"Science Verification","The second phase of Commissioning for the LSST Construction Project, Science Verification demonstrates the system's compliance with the survey performance specifications detailed in the LSST Science Requirements Document (SRD, LPM-17). These activities are based solely on the measured 'on-sky' performance of the LSST system","DM","LPM-17",""
+"SCons","A piece of software developed externally to LSST. An automated build tool used for DM software development. See the SCons website for details","DM","https://scons.org",""
+"SDQA Metric","The name of a quantity that is calculated for image data by SDQA-related pipeline processes (e.g., mean, standard deviation, number of saturated pixels, mean PSF width, etc.). Associated with the metric name are the physical units of the calculated quantity and whether the quantity's data type is integer or floating-point","DM","",""
+"SDQA Rating","The value and error associated with an SDQA metric. An image can have a set of different SDQA ratings","DM","",""
+"SDQA Status","The status assigned to an image by the SDQA subsystem (e.g., pass, fail, unknown, etc.). Database tables that store image metadata will include a field containing an ID number that corresponds to an SDQA status","DM","",""
+"SDQA Threshold","The set of lower and upper thresholds associated with an SDQA Metric. Some metrics have only either a lower or upper threshold. In general, the thresholds depend on observing conditions (e.g., atmospheric seeing, filter, etc.)","DM","",""
+"shape","In reference to a Source or Object, the shape is a functional characterization of its spatial intensity distribution, and the integral of the shape is the flux. Shape characterizations are a data product in the DIASource, DIAObject, Source, and Object catalogs","DM","",""
+"Single Visit Image","See CalExp","DM","","SVI, CalExp"
+"sky map","A sky tessellation for LSST. The Stack includes software to define a geometric mapping from the representation of World Coordinates in input images to the LSST sky map. This tessellation is comprised of individual tracts which are, in turn, comprised of patches","DM","LDM-151",""
+"Snap","One 15 second exposure within a Standard Visit in the LSST cadence","DM","",""
+"Software Stack","Often referred to as the LSST Stack, or just The Stack, it is the collection of software written by the LSST Data Management Team to process, generate, and serve LSST images, transient alerts, and catalogs. The Stack includes the LSST Science Pipelines, as well as packages upon which the DM software depends. It is open source and publicly available","DM","https://pipelines.lsst.io","The Stack, Science Pipelines"
+"Solar System Object","A solar system object is an astrophysical object that is identified as part of the Solar System: planets and their satellites, asteroids, comets, etc. This class of object had historically been referred to within the LSST Project as Moving Objects","DM","LSE-163","SSObject"
+"Source","A single detection of an astrophysical object in an image, the characteristics for which are stored in the Source Catalog of the DRP database. The association of Sources that are non-moving lead to Objects; the association of moving Sources leads to Solar System Objects. (Note that in non-LSST usage ""source"" is often used for what LSST calls an Object.)","DM","LSE-163, LDM-151",""
+"Source Association","The process of associating source detections on multiple images taken at different epochs, or in multiple passbands, with a single astronomical Object","DM","LDM-151",""
+"source footprint","A set of pixels that are determined to be part of a Source (or DIASource). It is implemented as a list of spans. A span contains coordinates of a stripe of pixels: row (y) given span belongs to, and a section of a column (xStart, xEnd). In DM code, the term 'footprint' refers to a 'source footprint'","DM","LDM-151",""
+"Special Program","Any LSST mini-survey or deep drilling field that is observed independently of the Wide-Fast-Deep (WFD) main survey","DM","DMTN-065",""
+"sqlite3","A software package external to DM, sqlite3 provides a SQL interface compliant with the DB-API 2.0 specification for SQLite, a self-contained public-domain SQL database engine","DM","https://www.sqlite.org/index.html, https://docs.python.org/3.4/library/sqlite3.html",""
+"Science Quality Analysis Harness","provides a minimal infrastructure for monitoring the LSST verification metrics. It can be used and extended to preserve the code and knowledge developed during LSST construction \url{https://squash.lsst.codes/}","DM","https://squash.lsst.codes/",""
+"Standard Visit","A single observation of a LSST field comprised of two 15 second 'Snap' exposures that are immediately combined. An 'Alternative Standard Visit' is a single observation of a LSST field comprised of one 30 second exposure","DM","LSE-30",""
+"Summit Facility","The main Observatory and Auxiliary Telescope buildings at the Summit Site on Cerro Pachon, Chile","DM","LDM-148",""
+"supertask","Deprecated term; see PipelineTask","DM","","PipelineTask"
+"survey footprint","The portion of the sky covered by data from an astronomical survey, e.g., the main wide-fast-deep LSST 10-year survey, the LSST deep drilling fields, or the Science Validation data taken during commissioning.  Sometimes represented by Boolean maps or other summary statistics in an all-sky representation, e.g., the \gls{IVOA} \gls{MOC} standard","DM","",""
+"Template","A co-added, single-band image of the sky that is deep, and created in a manner to remove transient or fast moving objects from the final image. Constituent images for templates may be selected from a limited range of quality parameters, such as PSF size or airmass. Such images are used to perform Difference Image Analysis in order to detect variable, transient, and Solar System astrophysical objects","DM","LDM-151, LSE-163","Template Image"
+"tile","Obsolete form of sky tessellation, superseded by tracts/patches","DM","","sky tile"
+"Task","Tasks are the basic unit of code re-use in the LSST Stack. They perform a well defined, logically contained piece of functionality. Tasks come standard with configuration, logging, processing metadata, and debugging features. For further details, see How to Write a Task in the source code documentation.  Tasks can be nested, providing a natural way to structure - and configure - high level algorithms that delegate work to lower-level algorithms","DM","http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/pipe_tasks_write_task.html","command-line task, PipelineTask"
+"tracklet","Links between unassociated DIASources within one night to identify moving objects","DM","LDM-151",""
+"tract","A portion of sky, a spherical convex polygon, within the LSST all-sky tessellation (sky map). Each tract is subdivided into sky patches","DM","LDM-151","sky tract"
+"User Generated Data Product","The products of User Generated Processing pipelines; these products will originate from the community, including project teams","DM","LPM-231","Level 3 Data Product"
+"User Generated Processing","Any (re)processing of LSST data performed by a user, with either custom pipelines or reconfigured LSST software, to create User Generated Data Products. This processing will originate from the community, including project teams","DM","LPM-231","Level 3 Processing"
+"warp","(noun) The pixels from a single CCD Exposure that overlap a given coadd patch, trimmed and resampled into the patch's coordinate system; in other words, an image that has been astrometrically registered to the common coordinate system of a tract","DM","LDM-151",""
+"Hierarchical Triangular Mesh"," is a partitioning scheme to divide the surface of the unit sphere into spherical triangles. It is a hierarchical scheme and the subdivisions have roughly equal areas. HTM is used to index the coordinates in the object databases for faster querying speeds","DM Sci","http://www.skyserver.org/htm/,  https://www.microsoft.com/en-us/research/wp-content/uploads/2005/09/tr-2005-123.pdf",""
+"Wide-Fast-Deep","The main survey of the LSST to cover at least 18000 square degrees of the southern sky","DM TS","","WFD"
+"adaptive moments","The second moments of the source intensity distribution, which are used for measuring source shapes. This approach is close to optimal for measuring the shapes of faint galaxies","Sci","",""
+"airmass","The pathlength of light from an astrophysical source through the Earth's atmosphere. It is given approximately by sec z, where z is the angular distance from the zenith (the point directly overhead, where airmass = 1.0) to the source","Sci","",""
+"algorithm","A computational implementation of a calculation or some method of processing","Sci","",""
+"astrometry","In astronomy, the sub-discipline of astrometry concerns precision measurement of positions (at a reference epoch), and real and apparent motions of astrophysical objects. Real motion means 3-D motions of the object with respect to an inertial reference frame; apparent motions are an artifact of the motion of the Earth. Astrometry per se is sometimes confused with the act of determining a World Coordinate System (WCS), which is a functional characterization of the mapping from pixels in an image or spectrum to world coordinate such as (RA, Dec) or wavelength","Sci","",""
+"astronomical object","A star, galaxy, asteroid, or other physical object of astronomical interest. Beware: in non-LSST usage, these are often known as sources","Sci","",""
+"camera","An imaging device mounted at a telescope focal plane, composed of optics, a shutter, a set of filters, and one or more sensors arranged in a focal plane array","Sci","",""
+"CFHT-LS","A 5-passband legacy imaging survey conducted at the Canada-France-Hawaii Telescope from 2003-2008","Sci","",""
+"declination","Often abbreviated Dec, it is a part of an equatorial coordinate pair that expresses the angular distance (usually expressed in degrees) from the Celestial Equator, measured along great circles that intersect the Equatorial poles. Positions south of the equator are given negative sign","Sci","",""
+"ephemeris","An ephemeris (pl: ephemerides) gives the predicted positions of astronomical objects or artificial satellites in the sky with time. The ephemerides are computed from mathematical models of motion of the object and the Earth. In the LSST Moving Object Processing System, it refers to a predicted position (RA/Dec/time/etc) of a MovingObject","Sci","",""
+"epoch","Sky coordinate reference frame, e.g., J2000. Alternatively refers to a single observation (usually photometric, can be multi-band) of a variable source","Sci","",""
+"exponential profile","The radial distribution of flux of an astronomical source that is characterized: I(r)=I0exp(.68(r/re)) The normalization 1.68 is chosen so that the model radius is a half-light radius. An 2-dimensional elliptical version of this profile is fit to every detected source","Sci","",""
+"flux","Shorthand for radiative flux, it is a measure of the transport of radiant energy per unit area per unit time. In astronomy this is usually expressed in cgs units: erg/cm2/s","Sci","",""
+"Julian Date","The Julian Date (JD) of any instant is the Julian day number for the preceding noon (UTC), plus the fraction of the day elapsed since that instant. The Julian day number is a running sequence of integral days, starting at noon, since the beginning of the Julian Period; JD 0.0 corresponds to noon on 1 January 4713 BCE. Various Julian Date converters are available on the Web. For example, 18h 00m 00.0s UT on 2014-July-01 (near the start of LSST construction) corresponds to JD 2456840.25","Sci","",""
+"magnitude, Petrosian","A magnitude determined from a fit to a Petrosian brightness profile: Rp(r) = stuf f Appropriate for galaxies","Sci","",""
+"magnitude, Petrosian","A magnitude determined from a fit to a Petrosian brightness profile: Rp(r) = stuf f Appropriate for galaxies","Sci","",""
 "magnitude, Pogson","Usually simply magnitude, it is a logarithmic measure of integrated source brightness, usually within a standard photometric passband, such that:
 MM0=2.5log(F/F0)
-where the zero-point flux is defined by a photometric standard.",Sci,,
-"magnitude, PSF","For isolated stars that are well described by the PSF, the optimal measure of the total flux is determined by fitting a PSF model to the object.",Sci,,
-passband,"The window of wavelength or the energy range admitted by an optical system; specifically the transmission as a function of wavelength or energy. Typically the passband is limited by a filter. The width of the passband may be characterized in a variety of ways, including the width of the half-power points of the transmission curve, or by the equivalent width of a filter with 100% transmission within the passband, and zero elsewhere.",Sci,,
-photometric redshift,"Often abbreviated to photo-z, this is an estimate of the true redshift (of a galaxy) determined from multi-band photometry. Generally determined from a fit of source colors to grid of model \gls{SED}s with redshift.",Sci,,
-point spread function,"The point-spread function (PSF) is the distribution of intensity on a sensor (or image) originating from an unresolved point-source (i.e., a star). Often the PSF is not the same Airy shape as would be expected from a finite-aperture optical system, owing primarily to atmospheric effects and imperfections in the optical system and the detector.",Sci,,PSF
-right ascension,"Often abbreviated RA, it is a part of an equatorial coordinate pair that expresses the angular distance along the Celestial Equator. It is analogous to terrestrial longitude. RA increases to the east along the projection of the Earth's equator, from the origin (i.e., the Vernal Equinox). Positions are customarily expressed in degrees (0 < RA < 360), or hours (0 < RA < 24, usually in sexagesimal format).",Sci,,
-Sloan Digital Sky Survey,"is a digital survey of roughly 10,000 square degrees of sky around the north Galactic pole, plus a ~300 square degree stripe along the celestial equator.",Sci,,
-SED,\gls{Spectral Energy Distribution},Sci,,
-Spectral Energy Distribution,"the radiated energy of an astrophysical object as a function of energy (or wavelength) across the entire spectrum of light.",Sci,,
-seeing,"An astronomical term for characterizing the stability of the atmosphere, as measured by the width of the point-spread function on images. The PSF width is also affected by a number of other factors, including the airmass, passband, and the telescope and camera optics.",Sci,,
-Stripe 82,"A 2.5° wide equatorial band of sky covering roughly 300 square degrees that was observed repeatedly in 5 passbands during the course of the SDSS, In part for calibration purposes.",Sci,,
-transient,"A transient source is one that has been detected on a difference image, but has not been associated with either an astronomical object or a solar system body.",Sci,,
-World Coordinate System,"a mapping from image pixel coordinates to physical coordinates; in the case of images the mapping is to sky coordinates, generally in an equatorial (RA, Dec) system. The \gls{WCS} is expressed in FITS file extensions as a collection of header keyword=value pairs (basically, the values of parameters for a selected functional representation of the mapping) that are specified in the FITS Standard.",Sci,,
-Attribute,A quantitative performance parameter in the context of the SysML based SysArch model used to generate a requirements document,SE,,
-Systems Engineering,"an interdisciplinary field of engineering that focuses on how to design and manage complex engineering systems over their life cycles. Issues such as requirements engineering, reliability, logistics, coordination of different teams, testing and evaluation, maintainability and many other disciplines necessary for successful system development, design, implementation, and ultimate decommission become more difficult when dealing with large or complex projects. Systems engineering deals with work-processes, optimization methods, and risk management tools in such projects. It overlaps technical and human-centered disciplines such as industrial engineering, control engineering, software engineering, organizational studies, and project management. Systems engineering ensures that all likely aspects of a project or system are considered, and integrated into a whole.",SE,,
-Eimage,"An output product of PhoSim, an Eimage is a simulation of the response of a single sensor, where the outputs of the constituent amps have been integrated, and the effects of variations in pixel-to-pixel sensitivity and amplifier gains have been removed.",Sims,,
-Image Simulation (ImSim),"High fidelity end-to-end simulations of the sky; these simulated images are used in designing and testing algorithms for use by Data Management; evaluating the capabilities and scalability of the reduction and analysis pipelines; testing and optimizing the scientific returns of the LSST survey; and providing realistic LSST data to the science collaborations to evaluate the expected performance of LSST. Under the direction of the Systems Engineering group, the Image Simulation group's principle goal during construction is to deliver a simulator to support commissioning.",Sims,,
-Instance Catalog,"A catalog of astronomical sources containing source type, coordinates, brightnesses, and SEDs for use in creating simulated LSST images with PhoSim. Synonym with trim file.",Sims,,
-OpSim,\gls{Operations Simulation},Sims,,
-Operations Simulation,"OpSim uses a sophisticated model to simulate 10 years of LSST operations using realistic seeing distributions, historical weather data, scheduled engineering downtime, and the most current telescope, dome, and camera design parameters. Under the direction of the Systems Engineering group, the OpSim group also works closely with the Telescope and Site group to ensure coordination with the OCS Scheduler development.",Sims,,
-Simulations Lead,"The person who oversees the activities of the LSST simulations efforts (ImSim, OpSim, PhoSim, etc.). The Simulations Lead is part of the Systems Engineering group and reports to the Systems Engineering Manager.",Sims Adm,,
-Cadence,"The sequence of pointings, visit exposures, and exposure durations performed over the course of a survey.",Sims Sci,,
-Cadence,The sequence of pointings and 30-second-equivalent visit exposures performed by LSST over the duration of the survey.,Sims Sci,,
-GIS:\gls{Global Interlock System}
-Global Interlock System,"A safety system that makes mechanisms or functions of the observatory system mutually dependent in order to prevent equipment from harming people or equipment by preventing  one element from changing state due to the state of another element, and vice versa.",TS,,
-System Integration and Test,"The first year of the two-year Commissioning phase of the LSST Construction Project, during which the various technical components of the three subsystems will be integrated and compliance with ICDs and system level compliance as detailed in the LSST Observatory System Specifications document (OSS, LSE-30) will be shown. Roughly 4-6 months into the System I&T phase, the telescope and camera will be fully integrated and periodically producing science grade images over the full field of view, at which point 'System First Light' will be declared.",TS Cam DM SE,,
-ZTF,Zwicky Transient Facility,Gen,,
-aggregate metric,"An aggregation of multiple point metrics. For example, the overall photometric repeatability for a particular tract given given the repeatability of multiple individual stars in the tract. See also: “metric”.",DM QA,DMTN-085,
-aggregation,"The process of reducing multiple input values to a single output, e.g., a metric value, computed from a collection of input values. For example, a sum or average of a metric computed over patches to produce an aggregate metric at tract level. See also: “metric”, “aggregate metric”.",DM QA,DMTN-085,
-Apache Parquet,A columnar storage data persistence format maintained by the Apache project.,DM QA,"DMTN-085, http://parquet.apache.org",
-dashboard,"A visual display of the most important information needed to achieve one or more objectives, consolidated and arranged on a single screen so that the information can be monitored at a glance (as in Few, S., 2013, Information Dashboard Design, Analytics Press, 2 edn.)",DM QA,DMTN-085,
-drill down,"Move from a higher level aggregation of data to its inputs. For example, given data describing a tract, to drill down to constituent patches and then to objects. Also refers to the act of identifying an issue in a high-level summary of the data (e.g. an aberrant metric value) and interactively investigating its inputs to find the source of the problem.",DM QA,DMTN-085,
-General Parallel File System,The bulk data storage provided through a POSIX filesystem interface at the LSST Data Facility. Refers specifically to IBM’s General Parallel File System; also known as IBM Spectrum Scale.,DM QA,DMTN-085,GBFS
-metric,"A measurable quantity which may be tracked. A metric has a name, description, unit, references, and tags (which are used for grouping). A metric is a scalar by definition. See also: aggregate metric, model metric, point metric.",DM QA,DMTN-085,
-metric value,The result of computing a particular metric on some given data. Note that metric values are typically computed rather than measured. See also: metric.,DM QA,DMTN-085,
-model metric,"A metric describing a model related to the data. For example, the coefficients of a 2D polynomial fit to the background of a single CCD exposure.",DM QA,DMTN-085,
-monitoring,"In DM QA, this refers to the process of collecting, storing, aggregating and visualizing metrics.",DM QA,DMTN-085,
-point metric,"A metric that is associated with a single entry in a catalog. Examples include the shape of a source, the standard deviation of the flux of an object detected on a Coadd, the flux of an source detected on a difference image.",DM QA,DMTN-085,
-Quality Assurance,"All activities, deliverables, services, documents, procedures or artifacts which are designed to ensure the quality of DM deliverables. This may include \gls{QC} systems, in so far as they are covered in the charge described in LDM-622. Note that contrasts with the LDM-522 definition of “QA” as “Quality Analysis”, a manual process which occurs only during commissioning and operations. See also: Quality Control.",DM QA,"DMTN-085, LDM-622",QA
-Quality Control,"Services and processes which are aimed at measuring and monitoring a system to verify and characterize its performance (as in LDM-522). Quality Control systems run autonomously, only notifying people when an anomaly has been detected. See also Quality Assurance.",DM QA,"DMTN-085, LDM-522",QC
-releasable product,A software package or other component of the DM system which is expected to be included in the next tagged release of the system. This implies inclusion in a standard top-level package. See also release-tag.,DM QA,DMTN-085,
-tidy data,"Tidy datasets have a specific structure: each variable is a column, each observation is a row, and each type of observational unit is a table (Wickham, H., 2014, Journal of Statistical Software, Articles, 59, 1).",DM QA,DMTN-085,
-QAWG,\gls{QA} Strategy Working Group,DM QA,DMTN-085,
+where the zero-point flux is defined by a photometric standard","Sci","",""
+"magnitude, PSF","For isolated stars that are well described by the PSF, the optimal measure of the total flux is determined by fitting a PSF model to the object","Sci","",""
+"passband","The window of wavelength or the energy range admitted by an optical system; specifically the transmission as a function of wavelength or energy. Typically the passband is limited by a filter. The width of the passband may be characterized in a variety of ways, including the width of the half-power points of the transmission curve, or by the equivalent width of a filter with 100% transmission within the passband, and zero elsewhere","Sci","",""
+"photometric redshift","Often abbreviated to photo-z, this is an estimate of the true redshift (of a galaxy) determined from multi-band photometry. Generally determined from a fit of source colors to grid of model \gls{SED}s with redshift","Sci","",""
+"point spread function","The point-spread function (PSF) is the distribution of intensity on a sensor (or image) originating from an unresolved point-source (i.e., a star). Often the PSF is not the same Airy shape as would be expected from a finite-aperture optical system, owing primarily to atmospheric effects and imperfections in the optical system and the detector","Sci","","PSF"
+"right ascension","Often abbreviated RA, it is a part of an equatorial coordinate pair that expresses the angular distance along the Celestial Equator. It is analogous to terrestrial longitude. RA increases to the east along the projection of the Earth's equator, from the origin (i.e., the Vernal Equinox). Positions are customarily expressed in degrees (0 < RA < 360), or hours (0 < RA < 24, usually in sexagesimal format)","Sci","",""
+"Sloan Digital Sky Survey","is a digital survey of roughly 10,000 square degrees of sky around the north Galactic pole, plus a ~300 square degree stripe along the celestial equator","Sci","",""
+"SED","\gls{Spectral Energy Distribution}","Sci","",""
+"Spectral Energy Distribution","the radiated energy of an astrophysical object as a function of energy (or wavelength) across the entire spectrum of light","Sci","",""
+"seeing","An astronomical term for characterizing the stability of the atmosphere, as measured by the width of the point-spread function on images. The PSF width is also affected by a number of other factors, including the airmass, passband, and the telescope and camera optics","Sci","",""
+"Stripe 82","A 2.5° wide equatorial band of sky covering roughly 300 square degrees that was observed repeatedly in 5 passbands during the course of the SDSS, In part for calibration purposes","Sci","",""
+"transient","A transient source is one that has been detected on a difference image, but has not been associated with either an astronomical object or a solar system body","Sci","",""
+"World Coordinate System","a mapping from image pixel coordinates to physical coordinates; in the case of images the mapping is to sky coordinates, generally in an equatorial (RA, Dec) system. The \gls{WCS} is expressed in FITS file extensions as a collection of header keyword=value pairs (basically, the values of parameters for a selected functional representation of the mapping) that are specified in the FITS Standard","Sci","",""
+"Attribute","A quantitative performance parameter in the context of the SysML based SysArch model used to generate a requirements document","SE","",""
+"Systems Engineering","an interdisciplinary field of engineering that focuses on how to design and manage complex engineering systems over their life cycles. Issues such as requirements engineering, reliability, logistics, coordination of different teams, testing and evaluation, maintainability and many other disciplines necessary for successful system development, design, implementation, and ultimate decommission become more difficult when dealing with large or complex projects. Systems engineering deals with work-processes, optimization methods, and risk management tools in such projects. It overlaps technical and human-centered disciplines such as industrial engineering, control engineering, software engineering, organizational studies, and project management. Systems engineering ensures that all likely aspects of a project or system are considered, and integrated into a whole","SE","",""
+"Eimage","An output product of PhoSim, an Eimage is a simulation of the response of a single sensor, where the outputs of the constituent amps have been integrated, and the effects of variations in pixel-to-pixel sensitivity and amplifier gains have been removed","Sims","",""
+"Image Simulation (ImSim)","High fidelity end-to-end simulations of the sky; these simulated images are used in designing and testing algorithms for use by Data Management; evaluating the capabilities and scalability of the reduction and analysis pipelines; testing and optimizing the scientific returns of the LSST survey; and providing realistic LSST data to the science collaborations to evaluate the expected performance of LSST. Under the direction of the Systems Engineering group, the Image Simulation group's principle goal during construction is to deliver a simulator to support commissioning","Sims","",""
+"Instance Catalog","A catalog of astronomical sources containing source type, coordinates, brightnesses, and SEDs for use in creating simulated LSST images with PhoSim. Synonym with trim file","Sims","",""
+"OpSim","\gls{Operations Simulation}","Sims","",""
+"Operations Simulation","OpSim uses a sophisticated model to simulate 10 years of LSST operations using realistic seeing distributions, historical weather data, scheduled engineering downtime, and the most current telescope, dome, and camera design parameters. Under the direction of the Systems Engineering group, the OpSim group also works closely with the Telescope and Site group to ensure coordination with the OCS Scheduler development","Sims","",""
+"Simulations Lead","The person who oversees the activities of the LSST simulations efforts (ImSim, OpSim, PhoSim, etc.). The Simulations Lead is part of the Systems Engineering group and reports to the Systems Engineering Manager","Sims Adm","",""
+"Cadence","The sequence of pointings, visit exposures, and exposure durations performed over the course of a survey","Sims Sci","",""
+"Cadence","The sequence of pointings and 30-second-equivalent visit exposures performed by LSST over the duration of the survey","Sims Sci","",""
+"Global Interlock System","A safety system that makes mechanisms or functions of the observatory system mutually dependent in order to prevent equipment from harming people or equipment by preventing  one element from changing state due to the state of another element, and vice versa","TS","",""
+"System Integration and Test","The first year of the two-year Commissioning phase of the LSST Construction Project, during which the various technical components of the three subsystems will be integrated and compliance with ICDs and system level compliance as detailed in the LSST Observatory System Specifications document (OSS, LSE-30) will be shown. Roughly 4-6 months into the System I&T phase, the telescope and camera will be fully integrated and periodically producing science grade images over the full field of view, at which point 'System First Light' will be declared","TS Cam DM SE","",""
+"ZTF","Zwicky Transient Facility","Gen","",""
+"aggregate metric","An aggregation of multiple point metrics. For example, the overall photometric repeatability for a particular tract given given the repeatability of multiple individual stars in the tract. See also: “metric”","DM QA","DMTN-085",""
+"aggregation","The process of reducing multiple input values to a single output, e.g., a metric value, computed from a collection of input values. For example, a sum or average of a metric computed over patches to produce an aggregate metric at tract level. See also: “metric”, “aggregate metric”","DM QA","DMTN-085",""
+"Apache Parquet","A columnar storage data persistence format maintained by the Apache project","DM QA","DMTN-085, http://parquet.apache.org",""
+"dashboard","A visual display of the most important information needed to achieve one or more objectives, consolidated and arranged on a single screen so that the information can be monitored at a glance (as in Few, S., 2013, Information Dashboard Design, Analytics Press, 2 edn.)","DM QA","DMTN-085",""
+"drill down","Move from a higher level aggregation of data to its inputs. For example, given data describing a tract, to drill down to constituent patches and then to objects. Also refers to the act of identifying an issue in a high-level summary of the data (e.g. an aberrant metric value) and interactively investigating its inputs to find the source of the problem","DM QA","DMTN-085",""
+"General Parallel File System","The bulk data storage provided through a POSIX filesystem interface at the LSST Data Facility. Refers specifically to IBM’s General Parallel File System; also known as IBM Spectrum Scale","DM QA","DMTN-085","GBFS"
+"metric","A measurable quantity which may be tracked. A metric has a name, description, unit, references, and tags (which are used for grouping). A metric is a scalar by definition. See also: aggregate metric, model metric, point metric","DM QA","DMTN-085",""
+"metric value","The result of computing a particular metric on some given data. Note that metric values are typically computed rather than measured. See also: metric","DM QA","DMTN-085",""
+"model metric","A metric describing a model related to the data. For example, the coefficients of a 2D polynomial fit to the background of a single CCD exposure","DM QA","DMTN-085",""
+"monitoring","In DM QA, this refers to the process of collecting, storing, aggregating and visualizing metrics","DM QA","DMTN-085",""
+"point metric","A metric that is associated with a single entry in a catalog. Examples include the shape of a source, the standard deviation of the flux of an object detected on a Coadd, the flux of an source detected on a difference image","DM QA","DMTN-085",""
+"Quality Assurance","All activities, deliverables, services, documents, procedures or artifacts which are designed to ensure the quality of DM deliverables. This may include \gls{QC} systems, in so far as they are covered in the charge described in LDM-622. Note that contrasts with the LDM-522 definition of “QA” as “Quality Analysis”, a manual process which occurs only during commissioning and operations. See also: Quality Control","DM QA","DMTN-085, LDM-622","QA"
+"Quality Control","Services and processes which are aimed at measuring and monitoring a system to verify and characterize its performance (as in LDM-522). Quality Control systems run autonomously, only notifying people when an anomaly has been detected. See also Quality Assurance","DM QA","DMTN-085, LDM-522","QC"
+"releasable product","A software package or other component of the DM system which is expected to be included in the next tagged release of the system. This implies inclusion in a standard top-level package. See also release-tag","DM QA","DMTN-085",""
+"tidy data","Tidy datasets have a specific structure: each variable is a column, each observation is a row, and each type of observational unit is a table (Wickham, H., 2014, Journal of Statistical Software, Articles, 59, 1)","DM QA","DMTN-085",""
+"QAWG","\gls{QA} Strategy Working Group","DM QA","DMTN-085",""
+Change Control Board,"Advisory board to the Project Manager; composed of technical and management representatives who recommend approval or disapproval of proposed changes to, deviations from, and waivers to a configuration item's current approved configuration documentation",Adm,,
+Visit,"A sequence of one or more consecutive exposures at a given position, orientation, and filter within the LSST cadence. See \gls{Standard Visit}, \gls{Alternative Standard Visit}, and \gls{Non-Standard Visit}",DM TS Sims,,
+Education and Public Outreach,"The LSST subsystem responsible for the cyberinfrastructure, user interfaces, and outreach programs necessary to connect educators, planetaria, citizen scientists, amateur astronomers, and the general public to the transformative LSST dataset",EPO,,EPO
+GIS,\gls{Global Interlock System},,,
+deVaucouleurs profile,"The radial distribution of flux of an astronomical source that is characterized as:
+I(r)=I0exp(7.67(r/re)1/4)
+An elliptical version of this profile can be fit to every detected source, yielding the deVaucouleurs parameters.",Sci,,


### PR DESCRIPTION
- Strip "." from the ends of entries, as it's not appropriate for use with the
  LaTeX glossaries package.
- Fix unescaped commas in definition of "Change Control Board", "Visit", "Education and
  Public Outreach" and "GIS".
- Fix "broken" "deVaucouleurs profile" definition.