### PR TITLE
add python3-pygments package

### DIFF
--- a/docker/install-base-packages.sh
+++ b/docker/install-base-packages.sh
@@ -47,7 +47,8 @@ apt-get -y install --no-install-recommends \
     texlive-fonts-recommended \
     texlive-fonts-extra \
     lmodern \
-    fonts-inconsolata
+    fonts-inconsolata \
+    python3-pygments
 
 # Delete cached files we don't need anymore:
 apt-get clean


### PR DESCRIPTION
The `pygmentize` command is required by the latex minted package.