### PR TITLE
Remove duplicated ORCiD for kernj

### DIFF
--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -2318,7 +2318,7 @@ authors:
     altaffil: []
     initials: Jeff
     name: Kern
-    orcid: 0000-0003-3221-0419
+    orcid: null
   kesslerr:
     affil:
     - Chicago


### PR DESCRIPTION
We've discovered a second duplicate orcid in authordb.yaml. Both `kesslerr` and `kernj` had the same orcid, likely due to a copy-and-paste oversight. I've verified that https://orcid.org/0000-0003-3221-0419 belongs to `kesslerr`. I have not been able to find an orcid entry for `kernj`, so therefore I'm setting that field to null at this time.