### PR TITLE
 Use orclink for ASCOM since [orcid] does not work

### DIFF
--- a/bin/db2authors.py
+++ b/bin/db2authors.py
@@ -533,11 +533,11 @@ class ASCOM(AuthorTextGenerator):
         authors = []
         for author in self.authors:
             affil_numbers = [str(affil_to_number[affil]) for affil in author.affiliations]
-            author_text = f"\\author[{','.join(affil_numbers)}]{{{author.full_latex_name}}}"
+            orclink = ""
             if author.orcid:
-                author_text += f"[orcid={author.orcid}]"
+                orclink = f"\\orcidlink{{{author.orcid}}}"
+            author_text = f"\\author[{','.join(affil_numbers)}]{{{author.full_latex_name}{orclink}}}"
             authors.append(author_text)
-
         affiliations = []
         for affil, number in affil_to_number.items():
             country = ""


### PR DESCRIPTION
will have to update the template to include \usepackage{orcidlink}  which is in standard texlive.  We could  use this in our docs as well if we wanted. 
