### PR TITLE
Add DMTR-191 to lsst.bib.

### DIFF
--- a/texmf/bibtex/bib/lsst.bib
+++ b/texmf/bibtex/bib/lsst.bib
@@ -2232,6 +2232,15 @@ High Cadence Observations of the Magellanic Clouds and Select Galactic Cluster F
       url = {http://dmtr-141.lsst.io }
 }
 
+@DocuShare{DMTR-191,
+   author = {J. Carlin, K. S. Krughoff, G. Comoretto},
+    title = {Characterization Metric Report: Science Pipelines Version 19.0.0},
+     year = 2019,
+    month = dec,
+   handle = {DMTR-191},
+      url = {http://dmtr-191.lsst.io }
+}
+
 @DocuShare{SQR-006,
   author = {Jonathan Sick},
    title = {The LSST the Docs Platform for Continuous Documentation Delivery},


### PR DESCRIPTION
I added DMTR-191 to the bibliography so the reference to this document in the Characterization Metric Report (DMTR-251) will compile correctly. 