### PR TITLE
one more author for DSS white paper

### DIFF
--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -7,6 +7,8 @@ affiliations:
     Serbia
   Belgrade-Uni: Faculty of Mathematics, Department of Astronomy, University of Belgrade,
     Studentski trg 16 Belgrade, Serbia
+  Belgrade-CS: Department of Informatics and Computer Science, Faculty of Mathematics,
+    University of Belgrade, Studentski trg 16, 11000 Belgrade, Serbia
   Belldex: Belldex IT Consulting, Tucson, AZ 85742, USA
   Berkeley-Astro: Astronomy Department,  University of California, 601 Campbell Hall,
     Berkeley, CA 94720, USA
@@ -349,6 +351,13 @@ authors:
     initials: Igor
     name: Andreoni
     orcid: 0000-0002-8977-1498
+  andricmitrovicn:
+    affil:
+    - Belgrade-CS
+    altaffil: []
+    initials: Nikola
+    name: Andri{\c} Mitrovi{\c}
+    orcid: null
   angeligz:
     affil:
     - GMTO


### PR DESCRIPTION
One person who contributed a use case to the DSS white paper missed the initial deadline to sign on as author; I'm adding him to the DB for v2.

I got explicit confirmation about the split between first name and surname on this one as it was unclear to me initially.