### PR TITLE
Removed vertical lines in acronyms longtable

### DIFF
--- a/bin/generateAcronyms.py
+++ b/bin/generateAcronyms.py
@@ -414,7 +414,7 @@ def write_latex_table(acronyms, fd=sys.stdout):
         List of 2-tuples with acronym and definition.
     """
     print(r"""\addtocounter{table}{-1}
-\begin{longtable}{|p{0.145\textwidth}|p{0.8\textwidth}|}\hline
+\begin{longtable}{p{0.145\textwidth}p{0.8\textwidth}}\hline
 \textbf{Acronym} & \textbf{Description}  \\\hline
 """, file=fd)
     glsreg = re.compile(r'\\gls{([\w \-]+)}')

--- a/texmf/bibtex/bib/refs.bib
+++ b/texmf/bibtex/bib/refs.bib
@@ -2218,7 +2218,7 @@ adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{osn,
-author = {Núñez-Corrales, Santiago and Cragin, Melissa and White (Wonders), Alainna and Norman, Michael and Kickpatrick, Christine and Mchenry, Kenton and Ahalt, Stanley and Shanley, Lea and Goodhue, John and Simmel, Derek and Szalay, Alex},
+author = {N{\'u}\~{n}ez-Corrales, Santiago and Cragin, Melissa and White (Wonders), Alainna and Norman, Michael and Kickpatrick, Christine and Mchenry, Kenton and Ahalt, Stanley and Shanley, Lea and Goodhue, John and Simmel, Derek and Szalay, Alex},
 year = {2018},
 month = {11},
 pages = {},


### PR DESCRIPTION
I tested locally and it works.
The change is very simple