### PR TITLE
update McWilliams Center listing

### DIFF
--- a/etc/authordb.yaml
+++ b/etc/authordb.yaml
@@ -370,12 +370,12 @@ affiliations:
     address:
       city: Pittsburgh
       country_code: USA
-      example_expanded: McWilliams Center for Cosmology, Department of Physics, Carnegie
+      example_expanded: McWilliams Center for Cosmology \& Astrophysics, Department of Physics, Carnegie
         Mellon University, Pittsburgh, PA 15213, USA
       postcode: '15213'
       state: PA
       street: ''
-    department: McWilliams Center for Cosmology, Department of Physics
+    department: McWilliams Center for Cosmology \& Astrophysics, Department of Physics
     email: null
     institute: Carnegie Mellon University
     ror_id: 05x2bcf33


### PR DESCRIPTION
The McWilliams Center at CMU has been renamed (was "McWilliams Center for Cosmology", is "McWilliams Center for Cosmology & Astrophysics" as of about a year ago) so its entry in `authordb.yaml` should be updated.