### PR TITLE
Add the ability to have a non-human author with _ affiliation

### DIFF
--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -303,7 +303,9 @@ affiliations:
   WisconsinMadison: Department of Physics, University of Wisconsin-Madison, Madison,
     WI 53706, USA
   Yale: Astronomy Department, Yale University, New Haven, CT 06520, USA
+  _: Placeholder used for collective author that will not be shown
 emails:
+  _: none.com
   Duke: duke.edu
   EdinburghIA: ed.ac.uk
   IPAC: ipac.caltech.edu
@@ -326,6 +328,13 @@ emails:
   Washington-Dirac: uw.edu
   Washington: uw.edu
 authors:
+  DMPipelines:
+    affil:
+    - _
+    altaffil: []
+    initials: ""
+    name: Rubin Observatory Science Pipelines Developers
+    orcid: null
   abelb:
     affil:
     - Olympic


### PR DESCRIPTION
Doesn't quite work yet with AASTeX 7 but should work at some point (works well enough for now). Add a DM pipelines developers collective author as example.