### PR TITLE
switch pygments install from .deb to pypy

### DIFF
--- a/docker/install-base-packages.sh
+++ b/docker/install-base-packages.sh
@@ -47,8 +47,7 @@ apt-get -y install --no-install-recommends \
     texlive-fonts-recommended \
     texlive-fonts-extra \
     lmodern \
-    fonts-inconsolata \
-    python3-pygments
+    fonts-inconsolata
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pytest
 pyyaml
-google-api-python-client 
-google-auth-httplib2  
-google-auth-oauthlib  
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib
 oauth2client
 algoliasearch
 latexcodec

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-auth-oauthlib
 oauth2client
 algoliasearch
 latexcodec
+pygments


### PR DESCRIPTION
Well, it seems that @jonathansick preference was better. The ubuntu packaged version of `pygments` appears to break with modern versions of `setuptools` installed.  My test container's env was dirty.

```console
Traceback (most recent call last):
  File "/usr/bin/pygmentize", line 6, in <module>
    from pkg_resources import load_entry_point
ModuleNotFoundError: No module named 'pkg_resources'
```