### PR TITLE
Correct institutional name for IPAC

### DIFF
--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -112,7 +112,7 @@ affiliations:
     M{\"o}nchhofstr. 12-14, 69120 Heidelberg, Germany
   Herts: Centre for Astrophysics Research, University of Hertfordshire, Hatfield, Hertfordshire, AL10 9AB, UK
   IAFE: Instituto de Astronom\'ia y F\'isica del Espacio (IAFE), Av. Inte. G\"uiraldes 2620, C1428ZAA, Buenos Aires, Argentina
-  IPAC: IPAC, California Institute of Technology, MS 100-22, Pasadena, CA 91125, USA
+  IPAC: Caltech/IPAC, California Institute of Technology, MS 100-22, Pasadena, CA 91125-2200, USA
   IRAM: Instituto de Radioastronom\'ia Milim\'{e}trica, Av.\ Divina Pastora 7, N\'{u}cleo
     Central, E-18012 Granada, Spain
   Illinois: University of Illinois, Physics and Astronomy Departments, 1110 W.\ Green


### PR DESCRIPTION
The formal name we use is "Caltech/IPAC".