### PR TITLE
Force author lists for PSTN-051 and PSTN-053 in bib file

### DIFF
--- a/bin/generateBibfile.py
+++ b/bin/generateBibfile.py
@@ -204,6 +204,35 @@ def create_bibentries(res: SearchResponse, dois: dict[str, str] | None = None) -
                     "Wei Yang",
                 ]
             )
+        elif d["handle"] == "PSTN-051":
+            authors = " and ".join(
+                [
+                    "R. Lynne Jones",
+                    "Peter Yoachim",
+                    "Željko Ivezić",
+                    "Eric H. {Neilsen Jr.}",
+                    "Tiago Ribeiro",
+                ]
+            )
+        elif d["handle"] == "PSTN-053":
+            authors = " and ".join(
+                [
+                    "Rubin's Survey Cadence Optimization Committee",
+                    "Franz E. Bauer",
+                    "Sarah Brough",
+                    "Renée Hložek",
+                    "Željko Ivezić",
+                    "R. Lynne Jones",
+                    "Mansi M. Kasliwal",
+                    "Knut Olsen",
+                    "Hiranya V. Peiris",
+                    "Megan E. Schwamb",
+                    "Daniel Scolnic",
+                    "Colin T. Slater",
+                    "Jay Strader",
+                    "Peter Yoachim",
+                ]
+            )
         be = BibEntry(
             checkFixAuthAndComma(fixTexSS(authors)),
             fixTex(d["h1"]),

--- a/texmf/bibtex/bib/lsst.bib
+++ b/texmf/bibtex/bib/lsst.bib
@@ -9172,7 +9172,7 @@
 }
 
 @TechReport{PSTN-051,
-    author = "Jones, R. Lynne",
+    author = "Jones, R. Lynne and Yoachim, Peter and Ivezi\'{c}, {\v Z}eljko and {Neilsen Jr.}, Eric H. and Ribeiro, Tiago",
     title = "{Survey Strategy and Cadence Choices for the Vera C. Rubin Observatory Legacy Survey of Space and Time (LSST)}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2021",
@@ -9198,7 +9198,7 @@
 }
 
 @TechReport{PSTN-053,
-    author = "Ivezic, Zeljko",
+    author = "{Rubin's Survey Cadence Optimization Committee} and Bauer, Franz E. and Brough, Sarah and Hlo{\v z}ek, Ren\'{e}e and Ivezi\'{c}, {\v Z}eljko and Jones, R. Lynne and Kasliwal, Mansi M. and Olsen, Knut and Peiris, Hiranya V. and Schwamb, Megan E. and Scolnic, Daniel and Slater, Colin T. and Strader, Jay and Yoachim, Peter",
     title = "{Survey Cadence Optimization Committee’s Phase 1 Recommendation}",
     institution = "{NSF-DOE Vera C. Rubin Observatory}",
     year = "2022",


### PR DESCRIPTION
These use authors.yaml with AASTeX but the metadata extraction tooling doesn't understand those.