### PR TITLE
Fixed myacronyms read function

### DIFF
--- a/bin/generateAcronyms.py
+++ b/bin/generateAcronyms.py
@@ -196,8 +196,8 @@ def read_myacronyms(filename="myacronyms.txt", allow_duplicates=False,
                                               " with same definition in {}, you may"
                                               " want to try using a tag (-t)".
                                               format(acr, filename)))
-
-            definitions[acr] = defn
+            # myacronyms will contains by definition only acronyms
+            definitions[acr] = (defn, "A")
 
     # Merge with the defaults
     if defaults is None:


### PR DESCRIPTION
Now that we are using an extra field from the "datamodel", the EntryType, we need to consider this when myacronyms is read and returned to be merged with the general definitions.

In alternative, we may want to make the mayacronyms more complex, but so far this should be OK.
DMTR-121 needs this fix if we want to include ATS in the acronyms table.