### PR TITLE
Update HSM (En) in glossarydefs.csv

### DIFF
--- a/etc/glossarydefs.csv
+++ b/etc/glossarydefs.csv
@@ -535,7 +535,7 @@ HR,Human Resources,Gen,,,A
 HSC,Hyper Suprime-Cam,Gen,,,A
 HSI,Hispanic Serving Institutions,Gen,,,A
 HSM,Hierarchical Storage Management,DM,,,A
-HSM,Half-Second Moment,Sci,,,A
+HSM,"Shape measurement algorithm from Hirata, Seljak & Mandelbaum (2005)",Sci,,,A
 HST,Hubble Space Telescope,Gen,,,A
 HTC,High Throughput Computing,DM,,,A
 HTM,Hierarchical Triangular Mesh,Gen,,,A

--- a/etc/glossarydefs.csv
+++ b/etc/glossarydefs.csv
@@ -535,7 +535,7 @@ HR,Human Resources,Gen,,,A
 HSC,Hyper Suprime-Cam,Gen,,,A
 HSI,Hispanic Serving Institutions,Gen,,,A
 HSM,Hierarchical Storage Management,DM,,,A
-HSM,"Shape measurement algorithm from Hirata, Seljak & Mandelbaum (2005)",Sci,,,G
+HSM,"Shape measurement algorithm from Hirata & Seljak (2003) and Mandelbaum et al. (2005)",Sci,,,G
 HST,Hubble Space Telescope,Gen,,,A
 HTC,High Throughput Computing,DM,,,A
 HTM,Hierarchical Triangular Mesh,Gen,,,A

--- a/etc/glossarydefs.csv
+++ b/etc/glossarydefs.csv
@@ -535,7 +535,7 @@ HR,Human Resources,Gen,,,A
 HSC,Hyper Suprime-Cam,Gen,,,A
 HSI,Hispanic Serving Institutions,Gen,,,A
 HSM,Hierarchical Storage Management,DM,,,A
-HSM,"Shape measurement algorithm from Hirata, Seljak & Mandelbaum (2005)",Sci,,,A
+HSM,"Shape measurement algorithm from Hirata, Seljak & Mandelbaum (2005)",Sci,,,G
 HST,Hubble Space Telescope,Gen,,,A
 HTC,High Throughput Computing,DM,,,A
 HTM,Hierarchical Triangular Mesh,Gen,,,A


### PR DESCRIPTION
The explanation provided for the HSM algorithm is incorrect. It is named after the authors, and does not stand for Half Second Moment, at least not in the context of DP1 paper. The Spanish version appears to be accurate from what I could understand.