### PR TITLE
Normalize unicode author names before fixing multi-surname names

### DIFF
--- a/texmf/bibtex/bib/lsst.bib
+++ b/texmf/bibtex/bib/lsst.bib
@@ -339,7 +339,7 @@
 }
 
 @TechReport{CTN-001,
-    author = "{Plazas Malag\'{o}n}, Andr\'{e}s A. and Digel, Seth W. and Roodman, Aaron and Broughton, Alex and {LSST Camera Team}",
+    author = "{Plazas Malag\'on}, Andr\'es A. and Digel, Seth W. and Roodman, Aaron and Broughton, Alex and {LSST Camera Team}",
     title = "{LSSTCam and LSSTComCam Focal Plane Layouts}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -363,7 +363,7 @@
 }
 
 @TechReport{CTN-003,
-    author = "Utsumi, Yousuke and Schutt, Theo and Liang, Shuang and Marshall, Stuart and Johnson, Anthony S. and Tether, Stephen A. and C\'{o}rdova, Julio Eduardo Constanzo",
+    author = "Utsumi, Yousuke and Schutt, Theo and Liang, Shuang and Marshall, Stuart and Johnson, Anthony S. and Tether, Stephen A. and {Constanzo C\'ordova}, Julio Eduardo",
     title = "{Configuring the PTP setting on the MOXA network switch}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -1599,7 +1599,7 @@
 }
 
 @TechReport{DMTN-101,
-    author = "Lupton, Robert and {Plazas Malag\'{o}n}, Andr\'{e}s A. and Waters, Christopher",
+    author = "Lupton, Robert and {Plazas Malag\'on}, Andr\'es A. and Waters, Christopher",
     title = "{Verifying LSST Calibration Data Products}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -9205,7 +9205,7 @@
 }
 
 @TechReport{RTN-002,
-    author = "Graham, Melissa and {Plazas Malag\'{o}n}, Andr\'{e}s A. and Carlin, Jeff and Guy, Leanne and Adair, Christina and Madejski, Greg",
+    author = "Graham, Melissa and {Plazas Malag\'on}, Andr\'es A. and Carlin, Jeff and Guy, Leanne and Adair, Christina and Madejski, Greg",
     title = "{Community Science Use Cases}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -9253,7 +9253,7 @@
 }
 
 @TechReport{RTN-006,
-    author = "Graham, Melissa L. and Adair, Christina L. and Annis, Jim and Carlin, Jeff and {de Peyster}, Robert and Drlica-Wagner, Alex and {Fonseca Alvarez}, Gloria and Guy, Leanne P. and Madejski, Greg and {Plazas Malag\'{o}n}, Andr\'{e}s A.",
+    author = "Graham, Melissa L. and Adair, Christina L. and Annis, Jim and Carlin, Jeff and {de Peyster}, Robert and Drlica-Wagner, Alex and {Fonseca Alvarez}, Gloria and Guy, Leanne P. and Madejski, Greg and {Plazas Malag\'on}, Andr\'es A.",
     title = "{Model for Community Science}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -9722,7 +9722,7 @@
 }
 
 @TechReport{RTN-045,
-    author = "Graham, Melissa L. and Carlin, Jeffrey L. and Adair, Christina L. and Choi, Yumi and {Fonseca Alvarez}, Gloria and Greenstreet, Sarah and Lau, Ryan M. and Madejski, Greg M. and Meisner, Aaron M. and {Plazas Malag\'{o}n}, Andr\'{e}s A. and Tucker, Douglas L. and Williams, Christina C.",
+    author = "Graham, Melissa L. and Carlin, Jeffrey L. and Adair, Christina L. and Choi, Yumi and {Fonseca Alvarez}, Gloria and Greenstreet, Sarah and Lau, Ryan M. and Madejski, Greg M. and Meisner, Aaron M. and {Plazas Malag\'on}, Andr\'es A. and Tucker, Douglas L. and Williams, Christina C.",
     title = "{Guidelines for User Tutorials}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -9855,7 +9855,7 @@
 }
 
 @TechReport{RTN-056,
-    author = "{Giraldo Murillo}, Lina M. and Calderon, Jer\'{o}nimo and {Plazas Malag\'{o}n}, Andr\'{e}s A. and Lage, Craig S.",
+    author = "{Giraldo Murillo}, Lina M. and Calderon, Jer\'{o}nimo and {Plazas Malag\'on}, Andr\'es A. and Lage, Craig S.",
     title = "{Study of the Photon Transfer Curve in the CCD detectors of the Vera C. Rubin Observatory}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -12536,7 +12536,7 @@
 }
 
 @TechReport{SITCOMTN-161,
-    author = "Combet, C. and {Plazas Malag\'{o}n}, A. and Fu, S. and Adari, P. and Dell'Antonio, I. and Englert, A. and Gorsuch, M. and Laliotis, K. and L\'{e}get, P.-F. and {Lorenzo Martinez}, N. and Mandelbaum, R. and Pedersen, E. and {von der Linden}, A. and Zhang, Y. and et al. (TBC)",
+    author = "Combet, C. and {Plazas Malag\'on}, A. and Fu, S. and Adari, P. and Dell'Antonio, I. and Englert, A. and Gorsuch, M. and Laliotis, K. and L\'{e}get, P.-F. and {Lorenzo Martinez}, N. and Mandelbaum, R. and Pedersen, E. and {von der Linden}, A. and Zhang, Y. and et al. (TBC)",
     title = "{PSF assessment in the field of Abell 360 and shapeHSM shear profile using LSSTComCam data}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",
@@ -12561,7 +12561,7 @@
 }
 
 @TechReport{SITCOMTN-163,
-    author = "Adari, Prakruth and {von der Linden}, Anja and Zhang, Tianqing and Combet, C\'{e}line and Englert, Anthony and Fu, Shenming and {Lorenzo Martinez}, Narei and {Plazas Malag\'{o}n}, Andr\'{e}s A.",
+    author = "Adari, Prakruth and {von der Linden}, Anja and Zhang, Tianqing and Combet, C\'{e}line and Englert, Anthony and Fu, Shenming and {Lorenzo Martinez}, Narei and {Plazas Malag\'on}, Andr\'es A.",
     title = "{Source Selection for Abell 360 in LSSTComCam Data Preview 1}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2025",


### PR DESCRIPTION
We were running into trouble with `\'e` vs `\'{e}` and it's easier to use the unicode version for replacement and then convert back to standard latex form.