### PR TITLE
Use UTC for timestamps

### DIFF
--- a/bin/generateBibfile.py
+++ b/bin/generateBibfile.py
@@ -9,7 +9,7 @@ data is supplied by Ook, https://github.com/lsst-sqre/ook.
 
 import argparse
 import calendar
-from datetime import datetime
+from datetime import UTC, datetime
 
 import latexcodec  # noqa provides the latex+latin codec
 import pybtex.database
@@ -147,7 +147,7 @@ def create_bibentries(res) -> BibliographyData:
         else:
             authors = " and ".join(d["authorNames"])
         dt = d["sourceUpdateTimestamp"]
-        date = datetime.fromtimestamp(dt)
+        date = datetime.fromtimestamp(dt, UTC)
         month = calendar.month_abbr[date.month].lower()
         if "baseUrl" in d:
             url = d["baseUrl"]

--- a/bin/makeTablesFromGoogle.py
+++ b/bin/makeTablesFromGoogle.py
@@ -95,7 +95,7 @@ def complete_and_close_table(tout):
 
 def outhead(ncols, tout, name, cap, form=None, font=r"\tiny"):
     """Return the table header."""
-    print(r"%s \begin{longtable} {" % font, file=tout, end="")
+    print(rf"{font} \begin{{longtable}} {{", file=tout, end="")
     c = 1
     if form is None:
         print(" |p{0.22\\textwidth} ", file=tout, end="")


### PR DESCRIPTION
Otherwise we keep changing the month for first days of the month depending on the timezone.