### PR TITLE
Remove incorrect orcid for sahaa

### DIFF
--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -7124,7 +7124,7 @@ authors:
     email: null
     family_name: Saha
     given_name: Abhijit
-    orcid: null
+    orcid: 0000-0002-6839-4881
   salnikova:
     affil:
     - SLAC

--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -7124,7 +7124,7 @@ authors:
     email: null
     family_name: Saha
     given_name: Abhijit
-    orcid: 0000-0002-5091-0470
+    orcid: null
   salnikova:
     affil:
     - SLAC


### PR DESCRIPTION
Based on https://orcid.org/0000-0002-5091-0470 this orcid should belong
to schmidts