### PR TITLE
DM-37864: Disable git safe directory checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ FROM base AS runtime
 # Create a directory for the lsst-texmf installation
 RUN mkdir lsst-texmf
 
+# Disable git safe directory checks, particularly for the /workspace
+# working directory that documents are mounted into.
+RUN git config --global --add safe.directory '*'
+
 # Point $TEXMFHOME to the container's lsst-texmf. This environment variable
 # exists for container runs by a user.
 ENV TEXMFHOME "/lsst-texmf/texmf"


### PR DESCRIPTION
This PR resolves the issue with `git` commands in a document's Makefile not running (for example, to set the data and version in `meta.tex`).

The /workspace directory that gets mounted into the container may not have the expected ownership, and this can result in errors with Git's new safe directory checks. See

https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory

This new git command in the Dockerfile adds a git configuration to the container that effectively disables these checks. This is fine because of the nature of the isolated container.