### PR TITLE
DM-50816: New implementation of db2authors

### DIFF
--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -41,7 +41,7 @@ affiliations:
     93117, USA
   CUNY: City University of New York
   CUNYAMNH: City University of New York, American Museum of Natural History
-  CUNYCT: City University of New York, New York City College of Technology
+  CUNYCT: City University of New York, New York City College of Technology, USA
   CUNYBM: Department of Science, CUNY Borough of Manhattan Community College, 199 Chambers
     Street, New York, NY 10007, USA
   CUNYL: Department of Physics and Astronomy, Lehman College, City University of New York,


### PR DESCRIPTION
Complete rewrite using per-target classes.

There is still some duplication but at least it's now clearer what is happening and has fixed numerous output bugs.

@jonathansick does not use any of your documenteer classes but hopefully would not be hard to migrate. Still wanting to have minimal dependencies for the moment.

* Fixes output bug in arxiv
* Fixes duplication of affiliation in ascom and spie outputs (and SPIE now uses letters rather than numbers).
* Fixes issue with lsstdoc with "," vs "and".

It's clear that the parsing of affiliation information is not clever enough -- used by ADASS and ASCOM. The best fix would be to change the affiliations in authordb.yaml to explicitly separate the content by institute, city, country, post code etc.

I will rename it to db2authors.py after review (it's easier to see what's there if it's not a diff).